### PR TITLE
ci(helm-release): authenticate cosign to GHCR before signing

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -62,4 +62,10 @@ jobs:
       - name: Sign chart (keyless)
         env:
           REF: ${{ steps.push.outputs.ref }}
-        run: cosign sign -y "$REF"
+          ACTOR: ${{ github.actor }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # cosign authenticates via the docker config, which `helm registry
+          # login` does not populate — log cosign in to GHCR explicitly.
+          echo "${GH_TOKEN}" | cosign login ghcr.io -u "${ACTOR}" --password-stdin
+          cosign sign -y "$REF"


### PR DESCRIPTION
The manual OCI chart release pushed the chart successfully but failed at `cosign sign` with `UNAUTHORIZED` — `helm registry login` doesn't populate the docker config cosign reads. Log cosign into GHCR with `GITHUB_TOKEN` before signing (mirrors how build.yaml signs the image). The chart (`ghcr.io/rafpe/charts/kube-oidc-proxy:0.4.0`) is already pushed; re-dispatch after merge to get it signed.