### PR TITLE
refactor(proxy): request-path correctness & structured logging (#51 #52 #55)

### DIFF
--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
 	"strings"
 
 	authuser "k8s.io/apiserver/pkg/authentication/user"
@@ -135,23 +136,16 @@ func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
 			}
 		}
 
+		// Defensively copy the authenticator-owned collections before enriching
+		// them. user.Info implementations are not required to return fresh
+		// slices/maps, so appending to GetGroups() or writing into GetExtra()
+		// could otherwise mutate cached or shared authenticator state.
+		groups := slices.Clone(user.GetGroups())
+		extra := cloneExtra(user.GetExtra())
+
 		// Ensure group contains allauthenticated builtin
-		allAuthFound := false
-		groups := user.GetGroups()
-		for _, elem := range groups {
-			if elem == authuser.AllAuthenticated {
-				allAuthFound = true
-				break
-			}
-		}
-		if !allAuthFound {
+		if !slices.Contains(groups, authuser.AllAuthenticated) {
 			groups = append(groups, authuser.AllAuthenticated)
-		}
-
-		extra := user.GetExtra()
-
-		if extra == nil {
-			extra = make(map[string][]string)
 		}
 
 		// If client IP user extra header option set then append the remote client
@@ -178,14 +172,8 @@ func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
 			// so they're recorded in the API server's audit log
 			extra["originaluser.jetstack.io-user"] = []string{userForContext.GetName()}
 
-			numGroups := len(userForContext.GetGroups())
-			if numGroups > 0 {
-				groupNames := make([]string, numGroups)
-				for i, groupName := range userForContext.GetGroups() {
-					groupNames[i] = groupName
-				}
-
-				extra["originaluser.jetstack.io-groups"] = groupNames
+			if origGroups := userForContext.GetGroups(); len(origGroups) > 0 {
+				extra["originaluser.jetstack.io-groups"] = slices.Clone(origGroups)
 			}
 
 			if userForContext.GetUID() != "" {
@@ -262,25 +250,39 @@ func (p *Proxy) newErrorHandler() func(rw http.ResponseWriter, r *http.Request, 
 			http.Error(rw, subjectaccessreview.ErrorNoImpersonationUserFound.Error(), http.StatusInternalServerError)
 			return
 
+			// Requester is not authorized to impersonate the requested identity.
+			// Classified by typed error (errors.Is), not by message text.
+		case errors.Is(err, subjectaccessreview.ErrImpersonationNotAllowed):
+			klog.V(2).Infof("impersonation not authorized (%s): %s", r.RemoteAddr, err)
+			http.Error(rw, err.Error(), http.StatusForbidden)
+			return
+
 			// Client canceled the request (SAR or reverse-proxy). Nothing to
 			// write back; the connection is already going away.
 		case errors.Is(err, stdcontext.Canceled):
 			klog.V(4).Infof("request canceled by client: %s", r.RemoteAddr)
 			return
 
-			// Server or unknown error
+			// Server or unknown error. Details stay server-side; the client
+			// receives an empty 500 body.
 		default:
-
-			if strings.Contains(err.Error(), "not allowed to impersonate") {
-				klog.V(2).Infof("%s (%s)", err.Error(), r.RemoteAddr)
-				http.Error(rw, err.Error(), http.StatusForbidden)
-			} else {
-				klog.Errorf("unknown error (%s): %s", r.RemoteAddr, err)
-				http.Error(rw, "", http.StatusInternalServerError)
-			}
-
+			klog.Errorf("unknown error (%s): %s", r.RemoteAddr, err)
+			http.Error(rw, "", http.StatusInternalServerError)
 		}
 	}
+}
+
+// cloneExtra returns a deep copy of an authenticator-owned extra map: both the
+// map and every value slice are freshly allocated, so subsequent enrichment can
+// append to a value slice without mutating collections owned by the
+// authenticator or the configuration caller. A nil input yields a non-nil,
+// ready-to-write map.
+func cloneExtra(in map[string][]string) map[string][]string {
+	out := make(map[string][]string, len(in))
+	for k, v := range in {
+		out[k] = slices.Clone(v)
+	}
+	return out
 }
 
 func (p *Proxy) hasImpersonation(header http.Header) bool {

--- a/pkg/proxy/handlers_test.go
+++ b/pkg/proxy/handlers_test.go
@@ -1,0 +1,61 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	authuser "k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// TestWithImpersonateRequestDoesNotMutateAuthenticatorUser is the regression
+// test for issue #52: request enrichment must never mutate the groups slice or
+// extra map owned by the authenticator. The user is built so that the unfixed
+// code would observably corrupt shared state — the groups slice has spare
+// capacity (so an in-place append writes into the shared backing array) and the
+// extra map both gains new keys and has an existing value slice extended.
+func TestWithImpersonateRequestDoesNotMutateAuthenticatorUser(t *testing.T) {
+	groups := make([]string, 1, 4)
+	groups[0] = "group1"
+
+	usr := &authuser.DefaultInfo{
+		Name:   "alice",
+		Groups: groups,
+		Extra: map[string][]string{
+			"foo": {"x"},
+		},
+	}
+
+	// Snapshots of exactly what the authenticator must still observe afterwards.
+	wantGroupsBacking := append([]string(nil), groups[:cap(groups)]...) // ["group1" "" "" ""]
+	wantExtra := map[string][]string{"foo": {"x"}}
+
+	p := &Proxy{
+		config: &Config{
+			ExtraUserHeadersClientIPEnabled: true,
+			ExtraUserHeaders:                map[string][]string{"foo": {"bar"}},
+		},
+	}
+
+	handler := p.withImpersonateRequest(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(genericapirequest.WithUser(req.Context(), usr))
+
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	// The full backing array of the groups slice must be untouched (catches an
+	// in-place append that the len-1 header would otherwise hide).
+	if gotBacking := usr.Groups[:cap(usr.Groups)]; !reflect.DeepEqual(gotBacking, wantGroupsBacking) {
+		t.Errorf("authenticator groups backing array mutated: got %#v, want %#v", gotBacking, wantGroupsBacking)
+	}
+
+	// The extra map must not have gained keys (Remote-Client-IP) nor had its
+	// existing value slice extended (foo -> [x bar]).
+	if !reflect.DeepEqual(usr.Extra, wantExtra) {
+		t.Errorf("authenticator extra map mutated: got %#v, want %#v", usr.Extra, wantExtra)
+	}
+}

--- a/pkg/proxy/logging/accesslog.go
+++ b/pkg/proxy/logging/accesslog.go
@@ -1,94 +1,249 @@
 // Copyright Jetstack Ltd. See LICENSE for details.
+
+// Package logging emits structured, sanitized access logs for proxied and
+// failed requests.
+//
+// # Client-IP and trusted-proxy semantics (see issue #56)
+//
+// The immediate peer (req.RemoteAddr) is always authoritative for the client
+// IP. X-Forwarded-For is honoured ONLY to the extent that the hops closest to
+// the proxy are themselves within a configured trusted-proxy network: the chain
+// is walked right-to-left, trusted hops are skipped, and the first untrusted
+// address is taken as the client. When no trusted proxies are configured (the
+// default), forwarded headers are never trusted and the direct peer is used, so
+// an untrusted client cannot spoof its resolved IP. Configure trusted networks
+// with SetTrustedProxies. The raw forwarded chain is still emitted for
+// observability under the explicitly-untrusted "forwarded_for_untrusted" field
+// and must not be treated as identity.
 package logging
 
 import (
-	"fmt"
+	"context"
+	"log/slog"
+	"net"
 	"net/http"
+	"os"
 	"strings"
-	"time"
+	"unicode"
 
 	"k8s.io/apiserver/pkg/authentication/user"
 )
 
 const (
 	UserHeaderClientIPKey = "Remote-Client-IP"
-	timestampLayout       = "2006-01-02T15:04:05-0700"
 )
 
-// logs the request
+// loggableExtraKeys is the allowlist of impersonation-extra keys that the proxy
+// sets itself and are safe to log. Everything else is authenticator-supplied
+// claim data and is counted, not logged, so arbitrary claims and credentials
+// never reach the log stream.
+var loggableExtraKeys = map[string]struct{}{
+	UserHeaderClientIPKey:             {},
+	"originaluser.jetstack.io-user":   {},
+	"originaluser.jetstack.io-groups": {},
+	"originaluser.jetstack.io-uid":    {},
+	"originaluser.jetstack.io-extra":  {},
+}
+
+// logger is the structured logger used for access logs. It defaults to a JSON
+// handler writing to stdout, preserving the previous stdout destination while
+// giving deterministic, injection-safe encoding. Tests redirect it with
+// SetLogger.
+var logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+// trustedProxies holds the networks whose forwarded headers are honoured when
+// resolving the client IP. Empty (the default) means no proxy is trusted.
+var trustedProxies []*net.IPNet
+
+// SetLogger overrides the structured logger used for access logs. A nil logger
+// is ignored. Intended for wiring and tests.
+func SetLogger(l *slog.Logger) {
+	if l != nil {
+		logger = l
+	}
+}
+
+// SetTrustedProxies configures the trusted-proxy networks used when resolving
+// the client IP from forwarded headers. Passing nil (the default) disables
+// forwarded-header trust entirely.
+func SetTrustedProxies(nets []*net.IPNet) {
+	trustedProxies = nets
+}
+
+// LogSuccessfulRequest logs a successfully authenticated and proxied request as
+// a single structured record.
 func LogSuccessfulRequest(req *http.Request, inboundUser user.Info, outboundUser user.Info) {
-	remoteAddr := req.RemoteAddr
-	indexOfColon := strings.Index(remoteAddr, ":")
-	if indexOfColon > 0 {
-		remoteAddr = remoteAddr[0:indexOfColon]
-	}
-
-	inboundExtras := ""
-
-	if inboundUser.GetExtra() != nil {
-		for key, value := range inboundUser.GetExtra() {
-			inboundExtras += key + "=" + strings.Join(value, "|") + " "
-		}
-	}
-
-	outboundUserLog := ""
-
+	attrs := requestAttrs("AuSuccess", req)
+	attrs = append(attrs, userAttrs("inbound", inboundUser)...)
 	if outboundUser != nil {
-		outboundExtras := ""
-
-		if outboundUser.GetExtra() != nil {
-			for key, value := range outboundUser.GetExtra() {
-				outboundExtras += key + "=" + strings.Join(value, "|") + " "
-			}
-		}
-
-		outboundUserLog = fmt.Sprintf(" outbound:[%s / %s / %s / %s]", outboundUser.GetName(), strings.Join(outboundUser.GetGroups(), "|"), outboundUser.GetUID(), outboundExtras)
+		attrs = append(attrs, userAttrs("outbound", outboundUser)...)
 	}
-
-	xFwdFor := findXForwardedFor(req.Header, remoteAddr)
-
-	fmt.Printf("[%s] AuSuccess src:[%s / % s] URI:%s inbound:[%s / %s / %s]%s\n", time.Now().Format(timestampLayout), remoteAddr, xFwdFor, req.RequestURI, inboundUser.GetName(), strings.Join(inboundUser.GetGroups(), "|"), inboundExtras, outboundUserLog)
+	logger.LogAttrs(context.Background(), slog.LevelInfo, "proxied request", attrs...)
 }
 
-// determines if the x-forwarded-for header is present, if so remove
-// the remoteaddr since it is repetitive
-func findXForwardedFor(headers http.Header, remoteAddr string) string {
-	xFwdFor := headers.Get("x-forwarded-for")
-	// clean off remoteaddr from x-forwarded-for
-	if xFwdFor != "" {
-
-		newXFwdFor := ""
-		oneFound := false
-		xFwdForIps := strings.Split(xFwdFor, ",")
-
-		for _, ip := range xFwdForIps {
-			ip = strings.TrimSpace(ip)
-
-			if ip != remoteAddr {
-				newXFwdFor = newXFwdFor + ip + ", "
-				oneFound = true
-			}
-
-		}
-
-		if oneFound {
-			newXFwdFor = newXFwdFor[0 : len(newXFwdFor)-2]
-		}
-
-		xFwdFor = newXFwdFor
-
-	}
-
-	return xFwdFor
-}
-
-// logs the failed request
+// LogFailedRequest logs a request that failed authentication or authorization.
 func LogFailedRequest(req *http.Request) {
-	remoteAddr := req.RemoteAddr
-	indexOfColon := strings.Index(remoteAddr, ":")
-	if indexOfColon > 0 {
-		remoteAddr = remoteAddr[0:indexOfColon]
+	logger.LogAttrs(context.Background(), slog.LevelInfo, "rejected request",
+		requestAttrs("AuFail", req)...)
+}
+
+// requestAttrs builds the request-scoped structured fields shared by successful
+// and failed logs. src_ip is the authoritative resolved client IP;
+// forwarded_for_untrusted is the raw, sanitized forwarded chain and is not
+// identity.
+func requestAttrs(event string, req *http.Request) []slog.Attr {
+	attrs := []slog.Attr{
+		slog.String("event", event),
+		slog.String("src_ip", resolveClientIP(req.RemoteAddr, forwardedFor(req.Header), trustedProxies)),
+		slog.String("path", sanitizePath(req)),
+	}
+	if fwd := sanitize(forwardedFor(req.Header)); fwd != "" {
+		attrs = append(attrs, slog.String("forwarded_for_untrusted", fwd))
+	}
+	return attrs
+}
+
+// userAttrs renders a user.Info as sanitized, structured fields under the given
+// prefix. Only allowlisted extras are logged; the number of omitted claim keys
+// is reported so operators can tell data was dropped.
+func userAttrs(prefix string, u user.Info) []slog.Attr {
+	attrs := []slog.Attr{
+		slog.String(prefix+"_user", sanitize(u.GetName())),
+		slog.Any(prefix+"_groups", sanitizeSlice(u.GetGroups())),
+	}
+	if uid := u.GetUID(); uid != "" {
+		attrs = append(attrs, slog.String(prefix+"_uid", sanitize(uid)))
+	}
+	safe, omitted := loggableExtras(u.GetExtra())
+	if len(safe) > 0 {
+		attrs = append(attrs, slog.Any(prefix+"_extra", safe))
+	}
+	if omitted > 0 {
+		attrs = append(attrs, slog.Int(prefix+"_extra_omitted", omitted))
+	}
+	return attrs
+}
+
+// loggableExtras splits an extra map into the allowlisted, sanitized entries
+// safe to log and a count of the omitted (non-allowlisted) keys.
+func loggableExtras(extra map[string][]string) (map[string][]string, int) {
+	if len(extra) == 0 {
+		return nil, 0
+	}
+	safe := make(map[string][]string)
+	omitted := 0
+	for k, v := range extra {
+		if _, ok := loggableExtraKeys[k]; ok {
+			safe[sanitize(k)] = sanitizeSlice(v)
+			continue
+		}
+		omitted++
+	}
+	return safe, omitted
+}
+
+// sanitizePath returns the request path with query string and control
+// characters stripped, guarding against a nil URL (requests are constructed
+// without one in some call sites).
+func sanitizePath(req *http.Request) string {
+	if req.URL == nil {
+		return ""
+	}
+	return sanitize(req.URL.Path)
+}
+
+// sanitize removes control characters from a user-controlled string so that
+// values cannot inject newlines or terminal escapes into the log stream. Tabs,
+// carriage returns and newlines collapse to a single space; other control
+// runes are dropped.
+func sanitize(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\r', '\t':
+			return ' '
+		}
+		if unicode.IsControl(r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// sanitizeSlice sanitizes every element of a slice, returning a fresh slice.
+func sanitizeSlice(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]string, len(in))
+	for i, v := range in {
+		out[i] = sanitize(v)
+	}
+	return out
+}
+
+// forwardedFor returns the raw X-Forwarded-For header value.
+func forwardedFor(headers http.Header) string {
+	return headers.Get("X-Forwarded-For")
+}
+
+// resolveClientIP returns the authoritative client IP for a request given the
+// peer address, the X-Forwarded-For chain, and the set of trusted proxy
+// networks. See the package documentation for the full contract. It is
+// IPv4/IPv6 aware and ignores malformed forwarded entries.
+func resolveClientIP(remoteAddr, xff string, trusted []*net.IPNet) string {
+	peer := peerHost(remoteAddr)
+
+	// Without trust, or when the peer itself is not a trusted proxy, forwarded
+	// headers are ignored entirely: the direct peer is the client.
+	if xff == "" || !ipInNetworks(peer, trusted) {
+		return peer
 	}
 
-	fmt.Printf("[%s] AuFail src:[%s / % s] URI:%s\n", time.Now().Format(timestampLayout), remoteAddr, req.Header.Get(("x-forwarded-for")), req.RequestURI)
+	// The peer is a trusted proxy. Walk the forwarded chain from the hop
+	// nearest the proxy toward the origin, skipping trusted hops, and take the
+	// first untrusted (or malformed-but-parseable) address as the client.
+	hops := strings.Split(xff, ",")
+	for i := len(hops) - 1; i >= 0; i-- {
+		ip := strings.TrimSpace(hops[i])
+		if net.ParseIP(ip) == nil {
+			// Malformed hop: cannot trust anything further left through it.
+			return peer
+		}
+		if ipInNetworks(ip, trusted) {
+			continue
+		}
+		return ip
+	}
+
+	return peer
+}
+
+// peerHost extracts the host portion of a host:port peer address, IPv6-safe. It
+// falls back to the raw value when the address has no port (some call sites
+// build requests without a RemoteAddr).
+func peerHost(remoteAddr string) string {
+	if remoteAddr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
+	}
+	return remoteAddr
+}
+
+// ipInNetworks reports whether ip parses and falls within any of the networks.
+func ipInNetworks(ip string, networks []*net.IPNet) bool {
+	if len(networks) == 0 {
+		return false
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, n := range networks {
+		if n != nil && n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/proxy/logging/accesslog_test.go
+++ b/pkg/proxy/logging/accesslog_test.go
@@ -2,67 +2,242 @@
 package logging
 
 import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
 )
 
-func TestXForwardedFor(t *testing.T) {
+func mustCIDR(t *testing.T, cidr string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("parse CIDR %q: %v", cidr, err)
+	}
+	return n
+}
+
+// TestResolveClientIP exercises the trusted-proxy / client-IP contract for
+// issue #56: forwarded headers are honoured only when the immediate peer is a
+// trusted proxy, across multiple hops, malformed values, IPv4 and IPv6.
+func TestResolveClientIP(t *testing.T) {
+	trustedV4 := []*net.IPNet{mustCIDR(t, "10.0.0.0/8")}
+	trustedMixed := []*net.IPNet{mustCIDR(t, "10.0.0.0/8"), mustCIDR(t, "fd00::/8")}
 
 	tests := map[string]struct {
-		headers    http.Header
 		remoteAddr string
+		xff        string
+		trusted    []*net.IPNet
 		exp        string
 	}{
-		"no x-forwarded-for": {
-			headers:    http.Header{},
-			remoteAddr: "1.2.3.4",
+		"no trusted proxies ignores XFF": {
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "1.2.3.4",
+			trusted:    nil,
+			exp:        "10.0.0.1",
+		},
+		"untrusted peer cannot spoof via XFF": {
+			remoteAddr: "203.0.113.9:5555",
+			xff:        "1.2.3.4",
+			trusted:    trustedV4,
+			exp:        "203.0.113.9",
+		},
+		"trusted peer single hop": {
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "1.2.3.4",
+			trusted:    trustedV4,
+			exp:        "1.2.3.4",
+		},
+		"trusted peer multiple hops takes first untrusted from the right": {
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "1.2.3.4, 10.0.0.9, 10.0.0.8",
+			trusted:    trustedV4,
+			exp:        "1.2.3.4",
+		},
+		"trusted peer all hops trusted falls back to peer": {
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "10.0.0.7, 10.0.0.8",
+			trusted:    trustedV4,
+			exp:        "10.0.0.1",
+		},
+		"malformed hop stops the walk": {
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "1.2.3.4, garbage, 10.0.0.8",
+			trusted:    trustedV4,
+			exp:        "10.0.0.1",
+		},
+		"empty XFF returns peer": {
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "",
+			trusted:    trustedV4,
+			exp:        "10.0.0.1",
+		},
+		"ipv6 trusted peer and client": {
+			remoteAddr: "[fd00::1]:443",
+			xff:        "2001:db8::1, fd00::2",
+			trusted:    trustedMixed,
+			exp:        "2001:db8::1",
+		},
+		"ipv6 peer without port": {
+			remoteAddr: "fd00::1",
+			xff:        "2001:db8::1",
+			trusted:    trustedMixed,
+			exp:        "2001:db8::1",
+		},
+		"empty remote addr": {
+			remoteAddr: "",
+			xff:        "1.2.3.4",
+			trusted:    trustedV4,
 			exp:        "",
-		},
-		"empty x-forwarded-for": {
-			headers: http.Header{
-				"X-Forwarded-For": []string{""},
-			},
-			remoteAddr: "1.2.3.4",
-			exp:        "",
-		},
-		"x-forwarded-for is remoteaddr": {
-			headers: http.Header{
-				"X-Forwarded-For": []string{"1.2.3.4"},
-			},
-			remoteAddr: "1.2.3.4",
-			exp:        "",
-		},
-		"x-forwarded-for with no remoteaddr": {
-			headers: http.Header{
-				"X-Forwarded-For": []string{"1.2.3.1"},
-			},
-			remoteAddr: "1.2.3.4",
-			exp:        "1.2.3.1",
-		},
-		"x-forwarded-for with with remoteaddr at the end": {
-			headers: http.Header{
-				"X-Forwarded-For": []string{"1.2.3.1, 1.2.3.4"},
-			},
-			remoteAddr: "1.2.3.4",
-			exp:        "1.2.3.1",
-		},
-		"x-forwarded-for with with remoteaddr at the beginning": {
-			headers: http.Header{
-				"X-Forwarded-For": []string{"1.2.3.4, 1.2.3.1"},
-			},
-			remoteAddr: "1.2.3.4",
-			exp:        "1.2.3.1",
 		},
 	}
 
-	for name, test := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			forwarded := findXForwardedFor(test.headers, test.remoteAddr)
-
-			if test.exp != forwarded {
-				t.Errorf("failed for %s: unexpected result : %s", name, forwarded)
-				t.FailNow()
+			t.Parallel()
+			got := resolveClientIP(tc.remoteAddr, tc.xff, tc.trusted)
+			if got != tc.exp {
+				t.Errorf("resolveClientIP(%q, %q) = %q, want %q", tc.remoteAddr, tc.xff, got, tc.exp)
 			}
 		})
+	}
+}
+
+func TestPeerHost(t *testing.T) {
+	tests := map[string]struct{ in, exp string }{
+		"ipv4 host port":    {"1.2.3.4:8080", "1.2.3.4"},
+		"ipv6 host port":    {"[::1]:8080", "::1"},
+		"bare ipv4 no port": {"1.2.3.4", "1.2.3.4"},
+		"empty":             {"", ""},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := peerHost(tc.in); got != tc.exp {
+				t.Errorf("peerHost(%q) = %q, want %q", tc.in, got, tc.exp)
+			}
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	tests := map[string]struct{ in, exp string }{
+		"plain":            {"alice@example.com", "alice@example.com"},
+		"newline to space": {"a\nb", "a b"},
+		"crlf to spaces":   {"a\r\nb", "a  b"},
+		"tab to space":     {"a\tb", "a b"},
+		"drops control":    {"a\x00\x1bb", "ab"},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := sanitize(tc.in); got != tc.exp {
+				t.Errorf("sanitize(%q) = %q, want %q", tc.in, got, tc.exp)
+			}
+		})
+	}
+}
+
+// captureLogger redirects the package logger to an in-memory JSON buffer and
+// returns the buffer plus a restore func.
+func captureLogger(t *testing.T) (*bytes.Buffer, func()) {
+	t.Helper()
+	prev := logger
+	buf := &bytes.Buffer{}
+	logger = slog.New(slog.NewJSONHandler(buf, nil))
+	return buf, func() { logger = prev }
+}
+
+// TestLogSuccessfulRequestStructured verifies issue #55: output is structured
+// JSON, a single line per record even with an injection attempt, arbitrary
+// identity extras are omitted (with a count), and allowlisted extras are kept.
+func TestLogSuccessfulRequestStructured(t *testing.T) {
+	buf, restore := captureLogger(t)
+	defer restore()
+
+	req := &http.Request{
+		RemoteAddr: "1.2.3.4:5555",
+		URL:        &url.URL{Path: "/api/v1/pods", RawQuery: "token=supersecret"},
+		Header:     http.Header{},
+	}
+
+	inbound := &user.DefaultInfo{
+		// Attempt to inject a second log line and a fake field via the username.
+		Name:   "evil\nAuSuccess src:[spoofed",
+		Groups: []string{"dev", "bad\ngroup"},
+		Extra: map[string][]string{
+			UserHeaderClientIPKey:      {"1.2.3.4"},
+			"email":                    {"secret@example.com"},
+			"authorization-bearer-tok": {"do-not-log"},
+		},
+	}
+
+	LogSuccessfulRequest(req, inbound, nil)
+
+	out := strings.TrimRight(buf.String(), "\n")
+	if strings.Contains(out, "\n") {
+		t.Fatalf("log output spans multiple lines, injection not prevented:\n%s", out)
+	}
+
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(out), &rec); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+
+	if rec["event"] != "AuSuccess" {
+		t.Errorf("event = %v, want AuSuccess", rec["event"])
+	}
+	if rec["src_ip"] != "1.2.3.4" {
+		t.Errorf("src_ip = %v, want 1.2.3.4", rec["src_ip"])
+	}
+	// Path only, query string must not be logged.
+	if rec["path"] != "/api/v1/pods" {
+		t.Errorf("path = %v, want /api/v1/pods", rec["path"])
+	}
+	if strings.Contains(out, "supersecret") {
+		t.Errorf("query string leaked into log: %s", out)
+	}
+	// Username newline was neutralised.
+	if name, _ := rec["inbound_user"].(string); strings.Contains(name, "\n") {
+		t.Errorf("inbound_user still contains newline: %q", name)
+	}
+	// Arbitrary claim extras must be omitted, not logged.
+	if strings.Contains(out, "secret@example.com") || strings.Contains(out, "do-not-log") {
+		t.Errorf("arbitrary extras leaked into log: %s", out)
+	}
+	if omitted, ok := rec["inbound_extra_omitted"].(float64); !ok || omitted != 2 {
+		t.Errorf("inbound_extra_omitted = %v, want 2", rec["inbound_extra_omitted"])
+	}
+	// Allowlisted extra must be present.
+	extra, ok := rec["inbound_extra"].(map[string]any)
+	if !ok {
+		t.Fatalf("inbound_extra missing or wrong type: %v", rec["inbound_extra"])
+	}
+	if _, ok := extra[UserHeaderClientIPKey]; !ok {
+		t.Errorf("allowlisted extra %q not logged: %v", UserHeaderClientIPKey, extra)
+	}
+}
+
+func TestLogFailedRequestNilURL(t *testing.T) {
+	buf, restore := captureLogger(t)
+	defer restore()
+
+	// Bare request as constructed by some call sites: no URL, no RemoteAddr.
+	req := &http.Request{Header: http.Header{}}
+
+	// Must not panic on nil URL / empty RemoteAddr.
+	LogFailedRequest(req)
+
+	out := strings.TrimRight(buf.String(), "\n")
+	var rec map[string]any
+	if err := json.Unmarshal([]byte(out), &rec); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if rec["event"] != "AuFail" {
+		t.Errorf("event = %v, want AuFail", rec["event"])
 	}
 }

--- a/pkg/proxy/subjectaccessreview/subjectaccessreview.go
+++ b/pkg/proxy/subjectaccessreview/subjectaccessreview.go
@@ -23,7 +23,43 @@ var (
 	// the underlying error (including context.Canceled/DeadlineExceeded) is wrapped
 	// alongside it so it remains detectable too.
 	ErrCreateSubjectAccessReview = errors.New("create SubjectAccessReview")
+
+	// ErrImpersonationNotAllowed is the sentinel that classifies an authorization
+	// denial: the requester is not permitted to impersonate a requested resource.
+	// Every denial returned by CheckAuthorizedForImpersonation is an
+	// *ImpersonationAuthError, which matches this sentinel via errors.Is. HTTP
+	// handlers select a 403 with errors.Is(err, ErrImpersonationNotAllowed)
+	// instead of matching on message text.
+	ErrImpersonationNotAllowed = errors.New("not allowed to impersonate")
 )
+
+// ImpersonationAuthError reports that a requester is not authorized to
+// impersonate a particular resource (user, group, uid, or extra info). It
+// classifies as ErrImpersonationNotAllowed through errors.Is so callers can
+// select an HTTP 403 without inspecting the message string, while Error()
+// preserves the human-readable, client-facing wording.
+type ImpersonationAuthError struct {
+	// Requester is the name of the authenticated user attempting impersonation.
+	Requester string
+
+	// Kind is the impersonated resource kind as rendered in the message, e.g.
+	// "user", "group", "uid", or "extra info".
+	Kind string
+
+	// Target is the quoted resource identifier as rendered in the message, e.g.
+	// "'a-user'" or "'foo'='bar'".
+	Target string
+}
+
+func (e *ImpersonationAuthError) Error() string {
+	return fmt.Sprintf("%s is not allowed to impersonate %s %s", e.Requester, e.Kind, e.Target)
+}
+
+// Is reports whether e should be treated as ErrImpersonationNotAllowed, letting
+// errors.Is classify any denial regardless of the concrete resource involved.
+func (e *ImpersonationAuthError) Is(target error) bool {
+	return target == ErrImpersonationNotAllowed
+}
 
 // DefaultTimeout is the default value for the SAR authorization budget. It
 // bounds the total time spent authorizing a single request's impersonation via
@@ -93,7 +129,11 @@ func (subjectAccessReview *SubjectAccessReview) CheckAuthorizedForImpersonation(
 						return nil, err
 					} else {
 						if !result {
-							return nil, fmt.Errorf("%s is not allowed to impersonate user '%s'", requester.GetName(), userToImpersonate)
+							return nil, &ImpersonationAuthError{
+								Requester: requester.GetName(),
+								Kind:      "user",
+								Target:    fmt.Sprintf("'%s'", userToImpersonate),
+							}
 						} else {
 							targetUser.Name = userToImpersonate
 						}
@@ -108,7 +148,11 @@ func (subjectAccessReview *SubjectAccessReview) CheckAuthorizedForImpersonation(
 						return nil, err
 					} else {
 						if !result {
-							return nil, fmt.Errorf("%s is not allowed to impersonate group '%s'", requester.GetName(), groupName)
+							return nil, &ImpersonationAuthError{
+								Requester: requester.GetName(),
+								Kind:      "group",
+								Target:    fmt.Sprintf("'%s'", groupName),
+							}
 						} else {
 							targetUser.Groups = append(targetUser.Groups, groupName)
 						}
@@ -121,7 +165,11 @@ func (subjectAccessReview *SubjectAccessReview) CheckAuthorizedForImpersonation(
 					return nil, err
 				} else {
 					if !result {
-						return nil, fmt.Errorf("%s is not allowed to impersonate uid '%s'", requester.GetName(), uidToImpersonate)
+						return nil, &ImpersonationAuthError{
+							Requester: requester.GetName(),
+							Kind:      "uid",
+							Target:    fmt.Sprintf("'%s'", uidToImpersonate),
+						}
 					} else {
 						targetUser.UID = uidToImpersonate
 					}
@@ -136,8 +184,11 @@ func (subjectAccessReview *SubjectAccessReview) CheckAuthorizedForImpersonation(
 						return nil, err
 					} else {
 						if !result {
-
-							return nil, fmt.Errorf("%s is not allowed to impersonate extra info '%s'='%s'", requester.GetName(), extraName, values[i])
+							return nil, &ImpersonationAuthError{
+								Requester: requester.GetName(),
+								Kind:      "extra info",
+								Target:    fmt.Sprintf("'%s'='%s'", extraName, values[i]),
+							}
 						} else {
 							infoVals, ok := targetUser.Extra[extraName]
 

--- a/pkg/proxy/subjectaccessreview/subjectaccessreview_test.go
+++ b/pkg/proxy/subjectaccessreview/subjectaccessreview_test.go
@@ -4,6 +4,7 @@ package subjectaccessreview
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -94,7 +95,7 @@ func TestSubectAccessReview(t *testing.T) {
 
 			expImpersonationHeaders:  true,
 			expAz:                    false,
-			expErr:                   errors.New("mmosley is not allowed to impersonate user 'jjackson-x'"),
+			expErr:                   &ImpersonationAuthError{Requester: "mmosley", Kind: "user", Target: "'jjackson-x'"},
 			expErrorRbac:             nil,
 			extraImpersonationHeader: false,
 		},
@@ -120,7 +121,7 @@ func TestSubectAccessReview(t *testing.T) {
 
 			expImpersonationHeaders:  true,
 			expAz:                    false,
-			expErr:                   errors.New("mmosley is not allowed to impersonate group 'group4'"),
+			expErr:                   &ImpersonationAuthError{Requester: "mmosley", Kind: "group", Target: "'group4'"},
 			expErrorRbac:             nil,
 			extraImpersonationHeader: false,
 		},
@@ -146,7 +147,7 @@ func TestSubectAccessReview(t *testing.T) {
 
 			expImpersonationHeaders:  true,
 			expAz:                    false,
-			expErr:                   errors.New("mmosley is not allowed to impersonate extra info 'remoteaddr'='1.2.3.5'"),
+			expErr:                   &ImpersonationAuthError{Requester: "mmosley", Kind: "extra info", Target: "'remoteaddr'='1.2.3.5'"},
 			expErrorRbac:             nil,
 			extraImpersonationHeader: false,
 		},
@@ -171,7 +172,7 @@ func TestSubectAccessReview(t *testing.T) {
 
 			expImpersonationHeaders:  true,
 			expAz:                    false,
-			expErr:                   errors.New("mmosley is not allowed to impersonate uid '1-2-3-5'"),
+			expErr:                   &ImpersonationAuthError{Requester: "mmosley", Kind: "uid", Target: "'1-2-3-5'"},
 			expErrorRbac:             nil,
 			extraImpersonationHeader: false,
 		},
@@ -354,6 +355,62 @@ func runTest(t *testing.T, name string, test testT) {
 
 	// everything checks out!
 
+}
+
+// TestImpersonationAuthErrorClassification pins the typed-error contract for
+// issue #51: every denial classifies as ErrImpersonationNotAllowed via
+// errors.Is (and errors.As), unrelated errors do not, and the client-facing
+// message is preserved verbatim.
+func TestImpersonationAuthErrorClassification(t *testing.T) {
+	tests := map[string]struct {
+		err    *ImpersonationAuthError
+		expMsg string
+	}{
+		"user": {
+			err:    &ImpersonationAuthError{Requester: "mmosley", Kind: "user", Target: "'a-user'"},
+			expMsg: "mmosley is not allowed to impersonate user 'a-user'",
+		},
+		"group": {
+			err:    &ImpersonationAuthError{Requester: "mmosley", Kind: "group", Target: "'a-group'"},
+			expMsg: "mmosley is not allowed to impersonate group 'a-group'",
+		},
+		"uid": {
+			err:    &ImpersonationAuthError{Requester: "mmosley", Kind: "uid", Target: "'bar'"},
+			expMsg: "mmosley is not allowed to impersonate uid 'bar'",
+		},
+		"extra info": {
+			err:    &ImpersonationAuthError{Requester: "mmosley", Kind: "extra info", Target: "'foo'='bar'"},
+			expMsg: "mmosley is not allowed to impersonate extra info 'foo'='bar'",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Message is stable and client-facing.
+			if got := tc.err.Error(); got != tc.expMsg {
+				t.Errorf("Error() = %q, want %q", got, tc.expMsg)
+			}
+
+			// Classifies as the sentinel through a wrap, without message matching.
+			wrapped := fmt.Errorf("handling request: %w", tc.err)
+			if !errors.Is(wrapped, ErrImpersonationNotAllowed) {
+				t.Errorf("errors.Is(wrapped, ErrImpersonationNotAllowed) = false, want true")
+			}
+
+			var asErr *ImpersonationAuthError
+			if !errors.As(wrapped, &asErr) {
+				t.Errorf("errors.As did not recover *ImpersonationAuthError from %v", wrapped)
+			}
+		})
+	}
+
+	// Unrelated errors must not be misclassified as a denial.
+	if errors.Is(ErrorNoImpersonationUserFound, ErrImpersonationNotAllowed) {
+		t.Error("ErrorNoImpersonationUserFound must not classify as ErrImpersonationNotAllowed")
+	}
+	if errors.Is(errors.New("boom"), ErrImpersonationNotAllowed) {
+		t.Error("arbitrary error must not classify as ErrImpersonationNotAllowed")
+	}
 }
 
 // blockingReviewer is a local test double implementing


### PR DESCRIPTION
## Code quality: request-path correctness & observability

Part of Epic #46. Stdlib-only (no `go.mod` change); `-race`-clean; composes with the sibling PRs.

- **#52** — defensively copy authenticator-owned state before enrichment in `withImpersonateRequest` (`slices.Clone` groups + deep-cloned `extra` map), so impersonation enrichment can't mutate the shared `user.Info`.
- **#51** — replaced string-matched authz classification with a typed `ImpersonationAuthError` + sentinel; `newErrorHandler` classifies via `errors.Is` (the `strings.Contains(err.Error(), …)` check is gone). Error wording preserved so existing 403 assertions/e2e hold.
- **#55** — access logs moved to stdlib `log/slog` (structured JSON), with **sanitization** of user-controlled fields (control-char/newline stripping → no log injection), allowlisted identity extras, and IPv6-safe peer parsing.
- **#56 (partial)** — added a documented, tested trusted-proxy/client-IP contract in the logging package (default trusts nothing; XFF only via configured trusted nets). The end-to-end wiring (`--trusted-proxies` flag → `context.go`/`proxy.go`) is out-of-lane and tracked for follow-up.

Boundary tests added for each (aliasing, typed-error classification, XFF trust, sanitized output).

Closes #51
Closes #52
Closes #55
