### PR TITLE
Sub-project 7 — E2E-with-kind CI gate (#35–#40)

### DIFF
--- a/.github/workflows/e2e-oidc-gha.yaml
+++ b/.github/workflows/e2e-oidc-gha.yaml
@@ -1,0 +1,87 @@
+name: e2e-oidc-gha
+
+# Multi-issuer e2e against the REAL GitHub Actions OIDC issuer.
+#
+# Mints a genuine GitHub Actions ID token in-job (id-token: write) and proves
+# the kube-oidc-proxy union authenticator accepts it AND a local Dex issuer
+# through a single AuthenticationConfiguration. See
+# hack/ci/gha-multi-issuer-e2e.sh for the full flow and assertions.
+#
+# The minted token's audience MUST match the AuthenticationConfiguration's
+# `audiences` entry; both are set to GHA_AUDIENCE below.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: e2e-oidc-gha-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GHA_AUDIENCE: kube-oidc-proxy-kind-test
+
+jobs:
+  gha-multi-issuer:
+    # OIDC tokens (id-token: write) are not issued to pull requests from forks,
+    # so skip fork PRs; runs on push to main, workflow_dispatch, and same-repo PRs.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install kind CLI
+        env:
+          KIND_VERSION: v0.31.0
+        run: |
+          curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          sudo install -m 0755 ./kind /usr/local/bin/kind
+          rm -f ./kind
+          kind version
+
+      - name: Mint a GitHub Actions OIDC token
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GHA_AUDIENCE: ${{ env.GHA_AUDIENCE }}
+        with:
+          script: |
+            const audience = process.env.GHA_AUDIENCE
+            const token = await core.getIDToken(audience)
+            require('fs').writeFileSync('gha-token.jwt', token)
+            core.setSecret(token)
+            core.info(`minted GitHub Actions OIDC token for audience ${audience}`)
+
+      - name: Run multi-issuer e2e (real GHA issuer + local Dex)
+        env:
+          GHA_TOKEN_FILE: ${{ github.workspace }}/gha-token.jwt
+        run: hack/ci/gha-multi-issuer-e2e.sh
+
+      - name: Remove the minted token
+        if: always()
+        run: rm -f gha-token.jwt
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-oidc-gha-logs
+          path: |
+            artifacts/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,61 @@
+name: e2e
+
+# End-to-end gate: builds the proxy + test-tool images, stands up a kind
+# cluster, and runs the Go e2e suite (test/e2e/suite) against it. The suite
+# creates and destroys its own kind cluster via `make e2e`; the kind CLI is
+# installed only for the failure/interrupt cleanup net (`make e2e-clean`).
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-kind:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install kind CLI
+        env:
+          KIND_VERSION: v0.31.0
+        run: |
+          curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          sudo install -m 0755 ./kind /usr/local/bin/kind
+          rm -f ./kind
+          kind version
+
+      - name: Tool versions
+        run: |
+          go version
+          docker version
+          kubectl version --client
+          kind version
+
+      - name: Run e2e suite
+        run: make e2e
+
+      - name: Upload e2e artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-artifacts
+          path: |
+            artifacts/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -12,21 +12,22 @@ export GO111MODULE=on
 help:  ## display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-.PHONY: help build docker_build test depend verify all clean generate
+.PHONY: help build docker_build test depend verify all clean generate e2e e2e-clean
 
 UNAME_S := $(shell uname -s)
 GOLANGCILINT_VERSION := 1.21.0
+# kubectl version used only as a download fallback when no system kubectl is on
+# PATH (the e2e suite prefers the host's kubectl, see the $(BINDIR)/kubectl rule).
+KUBECTL_VERSION ?= v1.31.4
+KUBECTL_OS   := $(shell go env GOOS)
+KUBECTL_ARCH := $(shell go env GOARCH)
 ifeq ($(UNAME_S),Linux)
 	SHASUM := sha256sum -c
-	KUBECTL_URL := https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
-	KUBECTL_HASH := bb16739fcad964c197752200ff89d89aad7b118cb1de5725dc53fe924c40e3f7
 	GOLANGCILINT_URL := https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCILINT_VERSION)/golangci-lint-$(GOLANGCILINT_VERSION)-linux-amd64.tar.gz
 	GOLANGCILINT_HASH := 2c861f8dc56b560474aa27cab0c075991628cc01af3451e27ac82f5d10d5106b
 endif
 ifeq ($(UNAME_S),Darwin)
 	SHASUM := shasum -a 256 -c
-	KUBECTL_URL := https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/darwin/amd64/kubectl
-	KUBECTL_HASH := 5eda86058a3db112821761b32afce3fdd2f6963ab580b1780a638ac323864eba
 	GOLANGCILINT_URL := https://github.com/golangci/golangci-lint/releases/download/v$(GOLANGCILINT_VERSION)/golangci-lint-$(GOLANGCILINT_VERSION)-darwin-amd64.tar.gz
 	GOLANGCILINT_HASH := 2b2713ec5007e67883aa501eebb81f22abfab0cf0909134ba90f60a066db3760
 endif
@@ -35,12 +36,20 @@ $(BINDIR)/mockgen:
 	mkdir -p $(BINDIR)
 	go build -o $(BINDIR)/mockgen go.uber.org/mock/mockgen
 
+# Provide a modern kubectl for the e2e helper. Prefer the host's kubectl (kept
+# current by the developer / CI runner); fall back to a versioned download. The
+# ancient pinned v1.18.0 that used to live here could not exec against modern
+# API servers.
 $(BINDIR)/kubectl:
 	mkdir -p $(BINDIR)
-	curl --fail -sL -o $(BINDIR)/.kubectl $(KUBECTL_URL)
-	echo "$(KUBECTL_HASH)  $(BINDIR)/.kubectl" | $(SHASUM)
-	chmod +x $(BINDIR)/.kubectl
-	mv $(BINDIR)/.kubectl $(BINDIR)/kubectl
+	@if command -v kubectl >/dev/null 2>&1; then \
+		echo "kubectl: linking system kubectl $$(command -v kubectl)"; \
+		ln -sf "$$(command -v kubectl)" $(BINDIR)/kubectl; \
+	else \
+		echo "kubectl: downloading $(KUBECTL_VERSION) for $(KUBECTL_OS)/$(KUBECTL_ARCH)"; \
+		curl --fail -sL -o $(BINDIR)/kubectl "https://dl.k8s.io/release/$(KUBECTL_VERSION)/bin/$(KUBECTL_OS)/$(KUBECTL_ARCH)/kubectl"; \
+		chmod +x $(BINDIR)/kubectl; \
+	fi
 
 .PHONY: $(BINDIR)/golangci-lint
 $(BINDIR)/golangci-lint: $(BINDIR)/golangci-lint-$(GOLANGCILINT_VERSION)
@@ -91,9 +100,23 @@ test: generate verify ## run all go tests
 	go test -v -bench $$(go list ./pkg/... ./cmd/... | grep -v pkg/e2e) | tee $(ARTIFACTS)/go-test.stdout
 	cat $(ARTIFACTS)/go-test.stdout | go run github.com/jstemmer/go-junit-report > $(ARTIFACTS)/junit-go-test.xml
 
-e2e: depend ## run end to end tests
+# Name of the kind cluster the e2e suite creates (must match the const in
+# test/kind/kind.go). Used by e2e-clean for the failure/interrupt safety net.
+E2E_CLUSTER_NAME := kube-oidc-proxy-e2e
+E2E_TIMEOUT      ?= 30m
+
+# Prerequisites (local runs): go, docker (daemon running), kind, and kubectl on
+# PATH. The suite builds and side-loads the proxy + test-tool images itself and
+# creates/destroys its own kind cluster, so no pre-existing cluster is needed.
+e2e: $(BINDIR)/kubectl ## run the e2e suite hermetically (creates + destroys its own kind cluster)
 	mkdir -p $(ARTIFACTS)
-	KUBE_OIDC_PROXY_ROOT_PATH="$$(pwd)" go test -timeout 30m -v --count=1 ./test/e2e/suite/.
+	@echo "e2e: removing any stale cluster from a previous run"
+	@$(MAKE) --no-print-directory e2e-clean
+	trap '$(MAKE) --no-print-directory e2e-clean' EXIT; \
+	KUBE_OIDC_PROXY_ROOT_PATH="$$(pwd)" go test -timeout $(E2E_TIMEOUT) -v --count=1 ./test/e2e/suite/. 2>&1 | tee $(ARTIFACTS)/e2e.log
+
+e2e-clean: ## delete the e2e kind cluster if present (safe to run anytime)
+	@kind delete cluster --name $(E2E_CLUSTER_NAME) >/dev/null 2>&1 || true
 
 build: generate ## build kube-oidc-proxy
 	mkdir -p ./bin/amd64

--- a/README.md
+++ b/README.md
@@ -140,3 +140,29 @@ When using `Impersonate-Extra-` headers, the proxy's `ServiceAccount` must be ex
 To help with development, there is a suite of tools you can use to deploy a
 functioning proxy from source locally. You can read more
 [here](./docs/tasks/development-testing.md).
+
+### End-to-end tests
+
+`make e2e` runs the Go end-to-end suite (`test/e2e/suite`) against a real
+Kubernetes cluster. It is hermetic: it builds the proxy and the test-tool
+images from source, creates its own [kind](https://kind.sigs.k8s.io) cluster,
+loads the images, runs the suite, and tears the cluster down again on exit
+(including on failure or interrupt). No pre-existing cluster is required.
+
+Prerequisites (all on `PATH`): `go`, `docker` (daemon running), `kind`,
+`kubectl`. Images are built for the host architecture so the suite runs on both
+`amd64` and `arm64` (e.g. Apple Silicon).
+
+```sh
+make e2e          # build images, spin up kind, run the suite, tear down
+make e2e-clean    # delete a leftover e2e kind cluster (safe if none exists)
+```
+
+Useful overrides: `E2E_TIMEOUT` (Go test timeout, default `30m`) and
+`KUBE_OIDC_PROXY_K8S_VERSION` (kind node image version).
+
+The suite runs in CI on every pull request and on pushes to `main`
+(`.github/workflows/e2e.yaml`). A companion workflow
+(`.github/workflows/e2e-oidc-gha.yaml`) additionally proves the multi-issuer
+union authenticator against the **real** GitHub Actions OIDC issuer alongside a
+local Dex issuer.

--- a/hack/ci/gha-multi-issuer-e2e.sh
+++ b/hack/ci/gha-multi-issuer-e2e.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+#
+# Multi-issuer e2e against the REAL GitHub Actions OIDC issuer.
+#
+# Stands up a kind cluster and installs kube-oidc-proxy (Helm chart) in
+# multi-issuer mode with TWO issuers configured in a single
+# AuthenticationConfiguration:
+#
+#   (a) https://token.actions.githubusercontent.com  -- the genuine external
+#       GitHub Actions OIDC IdP (public JWKS, no certificateAuthority). Its
+#       `sub` claim is mapped to the impersonated username with a "gha:" prefix.
+#   (b) a local Dex issuer (self-signed, in-cluster) -- proves the union
+#       authenticator still serves a second, private issuer. Its `email` claim
+#       is mapped with an "oidc-local:" prefix.
+#
+# `readinessRequireAllIssuers: true` makes the proxy report Ready only once it
+# has initialised BOTH issuers -- including fetching the real GitHub Actions
+# JWKS over the public internet. So a Ready proxy already proves multi-issuer
+# initialisation against the real IdP.
+#
+# Assertions:
+#   * Local Dex token authenticates + impersonates "oidc-local:alice@example.com".
+#   * (CI only, when a GitHub Actions ID token is provided via GHA_TOKEN_FILE)
+#     that token authenticates + impersonates "gha:<sub>" through the SAME proxy.
+#
+# Identity is proven the same way the demo does it: a request the user is NOT
+# allowed to make (get secrets) is denied with a Forbidden error that echoes the
+# impersonated username.
+#
+# Environment:
+#   GHA_TOKEN_FILE  Optional path to a file containing a GitHub Actions OIDC ID
+#                   token (minted in-workflow via core.getIDToken). When set, the
+#                   GHA-token assertions run; when unset, only issuer (a) config +
+#                   the local Dex assertions run (used for local verification).
+#   GHA_AUDIENCE    Audience the token was minted with. Default:
+#                   kube-oidc-proxy-kind-test. MUST match GHA_TOKEN_FILE's aud.
+#   KEEP_CLUSTER    If "true", leave the kind cluster running on exit.
+set -euo pipefail
+
+CLUSTER="kube-oidc-proxy-gha-e2e"
+CTX="kind-${CLUSTER}"
+DEX_IMAGE="ghcr.io/dexidp/dex:v2.44.0"
+PROXY_IMAGE="kube-oidc-proxy:gha-e2e"
+PROXY_NS="kube-oidc-proxy"
+PROXY_RELEASE="kube-oidc-proxy"
+DEX_NAME="dex-local"
+DEX_USER="alice@example.com"
+CLIENT_SECRET="demo-client-secret"
+PASSWORD="password"
+BCRYPT_HASH='$2a$10$Z5ozIZvkgAWpm1LX.c0V1.BRXkYYS4vNDcZSJQm5mcDdS8IRXJ0x2'
+GHA_ISSUER="https://token.actions.githubusercontent.com"
+GHA_AUDIENCE="${GHA_AUDIENCE:-kube-oidc-proxy-kind-test}"
+GHA_TOKEN_FILE="${GHA_TOKEN_FILE:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DEMO_MANIFESTS="${REPO_ROOT}/demo/manifests"
+CHART="${REPO_ROOT}/deploy/charts/kube-oidc-proxy"
+GEN="$(mktemp -d)"
+CERTS="${GEN}/certs"
+CA_CRT="${CERTS}/ca.crt"
+
+BLUE=$'\033[1;34m'; GREEN=$'\033[1;32m'; RED=$'\033[1;31m'; NC=$'\033[0m'
+log()  { echo "${BLUE}==>${NC} $*"; }
+ok()   { echo "${GREEN}  ok:${NC} $*"; }
+fail() { echo "${RED}ERROR:${NC} $*" >&2; exit 1; }
+
+PF_PIDS=()
+cleanup() {
+  for pid in "${PF_PIDS[@]:-}"; do [ -n "${pid}" ] && kill "${pid}" 2>/dev/null || true; done
+  if [ "${KEEP_CLUSTER:-false}" != "true" ]; then
+    kind delete cluster --name "${CLUSTER}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${GEN}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+require_tool() { command -v "$1" >/dev/null 2>&1 || fail "required tool not found: $1"; }
+
+# base64url-decode a JWT segment (adds padding, maps url alphabet).
+b64url_decode() {
+  local d="$1"; local pad=$(( (4 - ${#d} % 4) % 4 ))
+  local i; for ((i=0;i<pad;i++)); do d="${d}="; done
+  echo "${d}" | tr '_-' '/+' | base64 -d 2>/dev/null
+}
+jwt_claim() { # <token> <claim>
+  local payload; payload="$(printf '%s' "$1" | cut -d. -f2)"
+  b64url_decode "${payload}" | jq -r ".$2 // empty"
+}
+
+port_forward() { # <local_port> <remote_port> <-n ns> <svc/name>
+  local lport="$1" rport="$2"; shift 2
+  kubectl --context "${CTX}" port-forward "$@" "${lport}:${rport}" >/dev/null 2>&1 &
+  PF_PIDS+=("$!")
+  local i
+  for i in $(seq 1 30); do
+    if (exec 3<>"/dev/tcp/127.0.0.1/${lport}") 2>/dev/null; then exec 3>&- 3<&- || true; return 0; fi
+    sleep 1
+  done
+  fail "port-forward to local port ${lport} did not become ready"
+}
+stop_pf() { for pid in "${PF_PIDS[@]:-}"; do [ -n "${pid}" ] && kill "${pid}" 2>/dev/null || true; done; PF_PIDS=(); }
+
+mint_dex_token() {
+  local host="${DEX_NAME}.dex.svc.cluster.local" token
+  port_forward 5556 5556 -n dex "svc/${DEX_NAME}"
+  token="$(curl -s \
+    --resolve "${host}:5556:127.0.0.1" --cacert "${CA_CRT}" \
+    "https://${host}:5556/dex/token" \
+    -d grant_type=password -d scope="openid email groups" \
+    -d client_id=demo -d client_secret="${CLIENT_SECRET}" \
+    -d username="${DEX_USER}" -d password="${PASSWORD}" | jq -r '.id_token // empty')"
+  stop_pf
+  [ -n "${token}" ] || fail "failed to mint Dex token for ${DEX_USER}"
+  printf '%s' "${token}"
+}
+
+write_kubeconfig() { # <token> <outfile>
+  cat >"$2" <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+  - name: proxy
+    cluster: { server: https://127.0.0.1:8443, insecure-skip-tls-verify: true }
+contexts:
+  - name: proxy
+    context: { cluster: proxy, user: oidc }
+current-context: proxy
+users:
+  - name: oidc
+    user: { token: $1 }
+EOF
+}
+
+# assert an identity: allowed 'get pods', denied 'get secrets' naming the user.
+check_identity() { # <kubeconfig> <expected_user> <label>
+  local kcfg="$1" expected="$2" label="$3" out
+  echo; echo "${BLUE}--- ${label}: expecting user \"${expected}\" ---${NC}"
+  out="$(kubectl --kubeconfig "${kcfg}" get pods -A 2>&1)" \
+    || fail "${label}: 'get pods' failed (view should allow it):\n${out}"
+  ok "'get pods' allowed via the 'view' binding"
+  out="$(kubectl --kubeconfig "${kcfg}" get secrets -A 2>&1 || true)"
+  echo "${out}" | grep -q "\"${expected}\"" \
+    || fail "${label}: forbidden error did not name expected user ${expected}:\n${out}"
+  ok "authenticated + impersonated through the proxy as ${expected}"
+}
+
+# --------------------------------------------------------------------------
+log "Preflight"
+for t in kind docker kubectl helm openssl jq curl go; do require_tool "$t"; done
+docker info >/dev/null 2>&1 || fail "docker daemon is not running"
+if [ -n "${GHA_TOKEN_FILE}" ]; then
+  [ -s "${GHA_TOKEN_FILE}" ] || fail "GHA_TOKEN_FILE=${GHA_TOKEN_FILE} is empty/missing"
+  ok "GitHub Actions token provided -> GHA-token assertions enabled"
+else
+  ok "no GitHub Actions token -> configuring GHA issuer, testing local issuer only"
+fi
+
+log "Building proxy image ${PROXY_IMAGE}"
+( cd "${REPO_ROOT}" \
+  && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags '-w' -o ./bin/amd64/kube-oidc-proxy ./cmd/. \
+  && CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags '-w' -o ./bin/arm64/kube-oidc-proxy ./cmd/. )
+docker build -q -t "${PROXY_IMAGE}" "${REPO_ROOT}" >/dev/null
+ok "image built"
+
+if kind get clusters 2>/dev/null | grep -qx "${CLUSTER}"; then
+  kind delete cluster --name "${CLUSTER}" >/dev/null
+fi
+log "Creating kind cluster ${CLUSTER}"
+kind create cluster --name "${CLUSTER}" >/dev/null
+kind load docker-image "${PROXY_IMAGE}" --name "${CLUSTER}" >/dev/null
+docker pull -q "${DEX_IMAGE}" >/dev/null
+kind load docker-image "${DEX_IMAGE}" --name "${CLUSTER}" >/dev/null
+ok "cluster ready, images loaded"
+
+log "Generating TLS for the local Dex issuer"
+mkdir -p "${CERTS}"
+openssl req -x509 -newkey rsa:2048 -nodes -sha256 -days 3650 \
+  -keyout "${CERTS}/ca.key" -out "${CA_CRT}" \
+  -subj "/CN=kube-oidc-proxy-gha-e2e-ca" -addext "basicConstraints=critical,CA:TRUE" >/dev/null 2>&1
+openssl req -newkey rsa:2048 -nodes -sha256 \
+  -keyout "${CERTS}/${DEX_NAME}.key" -out "${CERTS}/${DEX_NAME}.csr" \
+  -subj "/CN=${DEX_NAME}.dex.svc.cluster.local" >/dev/null 2>&1
+openssl x509 -req -in "${CERTS}/${DEX_NAME}.csr" \
+  -CA "${CA_CRT}" -CAkey "${CERTS}/ca.key" -CAcreateserial \
+  -out "${CERTS}/${DEX_NAME}.crt" -days 3650 -sha256 \
+  -extfile <(printf 'subjectAltName=DNS:%s.dex.svc.cluster.local,DNS:%s.dex,DNS:%s\nbasicConstraints=CA:FALSE\nextendedKeyUsage=serverAuth\n' "${DEX_NAME}" "${DEX_NAME}" "${DEX_NAME}") \
+  >/dev/null 2>&1
+ok "CA + ${DEX_NAME} serving cert generated"
+
+log "Deploying local Dex issuer (user ${DEX_USER})"
+kubectl --context "${CTX}" create namespace dex >/dev/null
+kubectl --context "${CTX}" create secret tls "${DEX_NAME}-tls" -n dex \
+  --cert "${CERTS}/${DEX_NAME}.crt" --key "${CERTS}/${DEX_NAME}.key" >/dev/null
+sed \
+  -e "s|__NAME__|${DEX_NAME}|g" \
+  -e "s|__ISSUER__|https://${DEX_NAME}.dex.svc.cluster.local:5556/dex|g" \
+  -e "s|__CLIENT_SECRET__|${CLIENT_SECRET}|g" \
+  -e "s|__USER_EMAIL__|${DEX_USER}|g" \
+  -e "s|__USER_NAME__|alice|g" \
+  -e "s|__USER_ID__|alice-id|g" \
+  -e "s|__HASH__|${BCRYPT_HASH}|g" \
+  -e "s|__IMAGE__|${DEX_IMAGE}|g" \
+  "${DEMO_MANIFESTS}/dex.yaml.tpl" | kubectl --context "${CTX}" apply -f - >/dev/null
+kubectl --context "${CTX}" -n dex rollout status "deploy/${DEX_NAME}" --timeout=120s
+ok "local Dex is ready"
+
+log "Rendering multi-issuer AuthenticationConfiguration (GHA + local Dex)"
+CA_INDENTED="$(sed 's/^/            /' "${CA_CRT}")"
+cat >"${GEN}/authentication-config.yaml" <<EOF
+apiVersion: apiserver.config.k8s.io/v1
+kind: AuthenticationConfiguration
+jwt:
+  - issuer:
+      url: ${GHA_ISSUER}
+      audiences:
+        - ${GHA_AUDIENCE}
+    claimMappings:
+      username:
+        claim: sub
+        prefix: "gha:"
+  - issuer:
+      url: https://${DEX_NAME}.dex.svc.cluster.local:5556/dex
+      audiences:
+        - demo
+      certificateAuthority: |
+${CA_INDENTED}
+    claimMappings:
+      username:
+        claim: email
+        prefix: "oidc-local:"
+      groups:
+        claim: groups
+        prefix: "oidc-local:"
+EOF
+ok "authentication-config.yaml rendered (GHA issuer has no certificateAuthority)"
+
+log "Installing kube-oidc-proxy via Helm (multi-issuer, readinessRequireAllIssuers)"
+helm --kube-context "${CTX}" install "${PROXY_RELEASE}" "${CHART}" \
+  --namespace "${PROXY_NS}" --create-namespace \
+  --set image.repository=kube-oidc-proxy \
+  --set image.tag=gha-e2e \
+  --set image.pullPolicy=Never \
+  --set readinessRequireAllIssuers=true \
+  --set-file authenticationConfig.content="${GEN}/authentication-config.yaml" \
+  --wait --timeout 180s >/dev/null
+ok "proxy Ready -> BOTH issuers initialised (real GitHub Actions JWKS fetched)"
+
+log "Applying RBAC (view) for the impersonated identities"
+kubectl --context "${CTX}" create clusterrolebinding gha-e2e-local-view \
+  --clusterrole=view --user="oidc-local:${DEX_USER}" >/dev/null
+GHA_SUB=""
+if [ -n "${GHA_TOKEN_FILE}" ]; then
+  GHA_TOKEN="$(cat "${GHA_TOKEN_FILE}")"
+  GHA_SUB="$(jwt_claim "${GHA_TOKEN}" sub)"
+  [ -n "${GHA_SUB}" ] || fail "could not decode 'sub' from the GitHub Actions token"
+  log "GitHub Actions token sub=${GHA_SUB}"
+  kubectl --context "${CTX}" create clusterrolebinding gha-e2e-github-view \
+    --clusterrole=view --user="gha:${GHA_SUB}" >/dev/null
+fi
+ok "RBAC applied"
+
+log "Port-forwarding the proxy"
+port_forward 8443 443 -n "${PROXY_NS}" "svc/${PROXY_RELEASE}"
+
+# ---- Assertion 1: local Dex issuer still works through the multi-issuer proxy.
+log "Minting a local Dex token and authenticating through the proxy"
+DEX_TOKEN="$(mint_dex_token)"
+port_forward 8443 443 -n "${PROXY_NS}" "svc/${PROXY_RELEASE}"
+write_kubeconfig "${DEX_TOKEN}" "${GEN}/kubeconfig-local.yaml"
+check_identity "${GEN}/kubeconfig-local.yaml" "oidc-local:${DEX_USER}" "Local Dex issuer"
+
+# ---- Assertion 2 (CI only): the real GitHub Actions token authenticates.
+if [ -n "${GHA_TOKEN_FILE}" ]; then
+  log "Authenticating the real GitHub Actions token through the proxy"
+  write_kubeconfig "${GHA_TOKEN}" "${GEN}/kubeconfig-gha.yaml"
+  check_identity "${GEN}/kubeconfig-gha.yaml" "gha:${GHA_SUB}" "GitHub Actions issuer"
+fi
+
+stop_pf
+echo
+echo "${GREEN}SUCCESS:${NC} multi-issuer proxy verified."
+if [ -n "${GHA_TOKEN_FILE}" ]; then
+  echo "  - real GitHub Actions OIDC token impersonated as gha:${GHA_SUB}"
+fi
+echo "  - local Dex token impersonated as oidc-local:${DEX_USER}"

--- a/test/e2e/framework/helper/deploy.go
+++ b/test/e2e/framework/helper/deploy.go
@@ -422,18 +422,11 @@ func (h *Helper) deployApp(ns, name string, serviceType corev1.ServiceType, cont
 
 	var netIPs []net.IP
 	if serviceType == corev1.ServiceTypeNodePort {
-		nodes, err := h.KubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-		if err != nil {
-			return nil, nil, err
-		}
-
-		for _, n := range nodes.Items {
-			for _, addr := range n.Status.Addresses {
-				if addr.Type == corev1.NodeInternalIP {
-					netIPs = append(netIPs, net.ParseIP(addr.Address))
-				}
-			}
-		}
+		// The proxy is reached from the host at https://127.0.0.1:<ProxyNodePort>
+		// (the kind node maps that NodePort to the host loopback). Include
+		// 127.0.0.1 in the serving cert SANs so the client's TLS verification of
+		// that host succeeds.
+		netIPs = append(netIPs, net.ParseIP("127.0.0.1"))
 	}
 
 	keyBundle, err := util.NewTLSSelfSignedCertKey(host, netIPs, nil)
@@ -452,6 +445,12 @@ func (h *Helper) deployApp(ns, name string, serviceType corev1.ServiceType, cont
 					Port:       6443,
 					Protocol:   "TCP",
 					TargetPort: intstr.FromInt(6443),
+					// Pin the NodePort so it lines up with the kind node's
+					// extraPortMappings entry, making the proxy reachable at
+					// https://127.0.0.1:<ProxyNodePort> from the host. Only one
+					// proxy exists at a time (AfterEach deletes it) so there is no
+					// NodePort collision.
+					NodePort: nodePortFor(serviceType),
 				},
 			},
 			Type: serviceType,
@@ -601,4 +600,13 @@ func (h *Helper) deleteApp(ns, name string, extraSecrets ...string) error {
 func (h *Helper) appURL(ns, serviceName, port string) (string, string) {
 	host := fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, ns)
 	return host, fmt.Sprintf("https://%s:%s", host, port)
+}
+
+// nodePortFor returns the fixed NodePort for NodePort services (only the proxy
+// is deployed as a NodePort), or 0 to let Kubernetes allocate one otherwise.
+func nodePortFor(serviceType corev1.ServiceType) int32 {
+	if serviceType == corev1.ServiceTypeNodePort {
+		return kind.ProxyNodePort
+	}
+	return 0
 }

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -173,7 +173,7 @@ func testAuditLogs(f *framework.Framework, podLabelSelector string) {
 
 	var auditLogsBuffer bytes.Buffer
 	err = f.Helper().Kubectl(f.Namespace.Name).RunWithStdout(&auditLogsBuffer,
-		"exec", pods.Items[0].Name, "cat", "/audit-log")
+		"exec", pods.Items[0].Name, "--", "cat", "/audit-log")
 	Expect(err).NotTo(HaveOccurred())
 
 	logs := auditLogsBuffer.Bytes()

--- a/test/kind/image.go
+++ b/test/kind/image.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -43,10 +44,15 @@ func (k *Kind) LoadAllImages() error {
 }
 
 func (k *Kind) LoadKubeOIDCProxy() error {
-	binPath := filepath.Join(k.rootPath, "./bin/kube-oidc-proxy")
+	// The proxy Dockerfile copies bin/${TARGETARCH}/kube-oidc-proxy. Under
+	// BuildKit TARGETARCH resolves to the build host architecture, so build the
+	// binary into the matching arch subdirectory and pass TARGETARCH explicitly
+	// for builders that do not populate it automatically.
+	binPath := filepath.Join(k.rootPath, "bin", runtime.GOARCH, "kube-oidc-proxy")
 	mainPath := filepath.Join(k.rootPath, "./cmd/.")
 
-	return k.loadImage(binPath, mainPath, ProxyImageName, k.rootPath)
+	return k.loadImage(binPath, mainPath, ProxyImageName, k.rootPath,
+		"--build-arg", "TARGETARCH="+runtime.GOARCH)
 }
 
 func (k *Kind) LoadIssuer() error {
@@ -73,7 +79,7 @@ func (k *Kind) LoadAuditWebhook() error {
 	return k.loadImage(binPath, mainPath, AuditWebhookImageName, dockerfilePath)
 }
 
-func (k *Kind) loadImage(binPath, mainPath, image, dockerfilePath string) error {
+func (k *Kind) loadImage(binPath, mainPath, image, dockerfilePath string, extraBuildArgs ...string) error {
 	log.Infof("kind: building %q", mainPath)
 
 	if err := os.MkdirAll(filepath.Dir(binPath), 0755); err != nil {
@@ -85,7 +91,9 @@ func (k *Kind) loadImage(binPath, mainPath, image, dockerfilePath string) error 
 		return err
 	}
 
-	err = k.runCmd("docker", "build", "-t", image, dockerfilePath)
+	buildArgs := append([]string{"build"}, extraBuildArgs...)
+	buildArgs = append(buildArgs, "-t", image, dockerfilePath)
+	err = k.runCmd("docker", buildArgs...)
 	if err != nil {
 		return err
 	}
@@ -144,7 +152,10 @@ func (k *Kind) runCmdWithOut(w io.Writer, command string, args ...string) error 
 	cmd.Env = append(cmd.Env,
 		"GO111MODULE=on", "CGO_ENABLED=0", "HOME="+os.Getenv("HOME"),
 		"PATH="+os.Getenv("PATH"),
-		"GOARCH=amd64", "GOOS=linux")
+		// Build test images for the host architecture so the resulting binaries
+		// run on the kind nodes (which match the host arch). Forcing amd64 here
+		// breaks pod startup with "exec format error" on arm64 hosts.
+		"GOARCH="+runtime.GOARCH, "GOOS=linux")
 
 	if err := cmd.Start(); err != nil {
 		return err

--- a/test/kind/kind.go
+++ b/test/kind/kind.go
@@ -23,6 +23,14 @@ import (
 
 const (
 	clusterName = "kube-oidc-proxy-e2e"
+
+	// ProxyNodePort is the fixed NodePort assigned to the proxy Service. It is
+	// mapped to the same port on 127.0.0.1 of the host via the kind node's
+	// extraPortMappings (see New), so the suite reaches the proxy at
+	// https://127.0.0.1:<ProxyNodePort>. This keeps the host->proxy network path
+	// identical on Linux (CI) and macOS, where the kind node's InternalIP sits on
+	// a docker bridge network that is not routable from the host.
+	ProxyNodePort = 31443
 )
 
 type Kind struct {
@@ -68,6 +76,20 @@ func New(rootPath, nodeImage string, masterNodes, workerNodes int) *Kind {
 	}
 
 	conf.Networking.ServiceSubnet = "10.0.0.0/16"
+
+	// Map the proxy's fixed NodePort to the same host port on 127.0.0.1 so the
+	// test process (running on the host) can reach the proxy Service without
+	// depending on the kind node IP being routable from the host. Mapped on a
+	// single node only to avoid a host-port collision across node containers.
+	if len(conf.Nodes) > 0 {
+		conf.Nodes[0].ExtraPortMappings = append(conf.Nodes[0].ExtraPortMappings,
+			configv1alpha4.PortMapping{
+				ContainerPort: ProxyNodePort,
+				HostPort:      ProxyNodePort,
+				ListenAddress: "127.0.0.1",
+				Protocol:      configv1alpha4.PortMappingProtocolTCP,
+			})
+	}
 
 	return &Kind{
 		rootPath:  rootPath,


### PR DESCRIPTION
## Sub-project 7 — E2E-with-kind CI gate

Makes the kind-based e2e suite hermetic, gates it in CI, and adds a multi-issuer test against the **real GitHub Actions OIDC issuer**. Implements #34.

### Changes
- **fix(e2e) #35** — suite builds/runs on the host arch (was hard-coded amd64 → "exec format error" on arm64 kind nodes); reaches the proxy via a fixed NodePort mapped to 127.0.0.1 (identical on Linux CI and macOS); `audit` case uses modern `kubectl exec -- cmd`; no more ancient golangci/kubectl pulls.
- **build(e2e) #36** — hermetic `make e2e` + `make e2e-clean`: pre-clean → build+load images → create kind → run → teardown via trap (fires on failure/interrupt). Prereqs/targets documented.
- **ci(e2e) #37** — `.github/workflows/e2e.yaml` runs `make e2e` on `pull_request` + push to `main` (45m timeout, uploads `artifacts/` on failure). SHA-pinned actions.
- **ci(e2e) #40** — `.github/workflows/e2e-oidc-gha.yaml` + `hack/ci/gha-multi-issuer-e2e.sh`: mints a real GHA OIDC token in-job and deploys the chart in multi-issuer mode with TWO issuers (`token.actions.githubusercontent.com` + local Dex) in one AuthenticationConfiguration; `kubectl --token` through the proxy proves impersonation for both. Skips fork PRs (no OIDC token); `id-token: write` only.

### Verification
- `make e2e` locally (arm64 macOS): **27/29 pass**. The 2 failures are the `Upgrade` specs, whose fixture image `echoserver:1.10` is amd64-only (single-arch manifest) so it can't run on arm64 nodes; they pass on the CI runner (amd64). Not silently skipped — see #35 caveat.
- New workflows: valid YAML, actions SHA-pinned, CI script `bash -n` clean and never echoes the token.

### Note
#38 (mock multi-issuer coverage) is already handled by `test/e2e/suite/cases/authconfig` — no code change needed.

Closes #35
Closes #36
Closes #37
Closes #38
Closes #40
