### PR TITLE
Epic #1 — Fork-independence foundation (#2–#11)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Go module dependencies.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,33 @@
+name: security
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    # Weekly, Monday 06:00 UTC, so new advisories are caught even without
+    # repository activity.
+    - cron: "0 6 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,90 @@
+# Maintaining this fork
+
+`github.com/rafpe/kube-oidc-proxy` is an independent fork. This document
+describes how the fork stays secure on its own and how to pull fixes from
+upstream when they are worth adopting.
+
+## Independence model
+
+The fork does not depend on any upstream project for its security posture. Its
+own automation is the primary security channel:
+
+- **`.github/dependabot.yml`** — weekly dependency update PRs for Go modules
+  (`gomod`) and the GitHub Actions used by the workflows (`github-actions`).
+- **`.github/workflows/security.yaml`** — runs `govulncheck ./...` on every
+  pull request, on every push to `master`, and on a weekly schedule, so newly
+  disclosed vulnerabilities are surfaced even without repository activity.
+
+Treat a failing `security` workflow or an open Dependabot PR as the signal to
+act; do not wait for an upstream release to address a vulnerability.
+
+## Watching upstream
+
+The active upstream for this codebase is
+[`TremoloSecurity/kube-oidc-proxy`](https://github.com/TremoloSecurity/kube-oidc-proxy)
+(the project originated at `jetstack/kube-oidc-proxy`, which is now archived).
+
+To be notified of upstream changes:
+
+- Watch the upstream repository's **Releases** (GitHub → Watch → Custom →
+  Releases), or subscribe to its release Atom feed:
+  `https://github.com/TremoloSecurity/kube-oidc-proxy/releases.atom`.
+- Periodically review the upstream commit log and merged pull requests for
+  security fixes and bug fixes that are relevant to the features this fork uses.
+
+Adopt upstream changes selectively. Not every upstream change applies — this
+fork carries its own module path, multi-issuer OIDC support, and independent
+CI.
+
+## Cherry-picking upstream changes
+
+Use the existing helper `hack/cherry-pick-pull.sh` to bring an upstream pull
+request onto a branch here.
+
+```sh
+# Prerequisites:
+#   - the `hub` CLI (https://github.com/github/hub)
+#   - GITHUB_USER exported (your user or org where your fork lives)
+#   - an `upstream` remote pointing at the upstream repository, and an
+#     `origin` remote pointing at this fork
+export GITHUB_USER=<your-user>
+git remote add upstream https://github.com/TremoloSecurity/kube-oidc-proxy.git   # once
+
+# Cherry-pick PR 123 onto master and open a PR:
+./hack/cherry-pick-pull.sh upstream/master 123
+
+# Cherry-pick multiple PRs into a single proposal:
+./hack/cherry-pick-pull.sh upstream/master 123 456
+
+# Set DRY_RUN=1 to cherry-pick locally without pushing or opening a PR.
+```
+
+`UPSTREAM_REMOTE` (default `upstream`) and `FORK_REMOTE` (default `origin`)
+override the remote names if yours differ.
+
+### Reconciling the renamed import path
+
+This fork renamed its Go module from `github.com/jetstack/kube-oidc-proxy` to
+`github.com/rafpe/kube-oidc-proxy` (see the module rename commit). Upstream code
+still uses the original import path, so cherry-picked changes that touch Go
+imports will conflict or fail to build until the paths are reconciled. After a
+cherry-pick:
+
+```sh
+# Rewrite any upstream import paths introduced by the cherry-pick.
+grep -rl 'jetstack/kube-oidc-proxy' --include='*.go' . \
+  | xargs sed -i '' 's#github.com/jetstack/kube-oidc-proxy#github.com/rafpe/kube-oidc-proxy#g'  # macOS; drop the '' on GNU sed
+
+go build ./... && go vet ./... && go test ./...
+```
+
+Also note that `hack/cherry-pick-pull.sh` fetches the PR patch from a
+hardcoded `github.com/jetstack/kube-oidc-proxy` URL. If you are cherry-picking
+from `TremoloSecurity/kube-oidc-proxy`, fetch the patch from the correct
+repository (for example
+`https://github.com/TremoloSecurity/kube-oidc-proxy/pull/<n>.patch`) or update
+that URL in the script before running it.
+
+Do not rewrite the runtime impersonation extra keys
+(`originaluser.jetstack.io-*`) — they are part of the impersonation API
+contract and must stay as-is.

--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/pflag"
 	cliflag "k8s.io/component-base/cli/flag"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/util/flags"
+	"github.com/rafpe/kube-oidc-proxy/pkg/util/flags"
 )
 
 type KubeOIDCProxyOptions struct {

--- a/cmd/app/options/oidc.go
+++ b/cmd/app/options/oidc.go
@@ -3,6 +3,7 @@ package options
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/pflag"
 
@@ -34,6 +35,14 @@ func (o *OIDCAuthenticationOptions) Validate(authConfigSet bool) error {
 	}
 	if o != nil && (len(o.IssuerURL) > 0) != (len(o.ClientID) > 0) {
 		return fmt.Errorf("oidc-issuer-url and oidc-client-id should be specified together")
+	}
+	// Validate --oidc-ca-file readability up front: an empty path is allowed
+	// (the system root CA set is used), but a configured file that cannot be
+	// read is a hard error rather than being silently swallowed at request time.
+	if o != nil && len(o.CAFile) > 0 {
+		if _, err := os.ReadFile(o.CAFile); err != nil {
+			return fmt.Errorf("oidc-ca-file %q: %w", o.CAFile, err)
+		}
 	}
 	return nil
 }

--- a/cmd/app/options/oidc_test.go
+++ b/cmd/app/options/oidc_test.go
@@ -1,12 +1,23 @@
 // Copyright Jetstack Ltd. See LICENSE for details.
 package options
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestOIDCAuthenticationOptions_Validate(t *testing.T) {
+	// A real, readable CA file for the happy-path and non-regression cases.
+	readableCA := filepath.Join(t.TempDir(), "ca.pem")
+	if err := os.WriteFile(readableCA, []byte("-----BEGIN CERTIFICATE-----\n"), 0600); err != nil {
+		t.Fatalf("writing temp CA file: %v", err)
+	}
+
 	tests := map[string]struct {
 		issuerURL     string
 		clientID      string
+		caFile        string
 		authConfigSet bool
 		wantErr       bool
 	}{
@@ -14,6 +25,29 @@ func TestOIDCAuthenticationOptions_Validate(t *testing.T) {
 			issuerURL: "https://vault.example.com",
 			clientID:  "my-client",
 			wantErr:   false,
+		},
+		"empty CA file path is valid (uses system roots)": {
+			issuerURL: "https://vault.example.com",
+			clientID:  "my-client",
+			caFile:    "",
+			wantErr:   false,
+		},
+		"readable CA file is valid": {
+			issuerURL: "https://vault.example.com",
+			clientID:  "my-client",
+			caFile:    readableCA,
+			wantErr:   false,
+		},
+		"unreadable CA file is an error": {
+			issuerURL: "https://vault.example.com",
+			clientID:  "my-client",
+			caFile:    "/does/not/exist/ca.pem",
+			wantErr:   true,
+		},
+		"unreadable CA file is ignored when authentication-config is set": {
+			caFile:        "/does/not/exist/ca.pem",
+			authConfigSet: true,
+			wantErr:       false,
 		},
 		"neither issuer URL nor client ID set is valid": {
 			wantErr: false,
@@ -45,6 +79,7 @@ func TestOIDCAuthenticationOptions_Validate(t *testing.T) {
 			o := &OIDCAuthenticationOptions{
 				IssuerURL: tc.issuerURL,
 				ClientID:  tc.clientID,
+				CAFile:    tc.caFile,
 			}
 			err := o.Validate(tc.authConfigSet)
 			if (err != nil) != tc.wantErr {

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/term"
 	k8sErrors "k8s.io/apimachinery/pkg/util/errors"
 
@@ -79,7 +80,7 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 
 	authConfigSet := o.AuthenticationConfig.ConfigFile != ""
 
-	if authConfigSet && oidcFlagsChanged(cmd) {
+	if authConfigSet && o.oidcFlagsChanged(cmd) {
 		errs = append(errs, fmt.Errorf("authentication-config and --oidc-* flags are mutually exclusive"))
 	}
 
@@ -92,7 +93,7 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 	}
 
 	if o.SecureServing.BindPort == o.App.ReadinessProbePort {
-		errs = append(errs, errors.New("unable to securely serve on port 8080 (used by readiness probe)"))
+		errs = append(errs, fmt.Errorf("unable to securely serve on port %d (used by readiness probe)", o.SecureServing.BindPort))
 	}
 
 	if err := o.Audit.Validate(); len(err) > 0 {
@@ -111,23 +112,15 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 	return nil
 }
 
-var oidcFlagNames = []string{
-	"oidc-issuer-url",
-	"oidc-client-id",
-	"oidc-ca-file",
-	"oidc-username-claim",
-	"oidc-username-prefix",
-	"oidc-groups-claim",
-	"oidc-groups-prefix",
-	"oidc-signing-algs",
-	"oidc-required-claim",
-}
-
-func oidcFlagsChanged(cmd *cobra.Command) bool {
-	for _, name := range oidcFlagNames {
-		if f := cmd.Flag(name); f != nil && f.Changed {
-			return true
+// oidcFlagsChanged reports whether any --oidc-* flag was set on cmd. The flag
+// names are derived from the registered OIDC flag set so the list stays in sync
+// with the flags defined in OIDCAuthenticationOptions.AddFlags automatically.
+func (o *Options) oidcFlagsChanged(cmd *cobra.Command) bool {
+	changed := false
+	o.nfs.FlagSet("OIDC").VisitAll(func(f *pflag.Flag) {
+		if cf := cmd.Flag(f.Name); cf != nil && cf.Changed {
+			changed = true
 		}
-	}
-	return false
+	})
+	return changed
 }

--- a/cmd/app/options/options_test.go
+++ b/cmd/app/options/options_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 func TestOidcFlagsChanged(t *testing.T) {
@@ -32,25 +33,28 @@ func TestOidcFlagsChanged(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
+			o := New()
 			cmd := &cobra.Command{}
-			cmd.Flags().String("oidc-issuer-url", "", "")
-			cmd.Flags().String("oidc-client-id", "", "")
-			cmd.Flags().String("oidc-ca-file", "", "")
-			cmd.Flags().String("oidc-username-claim", "", "")
-			cmd.Flags().String("oidc-username-prefix", "", "")
-			cmd.Flags().String("oidc-groups-claim", "", "")
-			cmd.Flags().String("oidc-groups-prefix", "", "")
-			cmd.Flags().StringSlice("oidc-signing-algs", nil, "")
-			cmd.Flags().String("oidc-required-claim", "", "")
-			cmd.Flags().String("secure-port", "", "")
+			o.AddFlags(cmd)
 
-			for _, name := range tc.changedFlags {
-				if err := cmd.Flags().Set(name, "value"); err != nil {
-					t.Fatalf("setting flag %q: %v", name, err)
+			// Guard against a silently-empty derivation: if FlagSet("OIDC")
+			// returned a fresh empty set, oidcFlagsChanged would always report
+			// false and the mutual-exclusion guard would become a no-op.
+			visited := 0
+			o.nfs.FlagSet("OIDC").VisitAll(func(*pflag.Flag) { visited++ })
+			if visited == 0 {
+				t.Fatal("OIDC flag set is empty; oidcFlagsChanged would never detect a changed flag")
+			}
+
+			for _, flagName := range tc.changedFlags {
+				// "8443" is a valid value for every flag exercised here,
+				// including the integer --secure-port.
+				if err := cmd.Flags().Set(flagName, "8443"); err != nil {
+					t.Fatalf("setting flag %q: %v", flagName, err)
 				}
 			}
 
-			if got := oidcFlagsChanged(cmd); got != tc.want {
+			if got := o.oidcFlagsChanged(cmd); got != tc.want {
 				t.Errorf("oidcFlagsChanged() = %v, want %v", got, tc.want)
 			}
 		})

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -20,12 +20,12 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
-	"github.com/jetstack/kube-oidc-proxy/pkg/probe"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/tokenreview"
-	"github.com/jetstack/kube-oidc-proxy/pkg/util"
+	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
+	"github.com/rafpe/kube-oidc-proxy/pkg/probe"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/tokenreview"
+	"github.com/rafpe/kube-oidc-proxy/pkg/util"
 )
 
 func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -193,10 +194,25 @@ func buildTokenAuther(opts *options.Options) (authenticator.Token, []string, err
 	return buildSingleAuther(opts.OIDCAuthentication)
 }
 
-func buildSingleAuther(o *options.OIDCAuthenticationOptions) (authenticator.Token, []string, error) {
+// jwtAuthenticatorFromOIDCOptions builds the internal JWTAuthenticator config
+// for the single-issuer (--oidc-*) path. Any --oidc-required-claim key=value
+// pairs are mapped into ClaimValidationRules so the OIDC authenticator enforces
+// them; without this mapping the flag is silently ignored.
+func jwtAuthenticatorFromOIDCOptions(o *options.OIDCAuthenticationOptions) apiserverapi.JWTAuthenticator {
 	usernamePrefix := o.UsernamePrefix
 	groupsPrefix := o.GroupsPrefix
-	jwtConfig := apiserverapi.JWTAuthenticator{
+
+	rules := make([]apiserverapi.ClaimValidationRule, 0, len(o.RequiredClaims))
+	for claim, value := range o.RequiredClaims {
+		rules = append(rules, apiserverapi.ClaimValidationRule{
+			Claim:         claim,
+			RequiredValue: value,
+		})
+	}
+	// Map iteration order is randomized; sort for deterministic construction.
+	sort.Slice(rules, func(i, j int) bool { return rules[i].Claim < rules[j].Claim })
+
+	return apiserverapi.JWTAuthenticator{
 		Issuer: apiserverapi.Issuer{
 			URL:       o.IssuerURL,
 			Audiences: []string{o.ClientID},
@@ -211,7 +227,12 @@ func buildSingleAuther(o *options.OIDCAuthenticationOptions) (authenticator.Toke
 				Prefix: &groupsPrefix,
 			},
 		},
+		ClaimValidationRules: rules,
 	}
+}
+
+func buildSingleAuther(o *options.OIDCAuthenticationOptions) (authenticator.Token, []string, error) {
+	jwtConfig := jwtAuthenticatorFromOIDCOptions(o)
 	auther, err := oidc.New(context.Background(), oidc.Options{
 		CAContentProvider:    caContentProvider(o.CAFile),
 		SupportedSigningAlgs: o.SigningAlgs,

--- a/cmd/app/run_test.go
+++ b/cmd/app/run_test.go
@@ -59,6 +59,48 @@ func TestOIDCAutherFromJWT_Construction(t *testing.T) {
 	}
 }
 
+func TestJWTAuthenticatorFromOIDCOptions_RequiredClaims(t *testing.T) {
+	t.Run("required claims are mapped into ClaimValidationRules", func(t *testing.T) {
+		o := &options.OIDCAuthenticationOptions{
+			IssuerURL:     "https://vault.example.com",
+			ClientID:      "my-client",
+			UsernameClaim: "email",
+			GroupsClaim:   "groups",
+			SigningAlgs:   []string{"RS256"},
+			RequiredClaims: map[string]string{
+				"hd":   "example.com",
+				"team": "platform",
+			},
+		}
+
+		got := jwtAuthenticatorFromOIDCOptions(o)
+
+		// Sorted by claim name for deterministic construction.
+		want := []apiserverapi.ClaimValidationRule{
+			{Claim: "hd", RequiredValue: "example.com"},
+			{Claim: "team", RequiredValue: "platform"},
+		}
+		if !reflect.DeepEqual(got.ClaimValidationRules, want) {
+			t.Errorf("ClaimValidationRules = %#v, want %#v", got.ClaimValidationRules, want)
+		}
+	})
+
+	t.Run("no required claims yields no rules", func(t *testing.T) {
+		o := &options.OIDCAuthenticationOptions{
+			IssuerURL:     "https://vault.example.com",
+			ClientID:      "my-client",
+			UsernameClaim: "email",
+			GroupsClaim:   "groups",
+			SigningAlgs:   []string{"RS256"},
+		}
+
+		got := jwtAuthenticatorFromOIDCOptions(o)
+		if len(got.ClaimValidationRules) != 0 {
+			t.Errorf("ClaimValidationRules = %#v, want empty", got.ClaimValidationRules)
+		}
+	})
+}
+
 func TestBuildTokenAuther_SingleIssuer(t *testing.T) {
 	opts := &options.Options{
 		OIDCAuthentication: &options.OIDCAuthenticationOptions{

--- a/cmd/app/run_test.go
+++ b/cmd/app/run_test.go
@@ -10,7 +10,7 @@ import (
 	apiserverapi "k8s.io/apiserver/pkg/apis/apiserver"
 	authenticationcel "k8s.io/apiserver/pkg/authentication/cel"
 
-	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
+	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
 )
 
 func writeTempFile(t *testing.T, content string) string {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/jetstack/kube-oidc-proxy/cmd/app"
-	"github.com/jetstack/kube-oidc-proxy/pkg/util"
+	"github.com/rafpe/kube-oidc-proxy/cmd/app"
+	"github.com/rafpe/kube-oidc-proxy/pkg/util"
 	"k8s.io/klog/v2"
 )
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -9,7 +9,7 @@ separate providers (Google, Amazon and Digitalocean), deploying:
 - [Gangway](https://github.com/heptiolabs/gangway) web server to authenticate
   users to Dex and help generate Kubeconfig files.
 
-- [kube-oidc-proxy](https://github.com/jetstack/kube-oidc-proxy) to expose all
+- [kube-oidc-proxy](https://github.com/rafpe/kube-oidc-proxy) to expose all
   clusters to OIDC authentication.
 
 - [Contour](https://github.com/heptio/contour) as the ingress controller with

--- a/deploy/charts/kube-oidc-proxy/Chart.yaml
+++ b/deploy/charts/kube-oidc-proxy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 appVersion: "v1.0.0"
 description: A Helm chart for kube-oidc-proxy
-home: https://github.com/jetstack/kube-oidc-proxy
+home: https://github.com/rafpe/kube-oidc-proxy
 name: kube-oidc-proxy
 version: 0.3.2
 maintainers:

--- a/deploy/charts/kube-oidc-proxy/README.md
+++ b/deploy/charts/kube-oidc-proxy/README.md
@@ -1,11 +1,11 @@
 # kube-oidc-proxy helm chart
 
-This is a `helm` chart that installs [`kube-oidc-proxy`](https://github.com/jetstack/kube-oidc-proxy/).
+This is a `helm` chart that installs [`kube-oidc-proxy`](https://github.com/rafpe/kube-oidc-proxy/).
 This helm chart cannot be installed out of the box without providing own
 configuration.
 
 This helm chart is based on example configuration provided in `kube-oidc-proxy`
-[repository](https://github.com/jetstack/kube-oidc-proxy/blob/master/deploy/yaml/kube-oidc-proxy.yaml).
+[repository](https://github.com/rafpe/kube-oidc-proxy/blob/master/deploy/yaml/kube-oidc-proxy.yaml).
 
 Minimal required configuration is `oidc` section of `value.yaml` file.
 

--- a/deploy/charts/kube-oidc-proxy/values.yaml
+++ b/deploy/charts/kube-oidc-proxy/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 
 image:
-  repository: quay.io/jetstack/kube-oidc-proxy
+  repository: quay.io/rafpe/kube-oidc-proxy
   tag: v0.3.0
   pullPolicy: IfNotPresent
 
@@ -76,13 +76,13 @@ authenticationConfig:
 readinessRequireAllIssuers: false
 
 # To enable token passthrough feature
-# https://github.com/jetstack/kube-oidc-proxy/blob/master/docs/tasks/token-passthrough.md
+# https://github.com/rafpe/kube-oidc-proxy/blob/master/docs/tasks/token-passthrough.md
 tokenPassthrough:
   enabled: false
   audiences: []
 
 # To add extra impersonation headers
-# https://github.com/jetstack/kube-oidc-proxy/blob/master/docs/tasks/extra-impersonation-headers.md
+# https://github.com/rafpe/kube-oidc-proxy/blob/master/docs/tasks/extra-impersonation-headers.md
 extraImpersonationHeaders:
   clientIP: false
   #headers: key1=foo,key2=bar,key1=bar

--- a/deploy/yaml/kube-oidc-proxy.yaml
+++ b/deploy/yaml/kube-oidc-proxy.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       serviceAccountName: kube-oidc-proxy
       containers:
-      - image: quay.io/jetstack/kube-oidc-proxy:v0.3.0
+      - image: quay.io/rafpe/kube-oidc-proxy:v0.3.0
         ports:
         - containerPort: 443
         - containerPort: 8080

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jetstack/kube-oidc-proxy
+module github.com/rafpe/kube-oidc-proxy
 
 go 1.26.2
 

--- a/hack/version-ldflags.sh
+++ b/hack/version-ldflags.sh
@@ -23,5 +23,5 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 source "${KUBE_ROOT}/hack/lib/version.sh"
-KUBE_GO_PACKAGE=github.com/jetstack/kube-oidc-proxy
+KUBE_GO_PACKAGE=github.com/rafpe/kube-oidc-proxy
 kube::version::ldflags

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -3,12 +3,12 @@ package probe
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/heptiolabs/healthcheck"
@@ -19,6 +19,19 @@ import (
 const (
 	timeout = time.Second * 10
 )
+
+// transientMarkers are substrings that unambiguously identify a transient
+// network/timeout failure while probing an issuer. The set is deliberately
+// conservative: a false "pending" is worse than a false "ready" here, because
+// in require-all mode a healthy issuer wrongly classified as pending would keep
+// the pod from ever becoming ready. Only phrases that cannot appear in an
+// ordinary JWT verification error belong here.
+var transientMarkers = []string{
+	"context deadline exceeded",
+	"connection refused",
+	"no such host",
+	"i/o timeout",
+}
 
 // IssuerReadiness pairs an issuer with the fake JWT used to probe whether
 // its authenticator has completed JWKS initialization.
@@ -32,9 +45,9 @@ type HealthCheck struct {
 	oidcAuther authenticator.Token
 	issuers    []IssuerReadiness
 	requireAll bool
-	ready      atomic.Bool
 
 	mu          sync.Mutex
+	ready       bool
 	initialized map[string]bool
 }
 
@@ -49,17 +62,48 @@ func Run(port string, issuers []IssuerReadiness, requireAll bool, oidcAuther aut
 
 	h.handler.AddReadinessCheck("secure serving", h.Check)
 
+	// Bind synchronously so a failure to acquire the port is surfaced to the
+	// caller at startup rather than being swallowed inside the goroutine.
+	ln, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", port))
+	if err != nil {
+		return fmt.Errorf("readiness probe failed to listen on port %s: %w", port, err)
+	}
+
 	go func() {
-		for {
-			err := http.ListenAndServe(net.JoinHostPort("0.0.0.0", port), h.handler)
-			if err != nil {
-				klog.Errorf("ready probe listener failed: %s", err)
-			}
-			time.Sleep(5 * time.Second)
+		if err := http.Serve(ln, h.handler); err != nil {
+			klog.Errorf("ready probe listener failed: %s", err)
 		}
 	}()
 
 	return nil
+}
+
+// isNotInitialized reports whether err indicates the issuer's authenticator has
+// not yet completed JWKS initialization. It matches on the stable "not
+// initialized" fragment so both upstream phrasings ("authenticator not
+// initialized" and "... is not initialized") are handled.
+func isNotInitialized(err error) bool {
+	return strings.Contains(err.Error(), "not initialized")
+}
+
+// isTransient reports whether err is a transient network/timeout failure. Such
+// errors must leave the issuer pending rather than latching it as initialized,
+// otherwise a momentary hiccup would be mistaken for a fetched JWKS.
+func isTransient(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	msg := err.Error()
+	for _, marker := range transientMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // Check probes every issuer that has not yet been observed as initialized,
@@ -81,7 +125,11 @@ func (h *HealthCheck) Check() error {
 		}
 
 		_, _, err := h.oidcAuther.AuthenticateToken(ctx, issuer.FakeJWT)
-		if err != nil && strings.HasSuffix(err.Error(), "authenticator not initialized") {
+		// The issuer counts as initialized only once its authenticator reaches
+		// token verification. A "not initialized" signal (JWKS not fetched yet)
+		// or a transient network/timeout error both leave it pending; check
+		// "not initialized" first since it is the more specific signal.
+		if err != nil && (isNotInitialized(err) || isTransient(err)) {
 			pending = append(pending, issuer.IssuerURL)
 			continue
 		}
@@ -95,7 +143,7 @@ func (h *HealthCheck) Check() error {
 			len(h.initialized), len(h.issuers), pending)
 	}
 
-	if h.ready.Load() {
+	if h.ready {
 		return nil
 	}
 
@@ -106,7 +154,7 @@ func (h *HealthCheck) Check() error {
 		return errors.New("no OIDC provider initialized yet")
 	}
 
-	h.ready.Store(true)
+	h.ready = true
 	klog.V(4).Info("OIDC provider(s) initialized, marking ready.")
 	return nil
 }

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -4,6 +4,7 @@ package probe
 import (
 	"context"
 	"errors"
+	"net"
 	"sync"
 	"testing"
 
@@ -14,11 +15,14 @@ import (
 
 // fakeAuther simulates the union authenticator: tokens listed in notInit
 // hit an issuer whose JWKS is not yet fetched; every other token reaches
-// an initialized issuer and fails ordinary verification.
+// an initialized issuer and fails ordinary verification. A per-token error
+// may be supplied via override to model alternate phrasings and transient
+// failures.
 type fakeAuther struct {
-	mu      sync.Mutex
-	notInit map[string]bool
-	calls   map[string]int
+	mu       sync.Mutex
+	notInit  map[string]bool
+	override map[string]error
+	calls    map[string]int
 }
 
 func (f *fakeAuther) AuthenticateToken(_ context.Context, token string) (*authenticator.Response, bool, error) {
@@ -29,6 +33,9 @@ func (f *fakeAuther) AuthenticateToken(_ context.Context, token string) (*authen
 	f.calls[token]++
 	f.mu.Unlock()
 
+	if err, ok := f.override[token]; ok {
+		return nil, false, err
+	}
 	if f.notInit[token] {
 		return nil, false, errors.New("oidc: authenticator not initialized")
 	}
@@ -41,14 +48,18 @@ func (f *fakeAuther) callCount(token string) int {
 	return f.calls[token]
 }
 
-func newTestHealthCheck(requireAll bool, notInit map[string]bool, issuers ...IssuerReadiness) *HealthCheck {
+func newTestHealthCheckWithAuther(requireAll bool, auther authenticator.Token, issuers ...IssuerReadiness) *HealthCheck {
 	return &HealthCheck{
 		handler:     healthcheck.NewHandler(),
-		oidcAuther:  &fakeAuther{notInit: notInit},
+		oidcAuther:  auther,
 		issuers:     issuers,
 		requireAll:  requireAll,
 		initialized: make(map[string]bool),
 	}
+}
+
+func newTestHealthCheck(requireAll bool, notInit map[string]bool, issuers ...IssuerReadiness) *HealthCheck {
+	return newTestHealthCheckWithAuther(requireAll, &fakeAuther{notInit: notInit}, issuers...)
 }
 
 func TestCheckReadiness(t *testing.T) {
@@ -133,7 +144,7 @@ func TestCheckContinuesProbingPendingAfterLatch(t *testing.T) {
 	if err := h.Check(); err != nil {
 		t.Fatalf("expected ready (issuer A initialized), got: %v", err)
 	}
-	if !h.ready.Load() {
+	if !h.ready {
 		t.Fatal("expected readiness to have latched")
 	}
 
@@ -171,5 +182,87 @@ func TestCheckContinuesProbingPendingAfterLatch(t *testing.T) {
 	}
 	if got := fake.callCount("jwt-b"); got != bCallsAfterInit {
 		t.Fatalf("expected issuer B not to be re-probed once initialized, call count changed from %d to %d", bCallsAfterInit, got)
+	}
+}
+
+// TestCheckAlternatePhrasingKeepsPending verifies that the alternate upstream
+// wording "... is not initialized" is still recognised as pending and does not
+// falsely latch readiness.
+func TestCheckAlternatePhrasingKeepsPending(t *testing.T) {
+	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
+
+	auther := &fakeAuther{
+		override: map[string]error{
+			"jwt-a": errors.New("oidc: authenticator for issuer is not initialized"),
+		},
+	}
+	h := newTestHealthCheckWithAuther(true, auther, issuerA)
+
+	if err := h.Check(); err == nil {
+		t.Fatal("expected not-ready for alternate 'is not initialized' phrasing, got nil")
+	}
+	if h.ready {
+		t.Fatal("readiness must not latch while the only issuer is uninitialized")
+	}
+	if h.initialized[issuerA.IssuerURL] {
+		t.Fatal("issuer must not be marked initialized for a 'not initialized' error")
+	}
+}
+
+// TestCheckTransientErrorDoesNotLatch verifies that a transient network/timeout
+// error leaves the issuer pending instead of being mistaken for a fetched JWKS
+// (which would falsely latch readiness).
+func TestCheckTransientErrorDoesNotLatch(t *testing.T) {
+	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
+
+	tests := map[string]error{
+		"context deadline":    context.DeadlineExceeded,
+		"connection refused":  errors.New(`Get "https://a.example.com/.well-known/openid-configuration": dial tcp 10.0.0.1:443: connect: connection refused`),
+		"net timeout wrapped": &net.OpError{Op: "dial", Err: timeoutError{}},
+	}
+
+	for name, retErr := range tests {
+		t.Run(name, func(t *testing.T) {
+			auther := &fakeAuther{override: map[string]error{"jwt-a": retErr}}
+			h := newTestHealthCheckWithAuther(true, auther, issuerA)
+
+			if err := h.Check(); err == nil {
+				t.Fatal("expected not-ready for transient error, got nil")
+			}
+			if h.ready {
+				t.Fatal("readiness must not latch on a transient error")
+			}
+			if h.initialized[issuerA.IssuerURL] {
+				t.Fatal("issuer must not be marked initialized on a transient error")
+			}
+		})
+	}
+}
+
+// timeoutError is a net.Error whose Timeout reports true, modelling a wrapped
+// i/o timeout surfaced through errors.As.
+type timeoutError struct{}
+
+func (timeoutError) Error() string   { return "i/o timeout" }
+func (timeoutError) Timeout() bool   { return true }
+func (timeoutError) Temporary() bool { return true }
+
+func TestRunReturnsBindError(t *testing.T) {
+	// Occupy the wildcard address, then ask Run to bind the same port so the
+	// bind fails. Run listens on 0.0.0.0, so occupy 0.0.0.0 too: a loopback-only
+	// listener would not necessarily collide with a wildcard bind.
+	occupied, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("reserving port: %v", err)
+	}
+	defer func() { _ = occupied.Close() }()
+
+	_, port, err := net.SplitHostPort(occupied.Addr().String())
+	if err != nil {
+		t.Fatalf("splitting host/port: %v", err)
+	}
+
+	if err := Run(port, nil, false, &fakeAuther{}); err == nil {
+		t.Fatal("expected Run to return an error binding an occupied port, got nil")
 	}
 }

--- a/pkg/proxy/audit/audit.go
+++ b/pkg/proxy/audit/audit.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
+	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
 	"k8s.io/apimachinery/pkg/util/sets"
 	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
 	"k8s.io/apiserver/pkg/server"

--- a/pkg/proxy/context/context.go
+++ b/pkg/proxy/context/context.go
@@ -8,8 +8,6 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/transport"
-
-	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
 type key int
@@ -49,7 +47,7 @@ func NoImpersonation(req *http.Request) bool {
 func WithImpersonationConfig(req *http.Request, conf *ImpersonationRequest) *http.Request {
 	ctxToReturn := request.WithValue(req.Context(), impersonationConfigKey, conf)
 	if *conf.ImpersonatedUser != nil {
-		ctxToReturn = genericapirequest.WithUser(ctxToReturn, *conf.ImpersonatedUser)
+		ctxToReturn = request.WithUser(ctxToReturn, *conf.ImpersonatedUser)
 	}
 	return req.WithContext(ctxToReturn)
 }

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -12,10 +12,10 @@ import (
 	"k8s.io/client-go/transport"
 	"k8s.io/klog/v2"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/audit"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/context"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/logging"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/audit"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/context"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/logging"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
 )
 
 func (p *Proxy) withHandlers(handler http.Handler) http.Handler {

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -3,10 +3,10 @@ package proxy
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 
-	"k8s.io/apiserver/pkg/authentication/user"
 	authuser "k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/transport"
@@ -94,8 +94,7 @@ func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
 			return
 		}
 
-		var targetForContext user.Info
-		targetForContext = nil
+		var targetForContext authuser.Info
 
 		var remoteAddr string
 		req, remoteAddr = context.RemoteAddr(req)
@@ -192,7 +191,7 @@ func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
 				extra["originaluser.jetstack.io-uid"] = []string{userForContext.GetUID()}
 			}
 
-			if userForContext.GetExtra() != nil && len(userForContext.GetExtra()) > 0 {
+			if len(userForContext.GetExtra()) > 0 {
 				jsonExtras, errJsonMarshal := json.Marshal(userForContext.GetExtra())
 				if errJsonMarshal != nil {
 					p.handleError(rw, req, errJsonMarshal)
@@ -237,28 +236,28 @@ func (p *Proxy) newErrorHandler() func(rw http.ResponseWriter, r *http.Request, 
 		// regardless of reason, log failed auth
 		logging.LogFailedRequest(r)
 
-		switch err {
+		switch {
 
 		// Failed auth
-		case errUnauthorized:
+		case errors.Is(err, errUnauthorized):
 			// If Unauthorized then error and report to audit
 			unauthedHandler.ServeHTTP(rw, r)
 			return
 
 			// No name given or available in oidc request
-		case errNoName:
+		case errors.Is(err, errNoName):
 			klog.V(2).Infof("no name available in oidc info %s", r.RemoteAddr)
 			http.Error(rw, "Username claim not available in OIDC Issuer response", http.StatusForbidden)
 			return
 
 			// No impersonation configuration found in context
-		case errNoImpersonationConfig:
+		case errors.Is(err, errNoImpersonationConfig):
 			klog.Errorf("if you are seeing this, there is likely a bug in the proxy (%s): %s", r.RemoteAddr, err)
 			http.Error(rw, "", http.StatusInternalServerError)
 			return
 
 			// No impersonation user found
-		case subjectaccessreview.ErrorNoImpersonationUserFound:
+		case errors.Is(err, subjectaccessreview.ErrorNoImpersonationUserFound):
 			http.Error(rw, subjectaccessreview.ErrorNoImpersonationUserFound.Error(), http.StatusInternalServerError)
 			return
 
@@ -266,7 +265,7 @@ func (p *Proxy) newErrorHandler() func(rw http.ResponseWriter, r *http.Request, 
 		default:
 
 			if strings.Contains(err.Error(), "not allowed to impersonate") {
-				klog.V(2).Infof(err.Error(), r.RemoteAddr)
+				klog.V(2).Infof("%s (%s)", err.Error(), r.RemoteAddr)
 				http.Error(rw, err.Error(), http.StatusForbidden)
 			} else {
 				klog.Errorf("unknown error (%s): %s", r.RemoteAddr, err)

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -16,13 +16,13 @@ import (
 	"k8s.io/client-go/transport"
 	"k8s.io/klog/v2"
 
-	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/audit"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/context"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/hooks"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/logging"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/tokenreview"
+	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/audit"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/context"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/hooks"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/logging"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/tokenreview"
 )
 
 const (

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -31,9 +31,9 @@ const (
 )
 
 var (
-	errUnauthorized          = errors.New("Unauthorized")
-	errNoName                = errors.New("No name in OIDC info")
-	errNoImpersonationConfig = errors.New("No impersonation configuration in context")
+	errUnauthorized          = errors.New("unauthorized")
+	errNoName                = errors.New("no name in OIDC info")
+	errNoImpersonationConfig = errors.New("no impersonation configuration in context")
 )
 
 type Config struct {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -327,7 +327,7 @@ func TestHandlers(t *testing.T) {
 		"an empty request should 401": {
 			req:     new(http.Request),
 			expCode: http.StatusUnauthorized,
-			expBody: errUnauthorized.Error(),
+			expBody: "Unauthorized",
 		},
 		"a request with a badly formed token should 401": {
 			req: &http.Request{
@@ -336,7 +336,7 @@ func TestHandlers(t *testing.T) {
 				},
 			},
 			expCode: http.StatusUnauthorized,
-			expBody: errUnauthorized.Error(),
+			expBody: "Unauthorized",
 		},
 		"a request with a unauthed token should 401": {
 			req: &http.Request{
@@ -351,7 +351,7 @@ func TestHandlers(t *testing.T) {
 				err:  nil,
 			},
 			expCode: http.StatusUnauthorized,
-			expBody: errUnauthorized.Error(),
+			expBody: "Unauthorized",
 		},
 		"a request with an error during token auth should 401": {
 			req: &http.Request{
@@ -366,7 +366,7 @@ func TestHandlers(t *testing.T) {
 				err:  errors.New("some error"),
 			},
 			expCode: http.StatusUnauthorized,
-			expBody: errUnauthorized.Error(),
+			expBody: "Unauthorized",
 		},
 		"a request with an error but passes during token auth should still 401": {
 			req: &http.Request{
@@ -381,7 +381,7 @@ func TestHandlers(t *testing.T) {
 				err:  errors.New("some error"),
 			},
 			expCode: http.StatusUnauthorized,
-			expBody: errUnauthorized.Error(),
+			expBody: "Unauthorized",
 		},
 		"a request with unauth with impersonation should 401": {
 			req: &http.Request{
@@ -397,7 +397,7 @@ func TestHandlers(t *testing.T) {
 				err:  nil,
 			},
 			expCode: http.StatusUnauthorized,
-			expBody: errUnauthorized.Error(),
+			expBody: "Unauthorized",
 		},
 
 		// BEGIN IMPERSONATION TESTS

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -20,13 +20,13 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/server"
 
-	"github.com/jetstack/kube-oidc-proxy/cmd/app/options"
-	"github.com/jetstack/kube-oidc-proxy/pkg/mocks"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/audit"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/hooks"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/logging"
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
-	fakesubjectaccessreview "github.com/jetstack/kube-oidc-proxy/pkg/proxy/subjectaccessreview/fake"
+	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
+	"github.com/rafpe/kube-oidc-proxy/pkg/mocks"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/audit"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/hooks"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/logging"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
+	fakesubjectaccessreview "github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview/fake"
 )
 
 type fakeProxy struct {

--- a/pkg/proxy/subjectaccessreview/subjectaccessreview_test.go
+++ b/pkg/proxy/subjectaccessreview/subjectaccessreview_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/subjectaccessreview/fake"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview/fake"
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
 )

--- a/pkg/proxy/tokenreview/tokenreview.go
+++ b/pkg/proxy/tokenreview/tokenreview.go
@@ -14,7 +14,7 @@ import (
 	clientauthv1 "k8s.io/client-go/kubernetes/typed/authentication/v1"
 	"k8s.io/client-go/rest"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/util"
+	"github.com/rafpe/kube-oidc-proxy/pkg/util"
 )
 
 var (

--- a/pkg/proxy/tokenreview/tokenreview_test.go
+++ b/pkg/proxy/tokenreview/tokenreview_test.go
@@ -9,7 +9,7 @@ import (
 
 	authv1 "k8s.io/api/authentication/v1"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/proxy/tokenreview/fake"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/tokenreview/fake"
 )
 
 type testT struct {

--- a/test/e2e/framework/config/config.go
+++ b/test/e2e/framework/config/config.go
@@ -6,7 +6,7 @@ import (
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/jetstack/kube-oidc-proxy/test/environment"
+	"github.com/rafpe/kube-oidc-proxy/test/environment"
 )
 
 type Config struct {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -14,10 +14,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework/config"
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework/helper"
-	"github.com/jetstack/kube-oidc-proxy/test/kind"
-	"github.com/jetstack/kube-oidc-proxy/test/util"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework/config"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework/helper"
+	"github.com/rafpe/kube-oidc-proxy/test/kind"
+	"github.com/rafpe/kube-oidc-proxy/test/util"
 )
 
 var DefaultConfig = &config.Config{}

--- a/test/e2e/framework/helper/deploy.go
+++ b/test/e2e/framework/helper/deploy.go
@@ -17,8 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/jetstack/kube-oidc-proxy/test/kind"
-	"github.com/jetstack/kube-oidc-proxy/test/util"
+	"github.com/rafpe/kube-oidc-proxy/test/kind"
+	"github.com/rafpe/kube-oidc-proxy/test/util"
 )
 
 func (h *Helper) DeployProxy(ns *corev1.Namespace, issuerURL *url.URL, clientID string,

--- a/test/e2e/framework/helper/helper.go
+++ b/test/e2e/framework/helper/helper.go
@@ -4,7 +4,7 @@ package helper
 import (
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework/config"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework/config"
 )
 
 // Helper provides methods for common operations needed during tests.

--- a/test/e2e/framework/helper/token.go
+++ b/test/e2e/framework/helper/token.go
@@ -12,7 +12,7 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 	"k8s.io/client-go/rest"
 
-	"github.com/jetstack/kube-oidc-proxy/test/util"
+	"github.com/rafpe/kube-oidc-proxy/test/util"
 )
 
 func (h *Helper) NewValidRestConfig(issuerBundle, proxyBundle *util.KeyBundle,

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -19,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
 var _ = framework.CasesDescribe("Audit", func() {

--- a/test/e2e/suite/cases/authconfig/authconfig.go
+++ b/test/e2e/suite/cases/authconfig/authconfig.go
@@ -13,9 +13,9 @@ import (
 	apiserverv1 "k8s.io/apiserver/pkg/apis/apiserver/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/sharedtests"
-	"github.com/jetstack/kube-oidc-proxy/test/util"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/sharedtests"
+	"github.com/rafpe/kube-oidc-proxy/test/util"
 )
 
 const (

--- a/test/e2e/suite/cases/doc.go
+++ b/test/e2e/suite/cases/doc.go
@@ -2,13 +2,13 @@
 package cases
 
 import (
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/audit"
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/authconfig"
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/headers"
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/impersonation"
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/passthrough"
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/probe"
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/rbac"
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/token"
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/upgrade"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/audit"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/authconfig"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/headers"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/impersonation"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/passthrough"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/probe"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/rbac"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/token"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/upgrade"
 )

--- a/test/e2e/suite/cases/headers/headers.go
+++ b/test/e2e/suite/cases/headers/headers.go
@@ -10,8 +10,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
-	testutil "github.com/jetstack/kube-oidc-proxy/test/util"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
+	testutil "github.com/rafpe/kube-oidc-proxy/test/util"
 )
 
 var _ = framework.CasesDescribe("Headers", func() {

--- a/test/e2e/suite/cases/impersonation/impersonation.go
+++ b/test/e2e/suite/cases/impersonation/impersonation.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
 var _ = framework.CasesDescribe("Impersonation", func() {

--- a/test/e2e/suite/cases/passthrough/passthrough.go
+++ b/test/e2e/suite/cases/passthrough/passthrough.go
@@ -14,7 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
 var _ = framework.CasesDescribe("Passthrough", func() {

--- a/test/e2e/suite/cases/probe/probe.go
+++ b/test/e2e/suite/cases/probe/probe.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
-	"github.com/jetstack/kube-oidc-proxy/test/kind"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/kind"
 )
 
 var _ = framework.CasesDescribe("Readiness Probe", func() {

--- a/test/e2e/suite/cases/rbac/rbac.go
+++ b/test/e2e/suite/cases/rbac/rbac.go
@@ -12,7 +12,7 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
 var _ = framework.CasesDescribe("RBAC", func() {

--- a/test/e2e/suite/cases/sharedtests/sharedtests.go
+++ b/test/e2e/suite/cases/sharedtests/sharedtests.go
@@ -18,8 +18,8 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
-	"github.com/jetstack/kube-oidc-proxy/test/util"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/util"
 )
 
 // RunTokenValidationTests registers Ginkgo It blocks exercising the proxy's

--- a/test/e2e/suite/cases/token/token.go
+++ b/test/e2e/suite/cases/token/token.go
@@ -2,8 +2,8 @@
 package token
 
 import (
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases/sharedtests"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/sharedtests"
 )
 
 var _ = framework.CasesDescribe("Token", func() {

--- a/test/e2e/suite/cases/upgrade/upgrade.go
+++ b/test/e2e/suite/cases/upgrade/upgrade.go
@@ -26,8 +26,8 @@ import (
 	// required to register oidc auth plugin for rest client
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/util"
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/pkg/util"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
 var _ = framework.CasesDescribe("Upgrade", func() {

--- a/test/e2e/suite/suite.go
+++ b/test/e2e/suite/suite.go
@@ -7,8 +7,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework"
-	"github.com/jetstack/kube-oidc-proxy/test/environment"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/environment"
 )
 
 var (

--- a/test/e2e/suite/suite_test.go
+++ b/test/e2e/suite/suite_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	_ "github.com/jetstack/kube-oidc-proxy/test/e2e/suite/cases"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases"
 )
 
 func init() {

--- a/test/environment/dev/dev.go
+++ b/test/environment/dev/dev.go
@@ -15,10 +15,10 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework/config"
-	"github.com/jetstack/kube-oidc-proxy/test/e2e/framework/helper"
-	"github.com/jetstack/kube-oidc-proxy/test/environment"
-	"github.com/jetstack/kube-oidc-proxy/test/kind"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework/config"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework/helper"
+	"github.com/rafpe/kube-oidc-proxy/test/environment"
+	"github.com/rafpe/kube-oidc-proxy/test/kind"
 )
 
 const (

--- a/test/environment/environment.go
+++ b/test/environment/environment.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 
-	"github.com/jetstack/kube-oidc-proxy/test/kind"
+	"github.com/rafpe/kube-oidc-proxy/test/kind"
 )
 
 const (

--- a/test/tools/audit-webhook/cmd/main.go
+++ b/test/tools/audit-webhook/cmd/main.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/util"
-	"github.com/jetstack/kube-oidc-proxy/test/tools/audit-webhook/cmd/options"
-	"github.com/jetstack/kube-oidc-proxy/test/tools/audit-webhook/pkg/sink"
+	"github.com/rafpe/kube-oidc-proxy/pkg/util"
+	"github.com/rafpe/kube-oidc-proxy/test/tools/audit-webhook/cmd/options"
+	"github.com/rafpe/kube-oidc-proxy/test/tools/audit-webhook/pkg/sink"
 )
 
 func main() {

--- a/test/tools/fake-apiserver/cmd/main.go
+++ b/test/tools/fake-apiserver/cmd/main.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/util"
-	"github.com/jetstack/kube-oidc-proxy/test/tools/fake-apiserver/cmd/options"
-	"github.com/jetstack/kube-oidc-proxy/test/tools/fake-apiserver/pkg/server"
+	"github.com/rafpe/kube-oidc-proxy/pkg/util"
+	"github.com/rafpe/kube-oidc-proxy/test/tools/fake-apiserver/cmd/options"
+	"github.com/rafpe/kube-oidc-proxy/test/tools/fake-apiserver/pkg/server"
 )
 
 func main() {

--- a/test/tools/issuer/cmd/main.go
+++ b/test/tools/issuer/cmd/main.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jetstack/kube-oidc-proxy/pkg/util"
-	"github.com/jetstack/kube-oidc-proxy/test/tools/issuer/cmd/options"
-	"github.com/jetstack/kube-oidc-proxy/test/tools/issuer/pkg/issuer"
+	"github.com/rafpe/kube-oidc-proxy/pkg/util"
+	"github.com/rafpe/kube-oidc-proxy/test/tools/issuer/cmd/options"
+	"github.com/rafpe/kube-oidc-proxy/test/tools/issuer/pkg/issuer"
 )
 
 func main() {


### PR DESCRIPTION
## Epic #1 — Fork-independence foundation

Establishes this fork as an independent project that can still absorb upstream security fixes. Implements every child of #1.

> **Note:** the current `master` tip (`eee3560f`) does not compile — it swapped `fmt.Errorf` → `errors.New` in `pkg/probe/probe.go` without fixing imports (`fmt` unused, `errors` not imported). This PR is based on that commit and **fixes it** in the probe hardening commit, so merging also un-breaks `master`.

### What's in here (5 commits)
- **`fix(auth)` — honor `--oidc-required-claim`** — the flag was parsed and counted toward mutual exclusion but never mapped into the authenticator (silent no-op, security-relevant). Now populates `JWTAuthenticator.ClaimValidationRules`, with a test.
- **`fix(probe,options)` — hardening** — robust "not initialized" detection (both upstream phrasings) that no longer false-latches on transient/timeout errors; `probe.Run` surfaces listener bind errors; `--oidc-ca-file` readability validated at startup; non-constant klog format string fixed; `oidcFlagsChanged` derives flag names from the OIDC flagset; plus the low-severity lint/style sweep (ST1005/ST1019, `atomic.Bool`→mutex-guarded bool, `errors.Is` dispatch).
- **`refactor` — module rename** `github.com/jetstack/kube-oidc-proxy` → `github.com/rafpe/kube-oidc-proxy` across all Go files, `go.mod`, `hack/version-ldflags.sh`, chart, deploy yaml, docs. Runtime API strings (`originaluser.jetstack.io-*`) and the `jetstack/cert-manager` link left intact.
- **`ci` — independent security automation** — `.github/dependabot.yml` (gomod + github-actions) and a `govulncheck` workflow (PR + push + weekly).
- **`docs` — `MAINTAINING.md`** — the fork's independence model and the upstream cherry-pick workflow.

### Verification
- In-scope `go build` / `go vet` / `go test ./cmd/... ./pkg/...` — green; `gofmt` clean.
- Pre-existing out-of-scope failures unchanged (`hack/boilerplate/test`, `test/e2e/...`).
- `govulncheck` surfaces 14 pre-existing dependency vulns — Dependabot will action them (day-one: `golang.org/x/net` → v0.53.0, stdlib → go1.26.3).

### Reviewer note
`pkg/mocks/authenticator.go` is generated + gitignored — run `make generate` before building `pkg/proxy`.

Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
