### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+# OpenSSF Scorecard — supply-chain security analysis.
+# Publishes results so the OpenSSF Scorecard badge in the README is populated.
+name: scorecard
+
+on:
+  # Re-run when branch protection changes (a Scorecard signal).
+  branch_protection_rule:
+  # Weekly, so results stay fresh without repo activity.
+  schedule:
+    - cron: "27 6 * * 1"
+  push:
+    branches:
+      - main
+
+# Read-only by default; the job below elevates only what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF result to code scanning
+      id-token: write # publish results to the OpenSSF API (for the badge)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF Scorecard API — required for the badge and
+          # the public results viewer. Only runs on non-fork pushes.
+          publish_results: true
+
+      - name: Upload SARIF artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Implements the [ossf/scorecard-action](https://github.com/marketplace/actions/ossf-scorecard-action) supply-chain security analysis.

- Runs weekly + on push to `main` + on branch-protection changes; `permissions: read-all` with the job elevating only `security-events: write` and `id-token: write`.
- **`publish_results: true`** publishes to the OpenSSF Scorecard API, which populates the **Scorecard badge already in the README** (currently shows "no data") and the public results viewer.
- Results also uploaded to GitHub code scanning (SARIF) + retained as an artifact.
- All actions **SHA-pinned** (checkout, scorecard-action v2.4.4, upload-artifact, codeql-action v3) per the repo convention — which Scorecard itself rewards.

Note: Scorecard triggers on push/schedule, not `pull_request`, so it first runs after this merges to `main`; the badge populates on that run.