### PR TITLE
chore(chart): prepare Artifact Hub listing

### DIFF
--- a/chart/kube-oidc-proxy/Chart.yaml
+++ b/chart/kube-oidc-proxy/Chart.yaml
@@ -6,7 +6,7 @@ description: >-
   Supports single-issuer (--oidc-* flags) and multi-issuer
   (AuthenticationConfiguration) modes.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.1.0"
 home: https://github.com/rafpe/kube-oidc-proxy
 sources:
@@ -14,3 +14,19 @@ sources:
 maintainers:
   - name: RafPe
     url: https://github.com/RafPe
+annotations:
+  # Metadata consumed by Artifact Hub (https://artifacthub.io) to enrich the
+  # chart listing. See docs/artifact-hub.md for the one-time repo registration.
+  artifacthub.io/category: security
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/links: |
+    - name: Source
+      url: https://github.com/RafPe/kube-oidc-proxy
+    - name: Documentation
+      url: https://github.com/RafPe/kube-oidc-proxy/tree/main/docs
+    - name: Security policy
+      url: https://github.com/RafPe/kube-oidc-proxy/blob/main/SECURITY.md
+  artifacthub.io/images: |
+    - name: kube-oidc-proxy
+      image: ghcr.io/rafpe/kube-oidc-proxy:1.1.0

--- a/chart/kube-oidc-proxy/Chart.yaml
+++ b/chart/kube-oidc-proxy/Chart.yaml
@@ -6,7 +6,10 @@ description: >-
   Supports single-issuer (--oidc-* flags) and multi-issuer
   (AuthenticationConfiguration) modes.
 type: application
-version: 0.4.1
+# The chart and image share a single version. On a tagged release the
+# automation overrides both `version` and `appVersion` from the git tag
+# (vX.Y.Z); the values here are the development baseline.
+version: 1.1.0
 appVersion: "1.1.0"
 home: https://github.com/rafpe/kube-oidc-proxy
 sources:

--- a/chart/kube-oidc-proxy/artifacthub-repo.yml
+++ b/chart/kube-oidc-proxy/artifacthub-repo.yml
@@ -6,8 +6,8 @@
 #
 # Fill in `repositoryID` with the ID shown on the Artifact Hub control panel
 # after you add the repository, then push this file to the registry.
-repositoryID: REPLACE_WITH_ARTIFACT_HUB_REPOSITORY_ID
+repositoryID: 5d205049-3574-4871-8306-87e6930a3370
 owners:
   - name: RafPe
     # Must match the email on your Artifact Hub account.
-    email: rpieniaz@gmail.com
+    email: rafal@pieniazek.nl

--- a/chart/kube-oidc-proxy/artifacthub-repo.yml
+++ b/chart/kube-oidc-proxy/artifacthub-repo.yml
@@ -1,0 +1,13 @@
+# Artifact Hub repository metadata.
+#
+# This file claims ownership of the OCI Helm repository on Artifact Hub and
+# marks it as a "Verified Publisher". It is pushed ONCE to the OCI registry
+# (not on every chart release) — see docs/artifact-hub.md for the exact steps.
+#
+# Fill in `repositoryID` with the ID shown on the Artifact Hub control panel
+# after you add the repository, then push this file to the registry.
+repositoryID: REPLACE_WITH_ARTIFACT_HUB_REPOSITORY_ID
+owners:
+  - name: RafPe
+    # Must match the email on your Artifact Hub account.
+    email: rpieniaz@gmail.com

--- a/docs/artifact-hub.md
+++ b/docs/artifact-hub.md
@@ -1,0 +1,51 @@
+# Publishing on Artifact Hub
+
+[Artifact Hub](https://artifacthub.io) is where most Helm users discover charts.
+Listing `kube-oidc-proxy` there makes it installable and searchable beyond
+GitHub, and surfaces the cosign signature we already attach to every release.
+
+The chart is already prepared for it:
+
+- `chart/kube-oidc-proxy/Chart.yaml` carries `artifacthub.io/*` annotations
+  (category, license, links, images) that populate the listing.
+- `chart/kube-oidc-proxy/artifacthub-repo.yml` is the ownership file used to
+  claim the repository and become a Verified Publisher.
+- Releases are signed with cosign (keyless), which Artifact Hub detects and
+  displays automatically.
+
+Registration is a one-time manual step — it needs your Artifact Hub account.
+
+## One-time setup
+
+1. **Sign in** at <https://artifacthub.io> (GitHub sign-in works).
+
+2. **Add the repository** under *Control Panel → Repositories → Add*:
+   - **Kind:** `Helm charts`
+   - **Name:** `kube-oidc-proxy` (this becomes the URL slug)
+   - **URL:** `oci://ghcr.io/rafpe/charts/kube-oidc-proxy`
+
+3. **Copy the Repository ID** shown for the new repository and paste it into
+   `chart/kube-oidc-proxy/artifacthub-repo.yml` (replacing the placeholder).
+   Commit that change.
+
+4. **Publish the ownership metadata** to the OCI registry once, so Artifact Hub
+   can verify you own it (requires [`oras`](https://oras.land) and a GHCR login):
+
+   ```bash
+   echo "$GITHUB_TOKEN" | oras login ghcr.io -u <your-github-user> --password-stdin
+
+   oras push ghcr.io/rafpe/charts/kube-oidc-proxy:artifacthub.io \
+     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+     chart/kube-oidc-proxy/artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+   ```
+
+Artifact Hub re-indexes the repository within a few minutes and shows the
+chart, its annotations, and a "Verified Publisher" badge.
+
+## Keeping the listing fresh
+
+Nothing extra is needed per release. Artifact Hub polls the OCI repository and
+picks up new chart versions automatically. The `artifacthub.io/*` annotations in
+`Chart.yaml` travel with each packaged chart, so updating them there updates the
+listing on the next release. Bump the image reference in
+`artifacthub.io/images` whenever `appVersion` changes.


### PR DESCRIPTION
Prepares the Helm chart to be listed on [Artifact Hub](https://artifacthub.io) — the main discovery channel for Helm users.

## What
- **Chart.yaml annotations** — `artifacthub.io/{category,license,prerelease,links,images}` populate the listing (category *security*, license *Apache-2.0*, links to source/docs/security policy, the container image).
- **artifacthub-repo.yml** — ownership file to claim the OCI repo and become a Verified Publisher (repositoryID left as a placeholder for the one-time registration).
- **docs/artifact-hub.md** — step-by-step one-time registration (add `oci://ghcr.io/rafpe/charts/kube-oidc-proxy`, paste the repo ID, `oras push` the ownership file).
- **Chart 0.4.0 → 0.4.1** so the annotated metadata ships on the next `helm-release` dispatch.

## Notes
- `helm lint` passes (only the pre-existing 'icon recommended' info).
- Cosign signatures we already attach are auto-detected by Artifact Hub — no change needed.
- **Manual follow-up (yours):** register the repo on artifacthub.io, fill the repo ID, run the one-time `oras push`, then dispatch `helm-release` to publish 0.4.1.