### PR TITLE
ci: harden supply chain for OpenSSF Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  # Base images in the Dockerfiles (pinned by digest — keep the pins fresh).
+  - package-ecosystem: "docker"
+    directories:
+      - "/"
+      - "/test/tools/issuer"
+      - "/test/tools/fake-apiserver"
+      - "/test/tools/audit-webhook"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,43 @@
+name: codeql
+
+# Static analysis (SAST) for Go via GitHub CodeQL. Results appear under the
+# repository Security tab and satisfy the OpenSSF Scorecard SAST check.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "18 7 * * 2" # weekly, Tuesday 07:18 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: analyze (go)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload results to code scanning
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.26.x"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          languages: go
+          build-mode: autobuild
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          category: "/language:go"

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -12,6 +12,9 @@ on:
       - 'chart/kube-oidc-proxy/**'
       - '.github/workflows/helm.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-template:
     runs-on: ubuntu-latest

--- a/.github/workflows/oidc.yaml
+++ b/.github/workflows/oidc.yaml
@@ -1,17 +1,19 @@
 name: mint-oidc-token
 on: workflow_dispatch
 permissions:
-  id-token: write
+  contents: read
 jobs:
   mint:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # request an OIDC token from GitHub
     steps:
-    - uses: actions/github-script@v7
+    - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           const t = await core.getIDToken('kube-oidc-proxy-kind-test')
           require('fs').writeFileSync('token.jwt', t)
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: oidc-token
         path: token.jwt

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -28,7 +28,7 @@ jobs:
           go-version: "1.26.x"
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.6.0
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
-FROM ubuntu:24.04
+FROM ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
 LABEL description="OIDC reverse proxy authenticator based on Kubernetes"
 
 ARG TARGETARCH

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -63,9 +63,24 @@ Please include:
 
 Dependency CVEs are surfaced automatically by **Dependabot** and by
 **`govulncheck`** running in CI on every pull request and push. Third-party
-GitHub Actions are pinned to commit SHAs, and an
-[OpenSSF Scorecard](https://securityscorecards.dev/) workflow reports on the
-project's supply-chain posture.
+GitHub Actions are pinned to commit SHAs, container base images are pinned by
+digest, and an [OpenSSF Scorecard](https://securityscorecards.dev/) workflow
+reports on the project's supply-chain posture.
+
+### Accepted Scorecard findings
+
+A few Scorecard checks are knowingly accepted rather than "fixed", because they
+do not reflect real risk for this project:
+
+- **Vulnerabilities** — Scorecard lists OSV advisories by dependency *presence*.
+  We gate on **`govulncheck`**, which reports by *reachability*; it is green, so
+  the listed advisories are not reachable from our code.
+- **Code-Review** — the project is currently maintained by a single author, so
+  there are no separate approving reviewers for Scorecard to credit.
+- **Maintained** — flagged only because the fork's repository is recent; it
+  clears on its own as history accrues.
+- **Fuzzing** / **CII-Best-Practices** — aspirational; no fuzz targets or
+  best-practices enrolment yet.
 
 ## Upstream
 

--- a/test/tools/audit-webhook/Dockerfile
+++ b/test/tools/audit-webhook/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
-FROM alpine:3.10
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 LABEL description="A audit webhook sink to read audit events and write to file."
 

--- a/test/tools/fake-apiserver/Dockerfile
+++ b/test/tools/fake-apiserver/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
-FROM alpine:3.10
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 LABEL description="A fake API server that will respond to requests with the same body and headers."
 

--- a/test/tools/issuer/Dockerfile
+++ b/test/tools/issuer/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
-FROM alpine:3.10
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 LABEL description="A basic OIDC issuer that prsents a well-known and certs endpoint."
 


### PR DESCRIPTION
Addresses the **actionable** OpenSSF Scorecard findings after analyzing the results (several others are accepted false-positives — see below and SECURITY.md).

## Fixed
- **Token-Permissions** (high) — `helm.yaml` gains read-only top-level `permissions`; `mint-oidc-token` scopes `id-token: write` to the job. (`build.yaml` + the new release workflows are handled in #83.)
- **Pinned-Dependencies** (medium) — SHA-pin `mint-oidc-token`'s `github-script`/`upload-artifact`; pin `govulncheck@v1.6.0`; pin `ubuntu:24.04` by digest; bump the three **EOL `alpine:3.10`** test-tool images to **`alpine:3.21` pinned by digest** (verified: digest resolves, `apk add ca-certificates` works). Dependabot gains a `docker` ecosystem so the pins stay fresh.
- **SAST** (medium) — new **CodeQL** workflow for Go (Scorecard doesn't credit golangci-lint/govulncheck as SAST).

## Accepted as false-positive / by-design (documented in SECURITY.md)
- **Vulnerabilities** (high) — 3 OSV IDs listed by *presence*, but `govulncheck` (reachability) is **green** locally + in CI → not reachable.
- **Code-Review** / **Maintained** — solo maintainer; fork repo is <90 days old (auto-clears).
- **Fuzzing** / **CII-Best-Practices** — aspirational.

## Your call (repo settings, not code)
- **Branch-Protection** — requiring *approvers* would block a solo maintainer, but **requiring status checks** (build/test/e2e) before merge is low-friction and lifts the score.

All four changed workflows pass `actionlint`; YAML validated.