### PR TITLE
fix: distroless base image to clear Artifact Hub CVEs

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,5 @@
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
-FROM ubuntu:24.04@sha256:561618e2c15bf2397621dd04f96926663a3b5616c189cf7e38db7e82f5c538ea
+#
+# Distroless static base: the proxy is a CGO_ENABLED=0 static binary, so it
+# needs nothing from the OS except CA certificates (which distroless/static
+# ships). This drops every Ubuntu base package — and with them the base-image
+# CVEs that a static binary can never use — and runs as a non-root user.
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:f5b485ea962d9bd1186b2f6b3a061191539b905b82ec395de78cbfae51f20e35
 LABEL description="OIDC reverse proxy authenticator based on Kubernetes"
 
 ARG TARGETARCH
 
-RUN apt-get update;apt-get -y install ca-certificates;apt-get -y upgrade;apt-get clean;rm -rf /var/lib/apt/lists/*
-
 COPY bin/${TARGETARCH}/kube-oidc-proxy /usr/bin/
 
-CMD ["/usr/bin/kube-oidc-proxy"]
+ENTRYPOINT ["/usr/bin/kube-oidc-proxy"]

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
-	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
@@ -52,7 +52,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/btree v1.1.3 // indirect
-	github.com/google/cel-go v0.26.0 // indirect
+	github.com/google/cel-go v0.29.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260402051712-545e8a4df936 // indirect
@@ -84,7 +84,6 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
-	github.com/stoewer/go-strcase v1.3.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	go.etcd.io/etcd/api/v3 v3.6.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
-github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
-github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
+github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
+github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -85,8 +85,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
-github.com/google/cel-go v0.26.0 h1:DPGjXackMpJWH680oGY4lZhYjIameYmR+/6RBdDGmaI=
-github.com/google/cel-go v0.26.0/go.mod h1:A9O8OU9rdvrK5MQyrqfIxo1a0u4g3sF8KB6PUIaryMM=
+github.com/google/cel-go v0.29.0 h1:fEG+Ja3YRwNOqnQxTyJwoByAUAvTuxUGiro/jhrm4F4=
+github.com/google/cel-go v0.29.0/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/gnostic-models v0.7.0 h1:qwTtogB15McXDaNqTZdzPJRHvaVJlAl+HVQnLmJEJxo=
 github.com/google/gnostic-models v0.7.0/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7OUGxBlw57miDrQ=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -192,8 +192,6 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
-github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=
-github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -107,7 +107,9 @@ func (f *Framework) BeforeEach() {
 // AfterEach deletes the namespace, after reading its events.
 func (f *Framework) AfterEach() {
 	// Output logs from proxy of test case.
-	err := f.Helper().Kubectl(f.Namespace.Name).Run("logs", "-lapp=kube-oidc-proxy-e2e")
+	// --all-containers keeps this working when the proxy pod has a sidecar, as
+	// the audit to file case does.
+	err := f.Helper().Kubectl(f.Namespace.Name).Run("logs", "--all-containers", "-lapp=kube-oidc-proxy-e2e")
 	if err != nil {
 		By("Failed to gather logs from kube-oidc-proxy: " + err.Error())
 	}
@@ -126,6 +128,12 @@ func (f *Framework) AfterEach() {
 }
 
 func (f *Framework) DeployProxyWith(extraVolumes []corev1.Volume, extraArgs ...string) {
+	f.DeployProxyWithExtras(extraVolumes, nil, extraArgs...)
+}
+
+// DeployProxyWithExtras redeploys the proxy with extra volumes, plus writable
+// volumes and sidecar containers that extraVolumes cannot express.
+func (f *Framework) DeployProxyWithExtras(extraVolumes []corev1.Volume, extras *helper.ProxyExtras, extraArgs ...string) {
 	By("Deleting kube-oidc-proxy deployment")
 	err := f.Helper().DeleteProxy(f.Namespace.Name)
 	Expect(err).NotTo(HaveOccurred())
@@ -134,8 +142,8 @@ func (f *Framework) DeployProxyWith(extraVolumes []corev1.Volume, extraArgs ...s
 	Expect(err).NotTo(HaveOccurred())
 
 	By(fmt.Sprintf("Deploying kube-oidc-proxy with extra args %s", extraArgs))
-	f.proxyKeyBundle, f.proxyURL, err = f.helper.DeployProxy(f.Namespace, f.issuerURL,
-		clientID, f.issuerKeyBundle, extraVolumes, extraArgs...)
+	f.proxyKeyBundle, f.proxyURL, err = f.helper.DeployProxyWithExtras(f.Namespace, f.issuerURL,
+		clientID, f.issuerKeyBundle, extraVolumes, extras, extraArgs...)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/test/e2e/framework/helper/deploy.go
+++ b/test/e2e/framework/helper/deploy.go
@@ -21,8 +21,23 @@ import (
 	"github.com/rafpe/kube-oidc-proxy/test/util"
 )
 
+// ProxyExtras holds additions to the proxy pod that cannot be expressed with
+// extraVolumes, which are always mounted read only at /<volume name>. Volumes
+// are paired with explicit VolumeMounts on the proxy container, and Containers
+// are added to the pod as sidecars, typically to share one of those volumes.
+type ProxyExtras struct {
+	Volumes      []corev1.Volume
+	VolumeMounts []corev1.VolumeMount
+	Containers   []corev1.Container
+}
+
 func (h *Helper) DeployProxy(ns *corev1.Namespace, issuerURL *url.URL, clientID string,
 	oidcKeyBundle *util.KeyBundle, extraVolumes []corev1.Volume, extraArgs ...string) (*util.KeyBundle, *url.URL, error) {
+	return h.DeployProxyWithExtras(ns, issuerURL, clientID, oidcKeyBundle, extraVolumes, nil, extraArgs...)
+}
+
+func (h *Helper) DeployProxyWithExtras(ns *corev1.Namespace, issuerURL *url.URL, clientID string,
+	oidcKeyBundle *util.KeyBundle, extraVolumes []corev1.Volume, extras *ProxyExtras, extraArgs ...string) (*util.KeyBundle, *url.URL, error) {
 	authConfig := false
 	for _, a := range extraArgs {
 		if strings.HasPrefix(a, "--authentication-config") {
@@ -100,6 +115,16 @@ func (h *Helper) DeployProxy(ns *corev1.Namespace, issuerURL *url.URL, clientID 
 	}
 
 	volumes := extraVolumes
+	if extras != nil {
+		cnt.VolumeMounts = append(cnt.VolumeMounts, extras.VolumeMounts...)
+		volumes = append(volumes, extras.Volumes...)
+	}
+
+	containers := []corev1.Container{cnt}
+	if extras != nil {
+		containers = append(containers, extras.Containers...)
+	}
+
 	if !authConfig {
 		volumes = append(volumes, corev1.Volume{
 			Name: "oidc",
@@ -125,7 +150,7 @@ func (h *Helper) DeployProxy(ns *corev1.Namespace, issuerURL *url.URL, clientID 
 		}
 	}
 
-	bundle, appURL, err := h.deployApp(ns.Name, kind.ProxyImageName, corev1.ServiceTypeNodePort, cnt, volumes...)
+	bundle, appURL, err := h.deployApp(ns.Name, kind.ProxyImageName, corev1.ServiceTypeNodePort, containers, volumes...)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -296,7 +321,7 @@ func (h *Helper) DeployNamedIssuer(ns, name string) (*util.KeyBundle, *url.URL, 
 		},
 	}
 
-	bundle, appURL, err := h.deployApp(ns, name, corev1.ServiceTypeClusterIP, cnt)
+	bundle, appURL, err := h.deployApp(ns, name, corev1.ServiceTypeClusterIP, []corev1.Container{cnt})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -329,7 +354,7 @@ func (h *Helper) DeployFakeAPIServer(ns string) ([]corev1.Volume, *url.URL, erro
 		},
 	}
 
-	bundle, appURL, err := h.deployApp(ns, kind.FakeAPIServerImageName, corev1.ServiceTypeClusterIP, cnt)
+	bundle, appURL, err := h.deployApp(ns, kind.FakeAPIServerImageName, corev1.ServiceTypeClusterIP, []corev1.Container{cnt})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -387,7 +412,7 @@ func (h *Helper) DeployAuditWebhook(ns, logPath string) (corev1.Volume, *url.URL
 		},
 	}
 
-	bundle, appURL, err := h.deployApp(ns, kind.AuditWebhookImageName, corev1.ServiceTypeClusterIP, cnt)
+	bundle, appURL, err := h.deployApp(ns, kind.AuditWebhookImageName, corev1.ServiceTypeClusterIP, []corev1.Container{cnt})
 	if err != nil {
 		return corev1.Volume{}, nil, err
 	}
@@ -417,7 +442,7 @@ func (h *Helper) DeployAuditWebhook(ns, logPath string) (corev1.Volume, *url.URL
 	return auditWebhookCAVol, appURL, nil
 }
 
-func (h *Helper) deployApp(ns, name string, serviceType corev1.ServiceType, container corev1.Container, volumes ...corev1.Volume) (*util.KeyBundle, *url.URL, error) {
+func (h *Helper) deployApp(ns, name string, serviceType corev1.ServiceType, containers []corev1.Container, volumes ...corev1.Volume) (*util.KeyBundle, *url.URL, error) {
 	host, appURL := h.appURL(ns, name, "6443")
 
 	var netIPs []net.IP
@@ -501,7 +526,7 @@ func (h *Helper) deployApp(ns, name string, serviceType corev1.ServiceType, cont
 
 				Spec: corev1.PodSpec{
 					ServiceAccountName: name,
-					Containers:         []corev1.Container{container},
+					Containers:         containers,
 					Volumes: append(volumes,
 						corev1.Volume{
 							Name: "tls",

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -20,6 +20,19 @@ import (
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
 
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework/helper"
+	"github.com/rafpe/kube-oidc-proxy/test/kind"
+)
+
+const (
+	// The proxy image is distroless and runs as nonroot, so the audit log has
+	// to be written to a writable emptyDir rather than the root filesystem, and
+	// read back through a sidecar since the proxy image has no shell or cat.
+	auditLogDir      = "/var/log/kube-oidc-proxy"
+	auditLogPath     = auditLogDir + "/audit.log"
+	auditLogVolume   = "audit-log"
+	auditReaderName  = "audit-reader"
+	webhookAuditPath = "/audit-log"
 )
 
 var _ = framework.CasesDescribe("Audit", func() {
@@ -53,10 +66,47 @@ rules:
 			},
 		}
 
-		By("Deploying proxy with audit policy enabled")
-		f.DeployProxyWith(vols, "--audit-log-path=/audit-log", "--audit-policy-file=/audit/audit.yaml")
+		// The audit log lives in an emptyDir shared with a reader sidecar. The
+		// sidecar uses the audit webhook image because it is alpine based (so it
+		// has cat), runs as root (so it can read the 0600 log written by the
+		// proxy) and is already loaded into the kind nodes.
+		extras := &helper.ProxyExtras{
+			Volumes: []corev1.Volume{
+				{
+					Name: auditLogVolume,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: auditLogDir,
+					Name:      auditLogVolume,
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:            auditReaderName,
+					Image:           kind.AuditWebhookImageName,
+					ImagePullPolicy: corev1.PullNever,
+					Command:         []string{"sleep", "86400"},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							MountPath: auditLogDir,
+							Name:      auditLogVolume,
+							ReadOnly:  true,
+						},
+					},
+				},
+			},
+		}
 
-		testAuditLogs(f, "app=kube-oidc-proxy-e2e")
+		By("Deploying proxy with audit policy enabled")
+		f.DeployProxyWithExtras(vols, extras,
+			"--audit-log-path="+auditLogPath, "--audit-policy-file=/audit/audit.yaml")
+
+		testAuditLogs(f, "app=kube-oidc-proxy-e2e", auditReaderName, auditLogPath)
 	})
 
 	It("should be able to write audit logs to webhook", func() {
@@ -74,7 +124,7 @@ rules:
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		extraWebhookVol, webhookURL, err := f.Helper().DeployAuditWebhook(f.Namespace.Name, "/audit-log")
+		extraWebhookVol, webhookURL, err := f.Helper().DeployAuditWebhook(f.Namespace.Name, webhookAuditPath)
 		Expect(err).NotTo(HaveOccurred())
 
 		cmWebhook, err := f.Helper().KubeClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), &corev1.ConfigMap{
@@ -129,11 +179,14 @@ users: []`,
 		f.DeployProxyWith(vols, "--audit-webhook-config-file=/audit-webhook/kubeconfig.yaml",
 			"--audit-policy-file=/audit/audit.yaml", "--audit-webhook-initial-backoff=1s", "--audit-webhook-batch-max-wait=1s")
 
-		testAuditLogs(f, "app=audit-webhook-e2e")
+		testAuditLogs(f, "app=audit-webhook-e2e", "", webhookAuditPath)
 	})
 })
 
-func testAuditLogs(f *framework.Framework, podLabelSelector string) {
+// testAuditLogs reads the audit log at logPath from the pod matching
+// podLabelSelector. If containerName is non-empty the log is read from that
+// container, otherwise from the pod's default container.
+func testAuditLogs(f *framework.Framework, podLabelSelector, containerName, logPath string) {
 	By("Making calls to proxy to ensure audit get created")
 	token := f.Helper().NewTokenPayload(f.IssuerURL(), f.ClientID(), time.Now().Add(time.Second*5))
 	signedToken, err := f.Helper().SignToken(f.IssuerKeyBundle(), token)
@@ -171,9 +224,14 @@ func testAuditLogs(f *framework.Framework, podLabelSelector string) {
 		Expect(fmt.Errorf("expected single kube-oidc-proxy pod running, got=%d", len(pods.Items))).NotTo(HaveOccurred())
 	}
 
+	execArgs := []string{"exec", pods.Items[0].Name}
+	if containerName != "" {
+		execArgs = append(execArgs, "-c", containerName)
+	}
+	execArgs = append(execArgs, "--", "cat", logPath)
+
 	var auditLogsBuffer bytes.Buffer
-	err = f.Helper().Kubectl(f.Namespace.Name).RunWithStdout(&auditLogsBuffer,
-		"exec", pods.Items[0].Name, "--", "cat", "/audit-log")
+	err = f.Helper().Kubectl(f.Namespace.Name).RunWithStdout(&auditLogsBuffer, execArgs...)
 	Expect(err).NotTo(HaveOccurred())
 
 	logs := auditLogsBuffer.Bytes()

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -28,10 +28,13 @@ const (
 	// The proxy image is distroless and runs as nonroot, so the audit log has
 	// to be written to a writable emptyDir rather than the root filesystem, and
 	// read back through a sidecar since the proxy image has no shell or cat.
-	auditLogDir      = "/var/log/kube-oidc-proxy"
-	auditLogPath     = auditLogDir + "/audit.log"
-	auditLogVolume   = "audit-log"
-	auditReaderName  = "audit-reader"
+	auditLogDir     = "/var/log/kube-oidc-proxy"
+	auditLogPath    = auditLogDir + "/audit.log"
+	auditLogVolume  = "audit-log"
+	auditReaderName = "audit-reader"
+
+	// webhookAuditPath is where the audit webhook sink writes events inside its
+	// own pod.
 	webhookAuditPath = "/audit-log"
 )
 
@@ -68,8 +71,8 @@ rules:
 
 		// The audit log lives in an emptyDir shared with a reader sidecar. The
 		// sidecar uses the audit webhook image because it is alpine based (so it
-		// has cat), runs as root (so it can read the 0600 log written by the
-		// proxy) and is already loaded into the kind nodes.
+		// has cat), runs as root (so it can read the log file written by the
+		// nonroot proxy) and is already loaded into the kind nodes.
 		extras := &helper.ProxyExtras{
 			Volumes: []corev1.Volume{
 				{


### PR DESCRIPTION
Fixes the vulnerabilities Artifact Hub's Trivy scan flagged on `ghcr.io/rafpe/kube-oidc-proxy:1.1.1`.

## The finding (digest `sha256:c903000d…`)
| Class | Count | Fixable? |
|---|---|---|
| Ubuntu base OS packages | 8 MEDIUM + 6 LOW | **0 have a fix** (Ubuntu won't-fix/pending) |
| Go binary | 1 MEDIUM (`cel-go`) | yes → v0.29.0 |

All 14 OS CVEs are in base packages our **CGO_ENABLED=0 static binary never uses** (util-linux family, shadow/login, libsystemd, libgcrypt, libp11-kit, zlib) and none have an upstream fix — so `apt upgrade` can't clear them.

## Fix
- **Runtime image → `gcr.io/distroless/static-debian12:nonroot`** (digest-pinned). Removes the entire Ubuntu package surface → **all 14 OS CVEs gone**. Distroless ships CA certs and runs non-root.
- **`cel-go` v0.26.0 → v0.29.0** (GHSA-gcjh-h69q-9w9g) → the 1 Go CVE gone.

## Verified locally
- Static binary **runs on distroless** (`--version` via the chart's bare `command: [kube-oidc-proxy]`; `PATH` + `SSL_CERT_FILE` present).
- `go build`, `go test ./pkg/...`, and `govulncheck` all pass with the cel-go bump.
- No chart change needed (proxy binds 6443, chart already `runAsNonRoot`).

Merging (release/patch) cuts **v1.1.2**; the release pipeline rebuilds the image on distroless and Artifact Hub re-scans to a clean report.