### PR TITLE
refactor(lifecycle): explicit ownership for hooks, readiness & constructor (#53 #54 #57 #58)

### DIFF
--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -110,7 +110,7 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				return err
 			}
 
-			subectAccessReviewer, err := subjectaccessreview.New(kubeclient.AuthorizationV1().SubjectAccessReviews(), opts.App.SubjectAccessReviewTimeout)
+			subjectAccessReviewer, err := subjectaccessreview.New(kubeclient.AuthorizationV1().SubjectAccessReviews(), opts.App.SubjectAccessReviewTimeout)
 			if err != nil {
 				return err
 			}
@@ -121,8 +121,15 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 			}
 
 			// Initialise proxy with token authenticator
-			p, err := proxy.New(restConfig, tokenAuther, opts.Audit,
-				tokenReviewer, subectAccessReviewer, secureServingInfo, proxyConfig)
+			p, err := proxy.New(proxy.Dependencies{
+				RestConfig:            restConfig,
+				TokenAuthenticator:    tokenAuther,
+				AuditOptions:          opts.Audit,
+				TokenReviewer:         tokenReviewer,
+				SubjectAccessReviewer: subjectAccessReviewer,
+				SecureServingInfo:     secureServingInfo,
+				Config:                proxyConfig,
+			})
 			if err != nil {
 				return err
 			}
@@ -140,10 +147,24 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				})
 			}
 
-			// Start readiness probe
-			if err := probe.Run(strconv.Itoa(opts.App.ReadinessProbePort),
+			// Derive a context cancelled when the app stop signal fires, giving the
+			// readiness server an explicit shutdown path.
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				select {
+				case <-stopCh:
+					cancel()
+				case <-ctx.Done():
+				}
+			}()
+
+			// Start readiness probe with an explicit lifecycle. Start binds
+			// synchronously so a port-in-use failure surfaces here at startup.
+			probeServer := probe.NewServer(strconv.Itoa(opts.App.ReadinessProbePort),
 				issuerProbes, opts.App.ReadinessRequireAllIssuers,
-				p.OIDCTokenAuthenticator()); err != nil {
+				p.OIDCTokenAuthenticator())
+			if err := probeServer.Start(ctx); err != nil {
 				return err
 			}
 
@@ -155,6 +176,12 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 
 			<-waitCh
 			<-listenerStoppedCh
+
+			// Stop the readiness server and wait for its listener to be released.
+			cancel()
+			if err := probeServer.Wait(); err != nil {
+				return err
+			}
 
 			if err := p.RunPreShutdownHooks(); err != nil {
 				return err

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -18,6 +18,10 @@ import (
 
 const (
 	timeout = time.Second * 10
+
+	// shutdownTimeout bounds the graceful shutdown of the readiness server so a
+	// stuck connection cannot block process teardown indefinitely.
+	shutdownTimeout = time.Second * 5
 )
 
 // transientMarkers are substrings that unambiguously identify a transient
@@ -51,7 +55,24 @@ type HealthCheck struct {
 	initialized map[string]bool
 }
 
-func Run(port string, issuers []IssuerReadiness, requireAll bool, oidcAuther authenticator.Token) error {
+// Server owns the readiness HTTP listener and gives it an explicit lifecycle:
+// a caller Starts it (binding synchronously), the server serves until the
+// supplied context is cancelled, and Wait reports the terminal serve error.
+type Server struct {
+	hc  *HealthCheck
+	srv *http.Server
+
+	// served is closed once Serve returns; err holds the terminal serve error
+	// (nil after a clean shutdown). Closing served happens-after the write to
+	// err, so Wait observes err safely without additional synchronization.
+	served chan struct{}
+	err    error
+}
+
+// NewServer builds a readiness Server that probes the given issuers via
+// oidcAuther and serves the readiness endpoint on the given port. It does not
+// bind or serve until Start is called.
+func NewServer(port string, issuers []IssuerReadiness, requireAll bool, oidcAuther authenticator.Token) *Server {
 	h := &HealthCheck{
 		handler:     healthcheck.NewHandler(),
 		oidcAuther:  oidcAuther,
@@ -62,20 +83,68 @@ func Run(port string, issuers []IssuerReadiness, requireAll bool, oidcAuther aut
 
 	h.handler.AddReadinessCheck("secure serving", h.Check)
 
-	// Bind synchronously so a failure to acquire the port is surfaced to the
-	// caller at startup rather than being swallowed inside the goroutine.
-	ln, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", port))
+	return &Server{
+		hc: h,
+		srv: &http.Server{
+			Addr:    net.JoinHostPort("0.0.0.0", port),
+			Handler: h.handler,
+		},
+		served: make(chan struct{}),
+	}
+}
+
+// Start binds the readiness listener synchronously so a failure to acquire the
+// port is surfaced to the caller at startup rather than being swallowed inside
+// a goroutine. On success it serves in the background and gracefully shuts the
+// server down (bounded by shutdownTimeout) once ctx is cancelled. Start returns
+// once the listener is bound; use Wait to block on the terminal serve error.
+func (s *Server) Start(ctx context.Context) error {
+	ln, err := net.Listen("tcp", s.srv.Addr)
 	if err != nil {
-		return fmt.Errorf("readiness probe failed to listen on port %s: %w", port, err)
+		return fmt.Errorf("readiness probe failed to listen on %s: %w", s.srv.Addr, err)
 	}
 
 	go func() {
-		if err := http.Serve(ln, h.handler); err != nil {
-			klog.Errorf("ready probe listener failed: %s", err)
+		serveErr := s.srv.Serve(ln)
+		// A graceful shutdown is expected, not a failure.
+		if errors.Is(serveErr, http.ErrServerClosed) {
+			serveErr = nil
+		}
+		s.err = serveErr
+		close(s.served)
+	}()
+
+	// Bridge context cancellation to a bounded graceful shutdown. This goroutine
+	// exits either when ctx is cancelled or when serving has already stopped, so
+	// it never outlives the server (no leak across repeated Start/Shutdown).
+	go func() {
+		select {
+		case <-ctx.Done():
+			if err := s.Shutdown(); err != nil {
+				klog.Errorf("readiness probe shutdown error: %s", err)
+			}
+		case <-s.served:
 		}
 	}()
 
 	return nil
+}
+
+// Shutdown gracefully stops the readiness server with a bounded timeout. It is
+// safe to call more than once and is invoked automatically when the context
+// passed to Start is cancelled.
+func (s *Server) Shutdown() error {
+	ctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	return s.srv.Shutdown(ctx)
+}
+
+// Wait blocks until the server has stopped serving and returns the terminal
+// serve error, with http.ErrServerClosed normalized to nil. It may be called
+// by multiple goroutines.
+func (s *Server) Wait() error {
+	<-s.served
+	return s.err
 }
 
 // isNotInitialized reports whether err indicates the issuer's authenticator has
@@ -115,15 +184,21 @@ func (h *HealthCheck) Check() error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	// Snapshot the issuers still needing a probe under the lock, then release it
+	// so the potentially slow AuthenticateToken calls run lock-free. No blocking
+	// authenticator call may run while h.mu is held (#53).
 	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	var pending []string
+	toProbe := make([]IssuerReadiness, 0, len(h.issuers))
 	for _, issuer := range h.issuers {
-		if h.initialized[issuer.IssuerURL] {
-			continue
+		if !h.initialized[issuer.IssuerURL] {
+			toProbe = append(toProbe, issuer)
 		}
+	}
+	h.mu.Unlock()
 
+	// Probe each not-yet-initialized issuer without holding the lock.
+	var newlyInitialized, pending []string
+	for _, issuer := range toProbe {
 		_, _, err := h.oidcAuther.AuthenticateToken(ctx, issuer.FakeJWT)
 		// The issuer counts as initialized only once its authenticator reaches
 		// token verification. A "not initialized" signal (JWKS not fetched yet)
@@ -133,9 +208,19 @@ func (h *HealthCheck) Check() error {
 			pending = append(pending, issuer.IssuerURL)
 			continue
 		}
+		newlyInitialized = append(newlyInitialized, issuer.IssuerURL)
+	}
 
-		h.initialized[issuer.IssuerURL] = true
-		klog.Infof("OIDC issuer initialized: %s (%d/%d ready)", issuer.IssuerURL, len(h.initialized), len(h.issuers))
+	// Re-acquire the lock to record results and evaluate readiness.
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for _, issuerURL := range newlyInitialized {
+		if h.initialized[issuerURL] {
+			continue
+		}
+		h.initialized[issuerURL] = true
+		klog.Infof("OIDC issuer initialized: %s (%d/%d ready)", issuerURL, len(h.initialized), len(h.issuers))
 	}
 
 	if len(pending) > 0 {

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -5,8 +5,11 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/http"
+	"runtime"
 	"sync"
 	"testing"
+	"time"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 
@@ -247,10 +250,27 @@ func (timeoutError) Error() string   { return "i/o timeout" }
 func (timeoutError) Timeout() bool   { return true }
 func (timeoutError) Temporary() bool { return true }
 
-func TestRunReturnsBindError(t *testing.T) {
-	// Occupy the wildcard address, then ask Run to bind the same port so the
-	// bind fails. Run listens on 0.0.0.0, so occupy 0.0.0.0 too: a loopback-only
-	// listener would not necessarily collide with a wildcard bind.
+// freePort reserves and immediately releases a wildcard port, returning its
+// number for a subsequent bind. Server.Start binds 0.0.0.0, so reserve 0.0.0.0.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("reserving port: %v", err)
+	}
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("splitting host/port: %v", err)
+	}
+	if err := ln.Close(); err != nil {
+		t.Fatalf("releasing reserved port: %v", err)
+	}
+	return port
+}
+
+// TestServerStartReturnsBindError verifies Start surfaces a bind failure to the
+// caller synchronously rather than swallowing it inside a goroutine.
+func TestServerStartReturnsBindError(t *testing.T) {
 	occupied, err := net.Listen("tcp", "0.0.0.0:0")
 	if err != nil {
 		t.Fatalf("reserving port: %v", err)
@@ -262,7 +282,166 @@ func TestRunReturnsBindError(t *testing.T) {
 		t.Fatalf("splitting host/port: %v", err)
 	}
 
-	if err := Run(port, nil, false, &fakeAuther{}); err == nil {
-		t.Fatal("expected Run to return an error binding an occupied port, got nil")
+	s := NewServer(port, nil, false, &fakeAuther{})
+	if err := s.Start(context.Background()); err == nil {
+		t.Fatal("expected Start to return an error binding an occupied port, got nil")
+	}
+}
+
+// TestServerStartServesAndShutsDown verifies the full lifecycle: the server
+// serves after Start, stops when its context is cancelled, Wait returns nil for
+// the graceful shutdown, and the listener is released (proving the documented
+// stop path actually frees the port).
+func TestServerStartServesAndShutsDown(t *testing.T) {
+	port := freePort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	s := NewServer(port, nil, false, &fakeAuther{})
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start returned unexpected error: %v", err)
+	}
+
+	// The liveness endpoint has no checks, so it returns 200 once serving.
+	url := "http://127.0.0.1:" + port + "/live"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("readiness server not serving after Start: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status from /live: got %d want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// Cancelling the context must trigger a graceful shutdown; Wait then returns
+	// the normalized (nil) serve error.
+	cancel()
+	if err := s.Wait(); err != nil {
+		t.Fatalf("Wait returned unexpected error after graceful shutdown: %v", err)
+	}
+
+	// The listener must be released: rebinding the same port must now succeed.
+	ln, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", port))
+	if err != nil {
+		t.Fatalf("listener not released after shutdown, rebind failed: %v", err)
+	}
+	_ = ln.Close()
+}
+
+// TestServerNoGoroutineLeak verifies repeated Start/shutdown cycles do not leak
+// goroutines (the serve and context-watcher goroutines must both exit).
+func TestServerNoGoroutineLeak(t *testing.T) {
+	// Let any goroutines from earlier tests settle first.
+	baseline := stableGoroutines(t)
+
+	for i := 0; i < 20; i++ {
+		port := freePort(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		s := NewServer(port, nil, false, &fakeAuther{})
+		if err := s.Start(ctx); err != nil {
+			cancel()
+			t.Fatalf("Start returned unexpected error: %v", err)
+		}
+		cancel()
+		if err := s.Wait(); err != nil {
+			t.Fatalf("Wait returned unexpected error: %v", err)
+		}
+	}
+
+	if got := stableGoroutines(t); got > baseline {
+		t.Fatalf("goroutine leak across Start/shutdown cycles: baseline=%d got=%d", baseline, got)
+	}
+}
+
+// stableGoroutines polls until the goroutine count stops decreasing, returning
+// the settled value. This avoids flakiness from goroutines still winding down.
+func stableGoroutines(t *testing.T) int {
+	t.Helper()
+	prev := runtime.NumGoroutine()
+	for i := 0; i < 50; i++ {
+		time.Sleep(10 * time.Millisecond)
+		cur := runtime.NumGoroutine()
+		if cur >= prev {
+			return prev
+		}
+		prev = cur
+	}
+	return prev
+}
+
+// concurrentAuther records the maximum number of AuthenticateToken calls in
+// flight simultaneously. It is used to prove the health-check lock is not held
+// across the authenticator call (#53).
+type concurrentAuther struct {
+	mu      sync.Mutex
+	current int
+	max     int
+
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (c *concurrentAuther) AuthenticateToken(_ context.Context, _ string) (*authenticator.Response, bool, error) {
+	c.mu.Lock()
+	c.current++
+	if c.current > c.max {
+		c.max = c.current
+	}
+	c.mu.Unlock()
+
+	c.entered <- struct{}{}
+	<-c.release
+
+	c.mu.Lock()
+	c.current--
+	c.mu.Unlock()
+
+	// Keep the issuer pending so it is probed on every Check.
+	return nil, false, errors.New("oidc: authenticator not initialized")
+}
+
+func (c *concurrentAuther) maxConcurrent() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.max
+}
+
+// TestCheckDoesNotHoldLockDuringAuth verifies the authenticator call runs
+// lock-free: two concurrent Check calls must be able to sit inside
+// AuthenticateToken simultaneously. If h.mu were held across the call, the
+// second Check would block at entry and the two would serialize (max=1),
+// causing the barrier read below to time out.
+func TestCheckDoesNotHoldLockDuringAuth(t *testing.T) {
+	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
+	auther := &concurrentAuther{
+		entered: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	h := newTestHealthCheckWithAuther(true, auther, issuerA)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = h.Check()
+		}()
+	}
+
+	// Both Check calls must reach the authenticator concurrently.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-auther.entered:
+		case <-time.After(2 * time.Second):
+			close(auther.release)
+			t.Fatal("only one Check reached the authenticator: lock held across auth call")
+		}
+	}
+
+	close(auther.release)
+	wg.Wait()
+
+	if got := auther.maxConcurrent(); got < 2 {
+		t.Fatalf("expected >=2 concurrent authenticator calls, got %d", got)
 	}
 }

--- a/pkg/proxy/hooks/hooks.go
+++ b/pkg/proxy/hooks/hooks.go
@@ -8,36 +8,71 @@ import (
 	k8sErrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
-type Hooks struct {
-	preShutdownHooks    map[string]ShutdownHook
-	preShutdownHookLock sync.Mutex
+// ShutdownHook is a callback invoked during graceful shutdown.
+type ShutdownHook func() error
+
+// hookEntry pairs a hook with its registration name so hooks can run in a
+// stable, deterministic order rather than the randomized order of a map range.
+type hookEntry struct {
+	name string
+	hook ShutdownHook
 }
 
-type ShutdownHook func() error
+// Hooks is a registry of named pre-shutdown hooks. It is safe for concurrent
+// use.
+//
+// Ordering and semantics:
+//   - Hooks run in registration order.
+//   - Registering an already-registered name overwrites the hook in place,
+//     preserving its original position (last write wins).
+//   - Hooks registered while RunPreShutdownHooks is executing are not run by
+//     that in-flight pass (the run operates on a snapshot).
+type Hooks struct {
+	mu      sync.Mutex
+	entries []hookEntry
+	indexOf map[string]int
+}
 
 func New() *Hooks {
 	return &Hooks{
-		preShutdownHooks: make(map[string]ShutdownHook),
+		indexOf: make(map[string]int),
 	}
 }
 
+// AddPreShutdownHook registers hook under name. If name is already registered
+// its hook is replaced in place, preserving registration order.
 func (h *Hooks) AddPreShutdownHook(name string, hook ShutdownHook) {
-	h.preShutdownHookLock.Lock()
-	defer h.preShutdownHookLock.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
-	h.preShutdownHooks[name] = hook
+	if i, ok := h.indexOf[name]; ok {
+		h.entries[i].hook = hook
+		return
+	}
+
+	h.indexOf[name] = len(h.entries)
+	h.entries = append(h.entries, hookEntry{name: name, hook: hook})
 }
 
-// RunPreShutdownHooks runs the PreShutdownHooks for the server
+// RunPreShutdownHooks runs every registered pre-shutdown hook in registration
+// order and returns an aggregate of any failures.
+//
+// The registered hooks are snapshotted under the lock and then invoked WITHOUT
+// the lock held: a slow or blocking hook must not stall other registry
+// operations, and a hook that touches the registry must not deadlock. One
+// hook's failure does not prevent later hooks from running; each failure is
+// wrapped with %w so the cause remains inspectable via errors.Is through the
+// returned aggregate.
 func (h *Hooks) RunPreShutdownHooks() error {
+	h.mu.Lock()
+	snapshot := make([]hookEntry, len(h.entries))
+	copy(snapshot, h.entries)
+	h.mu.Unlock()
+
 	var errs []error
-
-	h.preShutdownHookLock.Lock()
-	defer h.preShutdownHookLock.Unlock()
-
-	for name, entry := range h.preShutdownHooks {
-		if err := entry(); err != nil {
-			errs = append(errs, fmt.Errorf("PreShutdownHook %q failed: %v", name, err))
+	for _, entry := range snapshot {
+		if err := entry.hook(); err != nil {
+			errs = append(errs, fmt.Errorf("PreShutdownHook %q failed: %w", entry.name, err))
 		}
 	}
 

--- a/pkg/proxy/hooks/hooks_test.go
+++ b/pkg/proxy/hooks/hooks_test.go
@@ -1,0 +1,125 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package hooks
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// TestRunPreShutdownHooksDoesNotHoldLock is the regression test for #54: a hook
+// must not run while the registry lock is held, otherwise a slow or blocking
+// hook stalls every other registry operation and a hook that touches the
+// registry deadlocks. We register a hook that blocks until released and assert
+// that AddPreShutdownHook (which needs the lock) still returns promptly while
+// the hook is mid-flight.
+func TestRunPreShutdownHooksDoesNotHoldLock(t *testing.T) {
+	h := New()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	h.AddPreShutdownHook("blocking", func() error {
+		close(entered)
+		<-release
+		return nil
+	})
+
+	runDone := make(chan error, 1)
+	go func() { runDone <- h.RunPreShutdownHooks() }()
+
+	// Wait until the blocking hook is executing.
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocking hook never started")
+	}
+
+	// The lock must be free while the hook runs: registering another hook must
+	// not block. If the lock were held across hook execution this would hang.
+	addDone := make(chan struct{})
+	go func() {
+		h.AddPreShutdownHook("added-during-run", func() error { return nil })
+		close(addDone)
+	}()
+
+	select {
+	case <-addDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AddPreShutdownHook blocked while a hook was running: lock held across hook execution")
+	}
+
+	// Let the blocking hook finish and confirm the run completes without error.
+	close(release)
+	select {
+	case err := <-runDone:
+		if err != nil {
+			t.Fatalf("unexpected error from RunPreShutdownHooks: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunPreShutdownHooks did not complete after hook released")
+	}
+}
+
+// TestRunPreShutdownHooksOrderAndContinuation verifies hooks run in registration
+// order and that one hook's failure does not prevent later hooks from running.
+func TestRunPreShutdownHooksOrderAndContinuation(t *testing.T) {
+	h := New()
+
+	var order []string
+	errBoom := errors.New("boom")
+
+	h.AddPreShutdownHook("first", func() error {
+		order = append(order, "first")
+		return nil
+	})
+	h.AddPreShutdownHook("second", func() error {
+		order = append(order, "second")
+		return errBoom
+	})
+	h.AddPreShutdownHook("third", func() error {
+		order = append(order, "third")
+		return nil
+	})
+
+	err := h.RunPreShutdownHooks()
+
+	if want := []string{"first", "second", "third"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("hooks ran out of order or a hook was skipped: got %v want %v", order, want)
+	}
+	if err == nil {
+		t.Fatal("expected an aggregate error from the failing hook, got nil")
+	}
+	// The wrapped cause must remain inspectable through the aggregate via %w.
+	if !errors.Is(err, errBoom) {
+		t.Fatalf("errors.Is could not reach wrapped cause through aggregate: %v", err)
+	}
+}
+
+// TestAddPreShutdownHookOverwritesInPlace verifies that re-registering a name
+// replaces the hook while preserving its original position (last write wins).
+func TestAddPreShutdownHookOverwritesInPlace(t *testing.T) {
+	h := New()
+
+	var order []string
+	h.AddPreShutdownHook("a", func() error { order = append(order, "a-old"); return nil })
+	h.AddPreShutdownHook("b", func() error { order = append(order, "b"); return nil })
+	// Overwrite "a": it must keep its original (first) position but run the new
+	// callback.
+	h.AddPreShutdownHook("a", func() error { order = append(order, "a-new"); return nil })
+
+	if err := h.RunPreShutdownHooks(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if want := []string{"a-new", "b"}; !reflect.DeepEqual(order, want) {
+		t.Fatalf("overwrite did not preserve position / replace callback: got %v want %v", order, want)
+	}
+}
+
+// TestRunPreShutdownHooksNoHooks verifies the empty registry runs cleanly.
+func TestRunPreShutdownHooksNoHooks(t *testing.T) {
+	if err := New().RunPreShutdownHooks(); err != nil {
+		t.Fatalf("expected nil error with no hooks, got %v", err)
+	}
+}

--- a/pkg/proxy/new_test.go
+++ b/pkg/proxy/new_test.go
@@ -1,0 +1,124 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package proxy
+
+import (
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
+
+	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
+	"github.com/rafpe/kube-oidc-proxy/pkg/mocks"
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
+	fakesubjectaccessreview "github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview/fake"
+)
+
+// validDeps returns a Dependencies value with every required field populated,
+// so individual tests can null out one field to exercise validation.
+func validDeps(t *testing.T) Dependencies {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	sar, err := subjectaccessreview.New(fakesubjectaccessreview.New(nil), subjectaccessreview.DefaultTimeout)
+	if err != nil {
+		t.Fatalf("building SubjectAccessReview: %v", err)
+	}
+
+	return Dependencies{
+		RestConfig:            &rest.Config{Host: "https://kube.example.com"},
+		TokenAuthenticator:    mocks.NewMockToken(ctrl),
+		AuditOptions:          new(options.AuditOptions),
+		SubjectAccessReviewer: sar,
+		SecureServingInfo:     new(server.SecureServingInfo),
+		// ExternalAddress must be set: audit.New derives the audit server's
+		// external address from it and fatals when it is empty with no listener.
+		Config: &Config{ExternalAddress: "0.0.0.0:1234"},
+	}
+}
+
+func TestNewValidatesDependencies(t *testing.T) {
+	tests := map[string]struct {
+		mutate  func(d *Dependencies)
+		wantErr bool
+	}{
+		"valid dependencies succeed": {
+			mutate:  func(d *Dependencies) {},
+			wantErr: false,
+		},
+		"nil RestConfig fails": {
+			mutate:  func(d *Dependencies) { d.RestConfig = nil },
+			wantErr: true,
+		},
+		"nil TokenAuthenticator fails": {
+			mutate:  func(d *Dependencies) { d.TokenAuthenticator = nil },
+			wantErr: true,
+		},
+		"nil SubjectAccessReviewer fails": {
+			mutate:  func(d *Dependencies) { d.SubjectAccessReviewer = nil },
+			wantErr: true,
+		},
+		"nil SecureServingInfo fails": {
+			mutate:  func(d *Dependencies) { d.SecureServingInfo = nil },
+			wantErr: true,
+		},
+		"nil Config fails": {
+			mutate:  func(d *Dependencies) { d.Config = nil },
+			wantErr: true,
+		},
+		"TokenReview enabled without reviewer fails": {
+			mutate: func(d *Dependencies) {
+				d.Config = &Config{TokenReview: true, ExternalAddress: "0.0.0.0:1234"}
+				d.TokenReviewer = nil
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			deps := validDeps(t)
+			tc.mutate(&deps)
+
+			p, err := New(deps)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("New(%s): expected an error, got nil", name)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("New(%s): unexpected error: %v", name, err)
+			}
+			if p == nil {
+				t.Fatalf("New(%s): expected a Proxy, got nil", name)
+			}
+		})
+	}
+}
+
+// TestNewCopiesExtraUserHeaders verifies New copies the caller's Config and its
+// ExtraUserHeaders map at the construction boundary, so mutating the caller's
+// map afterward cannot change proxy behavior.
+func TestNewCopiesExtraUserHeaders(t *testing.T) {
+	deps := validDeps(t)
+	src := map[string][]string{"team": {"platform"}}
+	deps.Config = &Config{ExtraUserHeaders: src, ExternalAddress: "0.0.0.0:1234"}
+
+	p, err := New(deps)
+	if err != nil {
+		t.Fatalf("New returned unexpected error: %v", err)
+	}
+
+	// Mutate the caller-owned map and slice after construction.
+	src["team"][0] = "mutated"
+	src["injected"] = []string{"value"}
+
+	got := p.config.ExtraUserHeaders
+	if v := got["team"][0]; v != "platform" {
+		t.Fatalf("proxy shares slice storage with caller: got %q want %q", v, "platform")
+	}
+	if _, ok := got["injected"]; ok {
+		t.Fatal("proxy shares map storage with caller: injected key leaked into proxy config")
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -51,7 +51,7 @@ type errorHandlerFn func(http.ResponseWriter, *http.Request, error)
 
 type Proxy struct {
 	oidcRequestAuther     *bearertoken.Authenticator
-	tokenAuther           authenticator.Token
+	tokenAuthenticator    authenticator.Token
 	tokenReviewer         *tokenreview.TokenReview
 	subjectAccessReviewer *subjectaccessreview.SubjectAccessReview
 	secureServingInfo     *server.SecureServingInfo
@@ -67,30 +67,84 @@ type Proxy struct {
 	handleError errorHandlerFn
 }
 
-func New(restConfig *rest.Config,
-	tokenAuther authenticator.Token,
-	auditOptions *options.AuditOptions,
-	tokenReviewer *tokenreview.TokenReview,
-	subjectAccessReviewer *subjectaccessreview.SubjectAccessReview,
-	ssinfo *server.SecureServingInfo,
-	config *Config) (*Proxy, error) {
+// Dependencies bundles the collaborators a Proxy needs. Using a named struct
+// keeps call sites self-documenting and lets New validate required
+// dependencies up front rather than failing on the first request.
+//
+// Ownership: New takes ownership of the Config value (it copies it, including
+// the ExtraUserHeaders map, so later mutation of the caller's Config does not
+// change proxy behavior). The remaining pointers are collaborators the Proxy
+// borrows for its lifetime; it does not close or mutate them. The Proxy creates
+// and owns its auditor and shutdown hooks internally.
+type Dependencies struct {
+	RestConfig            *rest.Config
+	TokenAuthenticator    authenticator.Token
+	AuditOptions          *options.AuditOptions
+	TokenReviewer         *tokenreview.TokenReview
+	SubjectAccessReviewer *subjectaccessreview.SubjectAccessReview
+	SecureServingInfo     *server.SecureServingInfo
+	Config                *Config
+}
 
-	auditor, err := audit.New(auditOptions, config.ExternalAddress, ssinfo)
+// New validates deps and constructs a Proxy. Invalid configurations fail here,
+// at construction, rather than on the first request.
+func New(deps Dependencies) (*Proxy, error) {
+	if deps.RestConfig == nil {
+		return nil, errors.New("proxy: RestConfig is required")
+	}
+	if deps.TokenAuthenticator == nil {
+		return nil, errors.New("proxy: TokenAuthenticator is required")
+	}
+	if deps.SubjectAccessReviewer == nil {
+		return nil, errors.New("proxy: SubjectAccessReviewer is required")
+	}
+	if deps.SecureServingInfo == nil {
+		return nil, errors.New("proxy: SecureServingInfo is required")
+	}
+	if deps.Config == nil {
+		return nil, errors.New("proxy: Config is required")
+	}
+	// Reject inconsistent combinations: token-review handling has no reviewer to
+	// call, so enabling it without one can never work.
+	if deps.Config.TokenReview && deps.TokenReviewer == nil {
+		return nil, errors.New("proxy: TokenReview enabled but no TokenReviewer provided")
+	}
+
+	// Copy the Config and its mutable map at the construction boundary so that
+	// mutating the caller's Config (or the map it shares) after New cannot alter
+	// proxy behavior.
+	cfg := *deps.Config
+	cfg.ExtraUserHeaders = cloneHeaderMap(deps.Config.ExtraUserHeaders)
+
+	auditor, err := audit.New(deps.AuditOptions, cfg.ExternalAddress, deps.SecureServingInfo)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Proxy{
-		restConfig:            restConfig,
+		restConfig:            deps.RestConfig,
 		hooks:                 hooks.New(),
-		tokenReviewer:         tokenReviewer,
-		subjectAccessReviewer: subjectAccessReviewer,
-		secureServingInfo:     ssinfo,
-		config:                config,
-		oidcRequestAuther:     bearertoken.New(tokenAuther),
-		tokenAuther:           tokenAuther,
+		tokenReviewer:         deps.TokenReviewer,
+		subjectAccessReviewer: deps.SubjectAccessReviewer,
+		secureServingInfo:     deps.SecureServingInfo,
+		config:                &cfg,
+		oidcRequestAuther:     bearertoken.New(deps.TokenAuthenticator),
+		tokenAuthenticator:    deps.TokenAuthenticator,
 		auditor:               auditor,
 	}, nil
+}
+
+// cloneHeaderMap returns a deep copy of a header map so the Proxy never shares
+// mutable state with its caller. A nil input yields nil.
+func cloneHeaderMap(in map[string][]string) map[string][]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string][]string, len(in))
+	for k, vs := range in {
+		out[k] = append([]string(nil), vs...)
+	}
+	return out
 }
 
 func (p *Proxy) Run(stopCh <-chan struct{}) (<-chan struct{}, <-chan struct{}, error) {
@@ -243,7 +297,7 @@ func (p *Proxy) roundTripperForRestConfig(config *rest.Config) (http.RoundTrippe
 
 // Return the proxy OIDC token authenticator
 func (p *Proxy) OIDCTokenAuthenticator() authenticator.Token {
-	return p.tokenAuther
+	return p.tokenAuthenticator
 }
 
 func (p *Proxy) RunPreShutdownHooks() error {


### PR DESCRIPTION
## Code quality: lifecycle & ownership

Part of Epic #46. Stdlib-only (no `go.mod` change); `-race`-clean; composes with the sibling PRs.

- **#54** — pre-shutdown hooks no longer run under the registry mutex: snapshot under the lock, release, then invoke lock-free (deterministic order, aggregated `%w` errors, continue-on-error).
- **#53** — the readiness server has an explicit lifecycle: an owned `probe.Server` (`NewServer`/`Start`/`Shutdown`/`Wait`) — synchronous bind, background serve, bounded graceful shutdown on context cancel; `Check` no longer calls the authenticator while holding its lock. Wired through `run.go`.
- **#57** — `proxy.New(Dependencies)` replaces the 7-positional-arg constructor: required deps validated, `Config` deep-copied at the boundary, ownership documented.
- **#58** — focused lifecycle/boundary tests (hook-mutex regression with timeouts, readiness serve→cancel→shutdown + goroutine-leak check, lock-free `Check` concurrency proof, constructor validation).

Behaviour preserved (same hooks/readiness decisions; graceful shutdown is additive).

Closes #53
Closes #54
Closes #57
Closes #58
