### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,59 @@
+name: Bug report
+description: Report a problem with kube-oidc-proxy
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report.
+
+        **Do not use this form for security vulnerabilities.** Report those
+        privately — see [SECURITY.md](https://github.com/RafPe/kube-oidc-proxy/blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected to happen instead.
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: The smallest set of steps that reliably triggers the issue.
+      placeholder: |
+        1. Deploy with values '...'
+        2. Send request '...'
+        3. See error
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version / image tag
+      placeholder: ghcr.io/rafpe/kube-oidc-proxy:1.1.0
+    validations:
+      required: true
+  - type: input
+    id: k8s
+    attributes:
+      label: Kubernetes version & provider
+      placeholder: "EKS 1.30 / kind 0.23 / ..."
+    validations:
+      required: true
+  - type: dropdown
+    id: mode
+    attributes:
+      label: Authentication mode
+      options:
+        - single-issuer (--oidc-issuer-url)
+        - multi-issuer (--authentication-config)
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs and configuration
+      description: Proxy logs, flags/values, and AuthenticationConfiguration (redact tokens and secrets).
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/RafPe/kube-oidc-proxy/security/advisories/new
+    about: Report security issues privately via a GitHub Security Advisory — please do not open a public issue.
+  - name: Documentation
+    url: https://github.com/RafPe/kube-oidc-proxy/tree/main/docs
+    about: Configuration, multi-issuer, architecture and operations guides.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Suggest an enhancement or new capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do, and what makes it hard today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would you like to see? Flags, chart values, behaviour changes, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you evaluated and why they fall short.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!-- Thanks for contributing! Keep the change focused and the description short. -->
+
+## What & why
+
+<!-- What does this change, and why? Link issues, e.g. "Closes #123". -->
+
+## Checklist
+
+- [ ] Tests added or updated where it makes sense
+- [ ] `go test ./cmd/... ./pkg/...` passes (and `make e2e` if behaviour changed)
+- [ ] Docs / chart values updated if flags or behaviour changed
+- [ ] Commits are focused, with no unrelated changes


### PR DESCRIPTION
Adds contributor-facing templates so incoming reports and PRs arrive structured.

## What
- `.github/ISSUE_TEMPLATE/bug_report.yml` — issue form: what happened, repro, version/image tag, k8s version, auth mode (single/multi-issuer), logs.
- `.github/ISSUE_TEMPLATE/feature_request.yml` — problem/use-case, proposal, alternatives.
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; routes **security reports to private GitHub Security Advisories** (not public issues) and links the docs.
- `.github/PULL_REQUEST_TEMPLATE.md` — short what/why + test/docs checklist.

## Notes
- Security contact link points at the private advisory flow, consistent with `SECURITY.md` (#79).
- Discussions link omitted (Discussions not enabled on the repo).