### PR TITLE
feat(proxy): trusted-proxy & client-IP semantics (#56)

### DIFF
--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -23,6 +23,8 @@ type KubeOIDCProxyOptions struct {
 
 	ExtraHeaderOptions ExtraHeaderOptions
 	TokenPassthrough   TokenPassthroughOptions
+
+	TrustedProxies []string
 }
 
 type TokenPassthroughOptions struct {
@@ -67,6 +69,16 @@ func (k *KubeOIDCProxyOptions) AddFlags(fs *pflag.FlagSet) *KubeOIDCProxyOptions
 			"calls for one request (not per-call), derived from the inbound request "+
 			"context so client cancellation still propagates. Must be greater than 0.")
 
+	fs.StringSliceVar(&k.TrustedProxies, "trusted-proxies", k.TrustedProxies,
+		"Comma-separated list of trusted proxy CIDRs (IPv4 or IPv6, e.g. "+
+			"'10.0.0.0/8,192.168.0.0/16'). X-Forwarded-For is honoured to resolve the "+
+			"client IP (used for the access log and the Impersonate-Extra-Remote-Client-IP "+
+			"header) ONLY when the immediate peer's address falls within one of these "+
+			"networks. When empty (the default) no proxy is trusted and the direct peer "+
+			"address is always used, so clients cannot spoof their IP via forwarded "+
+			"headers. Set this only to the addresses of proxies you operate in front of "+
+			"kube-oidc-proxy.")
+
 	k.TokenPassthrough.AddFlags(fs)
 	k.ExtraHeaderOptions.AddFlags(fs)
 
@@ -91,8 +103,9 @@ func (e *ExtraHeaderOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&e.EnableClientIPExtraUserHeader, "extra-user-header-client-ip",
 		e.EnableClientIPExtraUserHeader, "(Alpha) If enabled, proxied requests will "+
 			"include the extra user header 'Impersonate-Extra-Remote-Client-IP: "+
-			"<REMOTE_ADDR>' where <REMOTE_ADDR> will contain the remote address of "+
-			"the source of the request.")
+			"<CLIENT_IP>' where <CLIENT_IP> is the resolved client IP of the request. "+
+			"By default this is the direct peer address; X-Forwarded-For is only "+
+			"honoured when the peer is within a --trusted-proxies network.")
 
 	fs.Var(flags.NewStringToStringSliceValue(&e.ExtraUserHeaders), "extra-user-headers",
 		"(Alpha) A list of key value pairs of extra user headers to pass with "+

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -102,6 +102,8 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 
 				ExtraUserHeaders:                opts.App.ExtraHeaderOptions.ExtraUserHeaders,
 				ExtraUserHeadersClientIPEnabled: opts.App.ExtraHeaderOptions.EnableClientIPExtraUserHeader,
+
+				TrustedProxies: opts.App.TrustedProxies,
 			}
 
 			// Setup Subject Access Review

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,8 +43,9 @@ All ignored when `--authentication-config` is set.
 | `--token-passthrough` | `false` | (Alpha) Bearer tokens that fail OIDC validation are tried via TokenReview and, if valid, forwarded as-is with no impersonation. |
 | `--token-passthrough-audiences` | — | (Alpha) Allowed audiences for passthrough tokens. |
 | `--disable-impersonation` | `false` | (Alpha) Forward authenticated requests as-is, without impersonation. |
-| `--extra-user-header-client-ip` | `false` | (Alpha) Add `Impersonate-Extra-Remote-Client-IP` with the request's remote address. |
+| `--extra-user-header-client-ip` | `false` | (Alpha) Add `Impersonate-Extra-Remote-Client-IP` with the request's resolved client IP. |
 | `--extra-user-headers` | — | (Alpha) Extra `key=value` user headers to add to the impersonated request. |
+| `--trusted-proxies` | — | Comma-separated trusted proxy CIDRs (IPv4/IPv6). `X-Forwarded-For` is honoured for client-IP resolution only when the immediate peer is within one of these networks. Empty (default) trusts no proxy. See [Trusted proxies and client IP](#trusted-proxies-and-client-ip). |
 | `--subject-access-review-timeout` | `5s` | Timeout for authorizing inbound impersonation via `SubjectAccessReview` — a single shared budget across all SAR calls for one request (not per-call). Must be greater than 0. |
 
 ### Serving / TLS & misc
@@ -137,9 +138,10 @@ details to the target server. Two options are supported.
 --extra-user-header-client-ip
 ```
 
-Proxied requests then carry `Impersonate-Extra-Remote-Client-Ip: <REMOTE_ADDR>`.
-If `X-Forwarded-For` is present, its value is used instead (the source IP may
-otherwise be a proxy, not the real client).
+Proxied requests then carry `Impersonate-Extra-Remote-Client-Ip: <CLIENT_IP>`,
+where `<CLIENT_IP>` is the [resolved client IP](#trusted-proxies-and-client-ip).
+By default this is the direct peer address; `X-Forwarded-For` is only consulted
+when the peer is a configured trusted proxy.
 
 **Arbitrary headers** — comma-separated `key=value` pairs; a key may repeat to
 carry multiple values:
@@ -154,6 +156,53 @@ Proxied requests then carry:
 Impersonate-Extra-Key1: foo,bar
 Impersonate-Extra-Key2: foo
 ```
+
+## Trusted proxies and client IP
+
+The proxy resolves a single **client IP** per request and uses it consistently
+for both the per-request access log (`src_ip`) and, when
+`--extra-user-header-client-ip` is set, the `Impersonate-Extra-Remote-Client-IP`
+header forwarded to the API server.
+
+### Resolution rules
+
+- The **direct peer** (`RemoteAddr`, the TCP source of the connection) is always
+  authoritative.
+- `X-Forwarded-For` is honoured **only when the immediate peer's address falls
+  within a configured `--trusted-proxies` CIDR**. The chain is then walked from
+  the hop nearest the proxy toward the origin, trusted hops are skipped, and the
+  first untrusted address is taken as the client.
+- If the peer is not trusted, if no proxies are configured, or if a forwarded
+  entry is malformed, the direct peer is used.
+- Only `X-Forwarded-For` is parsed. The RFC 7239 `Forwarded` header is **not**
+  honoured.
+
+### Default: trust nothing
+
+`--trusted-proxies` defaults to empty. With no trusted proxies configured, the
+proxy **never** trusts `X-Forwarded-For` and always uses the direct peer as the
+client IP. This is the safe default.
+
+> [!WARNING]
+> `X-Forwarded-For` is a client-supplied header. If the proxy honoured it
+> unconditionally, any client connecting directly could forge its own client IP —
+> poisoning audit logs and the `Remote-Client-IP` impersonation extra. Configure
+> `--trusted-proxies` **only** with the addresses of load balancers or reverse
+> proxies you operate directly in front of `kube-oidc-proxy`. Never include
+> untrusted or client-reachable networks.
+
+### Deployment topology
+
+- **No proxy in front** (clients reach the proxy directly): leave
+  `--trusted-proxies` empty. The direct peer is the client.
+- **Behind a load balancer / ingress that sets `X-Forwarded-For`**: set
+  `--trusted-proxies` to the CIDR(s) the proxy sees those hops arriving from
+  (for example the pod/Service network or the LB's egress range), so the real
+  client IP is recovered from the forwarded chain. Example:
+
+  ```
+  --trusted-proxies=10.0.0.0/8,192.168.0.0/16,fd00::/8
+  ```
 
 ## Auditing
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,6 +22,11 @@ Security, troubleshooting, and testing the proxy locally.
 - **Use token passthrough deliberately.** `--token-passthrough` forwards
   non-OIDC tokens after a TokenReview; only enable it (and constrain
   `--token-passthrough-audiences`) when you understand the tokens involved.
+- **Configure trusted proxies before trusting forwarded IPs.** By default the
+  proxy ignores `X-Forwarded-For` and uses the direct peer as the client IP, so
+  clients cannot forge the logged or impersonated client IP. Set
+  `--trusted-proxies` only to CIDRs of proxies you run directly in front of it —
+  see [Trusted proxies and client IP](./configuration.md#trusted-proxies-and-client-ip).
 
 ## Troubleshooting
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/heptiolabs/healthcheck v0.0.0-20211123025425-613501dd5deb
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.40.0
-	github.com/sebest/xff v0.0.0-20210106013422-671bd2870b3a
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,6 @@ github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05Zp
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sebest/xff v0.0.0-20210106013422-671bd2870b3a h1:iLcLb5Fwwz7g/DLK89F+uQBDeAhHhwdzB5fSlVdhGcM=
-github.com/sebest/xff v0.0.0-20210106013422-671bd2870b3a/go.mod h1:wozgYq9WEBQBaIJe4YZ0qTSFAMxmcwBhQH0fO0R34Z0=
 github.com/sergi/go-diff v1.4.0 h1:n/SP9D5ad1fORl+llWyN+D6qoUETXNZARKjyY2/KVCw=
 github.com/sergi/go-diff v1.4.0/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=

--- a/pkg/proxy/context/context.go
+++ b/pkg/proxy/context/context.go
@@ -1,10 +1,31 @@
 // Copyright Jetstack Ltd. See LICENSE for details.
+
+// Package context stores request-scoped values on the http.Request context and
+// owns the proxy's client-IP resolution.
+//
+// # Client-IP and trusted-proxy semantics (see issue #56)
+//
+// The immediate peer (req.RemoteAddr) is always authoritative for the client
+// IP. X-Forwarded-For is honoured ONLY to the extent that the hops closest to
+// the proxy are themselves within a configured trusted-proxy network: the chain
+// is walked right-to-left, trusted hops are skipped, and the first untrusted
+// address is taken as the client. When no trusted proxies are configured (the
+// default), forwarded headers are never trusted and the direct peer is used, so
+// an untrusted client cannot spoof its resolved IP. Configure trusted networks
+// with SetTrustedProxies.
+//
+// Only X-Forwarded-For is parsed; the RFC 7239 Forwarded header is not honoured.
+// On a malformed forwarded hop, or when the entire chain is itself trusted, the
+// direct peer is returned. This contract is intentionally identical to the
+// resolver in the logging package so that the audit-log client IP and the
+// Remote-Client-IP impersonation extra never disagree.
 package context
 
 import (
+	"net"
 	"net/http"
+	"strings"
 
-	"github.com/sebest/xff"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/transport"
@@ -25,6 +46,19 @@ const (
 	// bearerTokenKey is the context key for the client address.
 	clientAddressKey
 )
+
+// trustedProxies holds the networks whose forwarded headers are honoured when
+// resolving the client IP. Empty (the default) means no proxy is trusted, so
+// the direct peer is always used.
+var trustedProxies []*net.IPNet
+
+// SetTrustedProxies configures the trusted-proxy networks used when resolving
+// the client IP from forwarded headers. Passing nil (the default) disables
+// forwarded-header trust entirely. Intended to be called once at startup before
+// requests are served.
+func SetTrustedProxies(nets []*net.IPNet) {
+	trustedProxies = nets
+}
 
 type ImpersonationRequest struct {
 	ImpersonationConfig *transport.ImpersonationConfig
@@ -69,17 +103,91 @@ func BearerToken(req *http.Request) string {
 	return token
 }
 
-// RemoteAddress will attempt to return the source client address if available
-// in the request context. If it is not, it will be gathered from the request
-// and entered into the context.
+// RemoteAddr returns the authoritative source client address for the request.
+// The value is resolved once (honouring the configured trusted proxies) and
+// cached on the request context so repeated calls within a request are
+// consistent and cheap.
 func RemoteAddr(req *http.Request) (*http.Request, string) {
 	ctx := req.Context()
 
 	clientAddress, ok := ctx.Value(clientAddressKey).(string)
 	if !ok {
-		clientAddress = xff.GetRemoteAddr(req)
+		clientAddress = ResolveClientIP(req.RemoteAddr, forwardedFor(req.Header), trustedProxies)
 		req = req.WithContext(request.WithValue(ctx, clientAddressKey, clientAddress))
 	}
 
 	return req, clientAddress
+}
+
+// forwardedFor returns the raw X-Forwarded-For header value.
+func forwardedFor(headers http.Header) string {
+	return headers.Get("X-Forwarded-For")
+}
+
+// ResolveClientIP returns the authoritative client IP for a request given the
+// peer address, the X-Forwarded-For chain, and the set of trusted proxy
+// networks. See the package documentation for the full contract. It is
+// IPv4/IPv6 aware and ignores malformed forwarded entries.
+//
+// This contract is intentionally identical to resolveClientIP in
+// pkg/proxy/logging/accesslog.go so the audit-log src_ip and the
+// Remote-Client-IP impersonation extra never disagree; the two are duplicated
+// only because of package/lane boundaries and MUST be kept in sync until they
+// are unified into one shared resolver.
+func ResolveClientIP(remoteAddr, xff string, trusted []*net.IPNet) string {
+	peer := peerHost(remoteAddr)
+
+	// Without trust, or when the peer itself is not a trusted proxy, forwarded
+	// headers are ignored entirely: the direct peer is the client.
+	if xff == "" || !ipInNetworks(peer, trusted) {
+		return peer
+	}
+
+	// The peer is a trusted proxy. Walk the forwarded chain from the hop nearest
+	// the proxy toward the origin, skipping trusted hops, and take the first
+	// untrusted address as the client.
+	hops := strings.Split(xff, ",")
+	for i := len(hops) - 1; i >= 0; i-- {
+		ip := strings.TrimSpace(hops[i])
+		if net.ParseIP(ip) == nil {
+			// Malformed hop: cannot trust anything further left through it.
+			return peer
+		}
+		if ipInNetworks(ip, trusted) {
+			continue
+		}
+		return ip
+	}
+
+	return peer
+}
+
+// peerHost extracts the host portion of a host:port peer address, IPv6-safe. It
+// falls back to the raw value when the address has no port (some call sites
+// build requests without a RemoteAddr).
+func peerHost(remoteAddr string) string {
+	if remoteAddr == "" {
+		return ""
+	}
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
+	}
+	return remoteAddr
+}
+
+// ipInNetworks reports whether ip parses and falls within any of the networks.
+func ipInNetworks(ip string, networks []*net.IPNet) bool {
+	if len(networks) == 0 {
+		return false
+	}
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return false
+	}
+	for _, n := range networks {
+		if n != nil && n.Contains(parsed) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/proxy/context/context_test.go
+++ b/pkg/proxy/context/context_test.go
@@ -1,0 +1,211 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package context
+
+import (
+	"net"
+	"net/http"
+	"testing"
+)
+
+// mustCIDRs parses CIDR strings into networks, failing the test on error.
+func mustCIDRs(t *testing.T, cidrs ...string) []*net.IPNet {
+	t.Helper()
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			t.Fatalf("mustCIDRs: parse %q: %v", c, err)
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}
+
+func TestResolveClientIP(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		remoteAddr string
+		xff        string
+		trusted    []*net.IPNet
+		want       string
+	}{
+		// Security core: the default (no trusted proxies) never honours XFF, so a
+		// client cannot spoof its resolved IP.
+		"default trusts nothing, ignores XFF": {
+			remoteAddr: "203.0.113.7:5555",
+			xff:        "1.2.3.4",
+			trusted:    nil,
+			want:       "203.0.113.7",
+		},
+		"untrusted peer cannot spoof via XFF": {
+			remoteAddr: "203.0.113.7:5555",
+			xff:        "1.2.3.4",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "203.0.113.7",
+		},
+		"untrusted peer, multi-hop XFF ignored": {
+			remoteAddr: "203.0.113.7:5555",
+			xff:        "1.2.3.4, 5.6.7.8, 9.10.11.12",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "203.0.113.7",
+		},
+
+		// Trusted peer: XFF is honoured.
+		"trusted peer, single hop honoured": {
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "203.0.113.7",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "203.0.113.7",
+		},
+		"trusted peer, multi-hop returns first untrusted from right": {
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "203.0.113.7, 10.0.0.9, 10.0.0.8",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "203.0.113.7",
+		},
+		"trusted peer, untrusted hop nearest proxy wins": {
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "9.9.9.9, 8.8.8.8, 203.0.113.7",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "203.0.113.7",
+		},
+		"trusted peer, whole chain trusted falls back to peer": {
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "10.0.0.2, 10.0.0.3",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "10.0.0.1",
+		},
+		"trusted peer, empty XFF returns peer": {
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "10.0.0.1",
+		},
+
+		// Malformed values: a malformed hop stops the walk and falls back to peer,
+		// so garbage cannot be promoted to a client IP.
+		"trusted peer, malformed hop falls back to peer": {
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "not-an-ip",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "10.0.0.1",
+		},
+		"trusted peer, malformed hop between trusted stops walk": {
+			remoteAddr: "10.0.0.1:5555",
+			xff:        "203.0.113.7, garbage, 10.0.0.9",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "10.0.0.1",
+		},
+
+		// IPv6.
+		"IPv6 trusted peer honours IPv6 XFF": {
+			remoteAddr: "[fd00::1]:5555",
+			xff:        "2001:db8::42",
+			trusted:    mustCIDRs(t, "fd00::/8"),
+			want:       "2001:db8::42",
+		},
+		"IPv6 untrusted peer ignores XFF": {
+			remoteAddr: "[2001:db8::99]:5555",
+			xff:        "2001:db8::42",
+			trusted:    mustCIDRs(t, "fd00::/8"),
+			want:       "2001:db8::99",
+		},
+		"IPv6 trusted peer, mixed chain returns first untrusted from right": {
+			remoteAddr: "[fd00::1]:5555",
+			xff:        "203.0.113.7, fd00::2",
+			trusted:    mustCIDRs(t, "fd00::/8"),
+			want:       "203.0.113.7",
+		},
+
+		// Peer address edge cases.
+		"peer without port falls through to raw value": {
+			remoteAddr: "203.0.113.7",
+			xff:        "1.2.3.4",
+			trusted:    mustCIDRs(t, "10.0.0.0/8"),
+			want:       "203.0.113.7",
+		},
+		"empty remote addr yields empty": {
+			remoteAddr: "",
+			xff:        "",
+			trusted:    nil,
+			want:       "",
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got := ResolveClientIP(tc.remoteAddr, tc.xff, tc.trusted)
+			if got != tc.want {
+				t.Errorf("ResolveClientIP(%q, %q) = %q, want %q",
+					tc.remoteAddr, tc.xff, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRemoteAddr_DefaultTrustsNothing verifies the request-level entry point
+// uses the direct peer by default and does not honour a forged XFF header.
+func TestRemoteAddr_DefaultTrustsNothing(t *testing.T) {
+	SetTrustedProxies(nil)
+	t.Cleanup(func() { SetTrustedProxies(nil) })
+
+	req := &http.Request{
+		RemoteAddr: "203.0.113.7:5555",
+		Header:     http.Header{"X-Forwarded-For": []string{"1.2.3.4"}},
+	}
+
+	_, got := RemoteAddr(req)
+	if got != "203.0.113.7" {
+		t.Fatalf("RemoteAddr = %q, want %q", got, "203.0.113.7")
+	}
+}
+
+// TestRemoteAddr_TrustedPeerHonoursXFF verifies XFF is honoured when the peer is
+// a configured trusted proxy. The returned value is exactly what handlers.go
+// writes into extra[UserHeaderClientIPKey] (the Remote-Client-IP impersonation
+// extra), so this also pins the impersonation-extra client IP.
+func TestRemoteAddr_TrustedPeerHonoursXFF(t *testing.T) {
+	SetTrustedProxies(mustCIDRs(t, "10.0.0.0/8"))
+	t.Cleanup(func() { SetTrustedProxies(nil) })
+
+	req := &http.Request{
+		RemoteAddr: "10.0.0.1:5555",
+		Header:     http.Header{"X-Forwarded-For": []string{"203.0.113.7"}},
+	}
+
+	_, got := RemoteAddr(req)
+	if got != "203.0.113.7" {
+		t.Fatalf("RemoteAddr = %q, want %q", got, "203.0.113.7")
+	}
+}
+
+// TestRemoteAddr_CachesResolvedValue verifies the resolved address is cached on
+// the request context: a second call returns the cached value even if the
+// header or trusted set later changes, keeping the value stable within a
+// request.
+func TestRemoteAddr_CachesResolvedValue(t *testing.T) {
+	SetTrustedProxies(nil)
+	t.Cleanup(func() { SetTrustedProxies(nil) })
+
+	req := &http.Request{
+		RemoteAddr: "203.0.113.7:5555",
+		Header:     http.Header{"X-Forwarded-For": []string{"1.2.3.4"}},
+	}
+
+	req, first := RemoteAddr(req)
+	if first != "203.0.113.7" {
+		t.Fatalf("first RemoteAddr = %q, want %q", first, "203.0.113.7")
+	}
+
+	// Change trust config and header; the cached value must not change.
+	SetTrustedProxies(mustCIDRs(t, "0.0.0.0/0"))
+	req.Header.Set("X-Forwarded-For", "5.6.7.8")
+
+	_, second := RemoteAddr(req)
+	if second != first {
+		t.Errorf("cached RemoteAddr changed: got %q, want %q", second, first)
+	}
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -4,9 +4,11 @@ package proxy
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -45,6 +47,12 @@ type Config struct {
 
 	ExtraUserHeaders                map[string][]string
 	ExtraUserHeadersClientIPEnabled bool
+
+	// TrustedProxies is the list of CIDRs (IPv4 or IPv6) whose immediate peers
+	// are trusted to set X-Forwarded-For. It is validated and parsed at
+	// construction. Empty (the default) trusts no proxy, so the direct peer is
+	// always used as the client IP and forwarded headers cannot be spoofed.
+	TrustedProxies []string
 }
 
 type errorHandlerFn func(http.ResponseWriter, *http.Request, error)
@@ -62,6 +70,10 @@ type Proxy struct {
 	noAuthClientTransport http.RoundTripper
 
 	config *Config
+
+	// trustedProxies is the parsed form of config.TrustedProxies, resolved once
+	// at construction and applied to the client-IP resolvers when Run starts.
+	trustedProxies []*net.IPNet
 
 	hooks       *hooks.Hooks
 	handleError errorHandlerFn
@@ -115,6 +127,14 @@ func New(deps Dependencies) (*Proxy, error) {
 	// proxy behavior.
 	cfg := *deps.Config
 	cfg.ExtraUserHeaders = cloneHeaderMap(deps.Config.ExtraUserHeaders)
+	cfg.TrustedProxies = append([]string(nil), deps.Config.TrustedProxies...)
+
+	// Validate trusted-proxy CIDRs up front so a bad configuration fails at
+	// construction rather than silently trusting nothing at request time.
+	trustedProxies, err := parseTrustedProxies(cfg.TrustedProxies)
+	if err != nil {
+		return nil, err
+	}
 
 	auditor, err := audit.New(deps.AuditOptions, cfg.ExternalAddress, deps.SecureServingInfo)
 	if err != nil {
@@ -128,10 +148,34 @@ func New(deps Dependencies) (*Proxy, error) {
 		subjectAccessReviewer: deps.SubjectAccessReviewer,
 		secureServingInfo:     deps.SecureServingInfo,
 		config:                &cfg,
+		trustedProxies:        trustedProxies,
 		oidcRequestAuther:     bearertoken.New(deps.TokenAuthenticator),
 		tokenAuthenticator:    deps.TokenAuthenticator,
 		auditor:               auditor,
 	}, nil
+}
+
+// parseTrustedProxies parses a list of CIDR strings (IPv4 or IPv6) into
+// networks. Empty or whitespace-only entries are rejected so a malformed flag
+// value cannot be silently ignored. A nil/empty input yields a nil slice,
+// meaning no proxy is trusted.
+func parseTrustedProxies(cidrs []string) ([]*net.IPNet, error) {
+	if len(cidrs) == 0 {
+		return nil, nil
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			return nil, fmt.Errorf("proxy: empty trusted-proxy CIDR")
+		}
+		_, network, err := net.ParseCIDR(c)
+		if err != nil {
+			return nil, fmt.Errorf("proxy: invalid trusted-proxy CIDR %q: %w", c, err)
+		}
+		nets = append(nets, network)
+	}
+	return nets, nil
 }
 
 // cloneHeaderMap returns a deep copy of a header map so the Proxy never shares
@@ -148,6 +192,13 @@ func cloneHeaderMap(in map[string][]string) map[string][]string {
 }
 
 func (p *Proxy) Run(stopCh <-chan struct{}) (<-chan struct{}, <-chan struct{}, error) {
+	// Apply the trusted-proxy networks to both client-IP resolvers so the audit
+	// log's src_ip and the Remote-Client-IP impersonation extra resolve
+	// identically. Done here (rather than in New) to keep the package-global
+	// setters out of construction-time unit tests.
+	context.SetTrustedProxies(p.trustedProxies)
+	logging.SetTrustedProxies(p.trustedProxies)
+
 	// standard round tripper for proxy to API Server
 	clientRT, err := p.roundTripperForRestConfig(p.restConfig)
 	if err != nil {

--- a/pkg/proxy/trustedproxies_test.go
+++ b/pkg/proxy/trustedproxies_test.go
@@ -1,0 +1,69 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package proxy
+
+import (
+	"testing"
+)
+
+func TestParseTrustedProxies(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		in      []string
+		wantLen int
+		wantErr bool
+	}{
+		"nil is no trust": {
+			in:      nil,
+			wantLen: 0,
+		},
+		"empty slice is no trust": {
+			in:      []string{},
+			wantLen: 0,
+		},
+		"valid IPv4 CIDRs": {
+			in:      []string{"10.0.0.0/8", "192.168.0.0/16"},
+			wantLen: 2,
+		},
+		"valid IPv6 CIDR": {
+			in:      []string{"fd00::/8"},
+			wantLen: 1,
+		},
+		"whitespace is trimmed": {
+			in:      []string{" 10.0.0.0/8 "},
+			wantLen: 1,
+		},
+		"bare IP without mask is rejected": {
+			in:      []string{"10.0.0.1"},
+			wantErr: true,
+		},
+		"garbage is rejected": {
+			in:      []string{"not-a-cidr"},
+			wantErr: true,
+		},
+		"empty entry is rejected": {
+			in:      []string{"10.0.0.0/8", ""},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseTrustedProxies(tc.in)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("parseTrustedProxies(%v) = nil error, want error", tc.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTrustedProxies(%v) unexpected error: %v", tc.in, err)
+			}
+			if len(got) != tc.wantLen {
+				t.Errorf("parseTrustedProxies(%v) len = %d, want %d", tc.in, len(got), tc.wantLen)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Define trusted-proxy & client-IP semantics (#56)

Part of Epic #46. Closes the client-IP spoofing gap left by the implicit `sebest/xff` policy.

- **Project-owned resolver** replaces `sebest/xff` (dependency removed). The direct peer (`req.RemoteAddr`) is authoritative; `X-Forwarded-For` is honoured **only when the immediate peer is within a configured `--trusted-proxies` CIDR** (chain walked right-to-left, first untrusted address wins; malformed/fully-trusted → peer). **Default: trust nothing.**
- **`--trusted-proxies`** flag (comma-separated CIDRs, validated at startup) → `proxy.Config.TrustedProxies` → applied to both the `context` resolver and the existing `logging.SetTrustedProxies`, so the access-log `src_ip` and the `Remote-Client-IP` impersonation extra stay consistent and spoof-safe.
- Docs: trusted-proxy configuration + spoofing risk added to `docs/`.
- Tests: spoof (single/multi-hop), trusted-hop honoured, malformed, IPv4, IPv6 — `-race` clean.

**Scope note:** the Kubernetes apiserver *audit* `sourceIPs` are derived internally by the apiserver, outside this resolver — unchanged here (would need apiserver plumbing). The proxy's own access log is spoof-safe.

Closes #56
