### PR TITLE
test(e2e): group same-config specs to cut redeploys

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -51,15 +51,43 @@ func NewDefaultFramework(baseName string) *Framework {
 }
 
 func NewFramework(baseName string, config *config.Config) *Framework {
-	f := &Framework{
-		BaseName: baseName,
-		config:   config,
-	}
+	f := newFramework(baseName, config)
 
 	JustBeforeEach(f.BeforeEach)
 	AfterEach(f.AfterEach)
 
 	return f
+}
+
+// NewOrderedDefaultFramework is NewOrderedFramework using DefaultConfig.
+func NewOrderedDefaultFramework(baseName string) *Framework {
+	return NewOrderedFramework(baseName, DefaultConfig)
+}
+
+// NewOrderedFramework deploys the namespace, issuer and proxy once for the
+// whole enclosing container rather than once per spec, so a run of specs
+// sharing the same proxy configuration pays for a single deploy. It must be
+// called inside an Ordered container — Ginkgo panics at tree construction
+// otherwise — and only for specs that share a configuration and leave no
+// residue that a sibling spec depends on being absent.
+//
+// Proxy logs are still gathered after every spec; only the teardown of the
+// proxy, issuer and namespace is deferred to the end of the container.
+func NewOrderedFramework(baseName string, config *config.Config) *Framework {
+	f := newFramework(baseName, config)
+
+	BeforeAll(f.BeforeEach)
+	AfterEach(f.gatherProxyLogs)
+	AfterAll(f.deleteResources)
+
+	return f
+}
+
+func newFramework(baseName string, config *config.Config) *Framework {
+	return &Framework{
+		BaseName: baseName,
+		config:   config,
+	}
 }
 
 func (f *Framework) BeforeEach() {
@@ -106,16 +134,25 @@ func (f *Framework) BeforeEach() {
 
 // AfterEach deletes the namespace, after reading its events.
 func (f *Framework) AfterEach() {
-	// Output logs from proxy of test case.
+	f.gatherProxyLogs()
+	f.deleteResources()
+}
+
+// gatherProxyLogs dumps the proxy logs to the test output. It runs after every
+// spec, including in Ordered containers where teardown is deferred, so a
+// failing spec always has the logs of the proxy it ran against.
+func (f *Framework) gatherProxyLogs() {
 	// --all-containers keeps this working when the proxy pod has a sidecar, as
 	// the audit to file case does.
 	err := f.Helper().Kubectl(f.Namespace.Name).Run("logs", "--all-containers", "-lapp=kube-oidc-proxy-e2e")
 	if err != nil {
 		By("Failed to gather logs from kube-oidc-proxy: " + err.Error())
 	}
+}
 
+func (f *Framework) deleteResources() {
 	By("Deleting kube-oidc-proxy deployment")
-	err = f.Helper().DeleteProxy(f.Namespace.Name)
+	err := f.Helper().DeleteProxy(f.Namespace.Name)
 	Expect(err).NotTo(HaveOccurred())
 
 	By("Deleting mock OIDC issuer")
@@ -188,6 +225,9 @@ func (f *Framework) NewProxyClient() kubernetes.Interface {
 	return proxyClient
 }
 
-func CasesDescribe(text string, body func()) bool {
-	return Describe("[TEST] "+text, body)
+// CasesDescribe declares a test case container. args is the container body
+// plus any Ginkgo decorators, such as Ordered and ContinueOnFailure for cases
+// that share a single deploy across their specs.
+func CasesDescribe(text string, args ...interface{}) bool {
+	return Describe("[TEST] "+text, args...)
 }

--- a/test/e2e/suite/cases/authconfig/authconfig.go
+++ b/test/e2e/suite/cases/authconfig/authconfig.go
@@ -24,8 +24,10 @@ const (
 	authConfigKey    = "config.yaml"
 )
 
-var _ = framework.CasesDescribe("AuthenticationConfiguration multi-issuer", func() {
-	f := framework.NewDefaultFramework("authconfig")
+// Every spec here reads through the same AuthenticationConfiguration proxy
+// deployment and mutates no cluster state, so they all share a single deploy.
+var _ = framework.CasesDescribe("AuthenticationConfiguration multi-issuer", Ordered, ContinueOnFailure, func() {
+	f := framework.NewOrderedDefaultFramework("authconfig")
 
 	var (
 		issuer2Bundle *util.KeyBundle

--- a/test/e2e/suite/cases/impersonation/impersonation.go
+++ b/test/e2e/suite/cases/impersonation/impersonation.go
@@ -19,171 +19,182 @@ import (
 )
 
 var _ = framework.CasesDescribe("Impersonation", func() {
-	f := framework.NewDefaultFramework("impersonation")
+	// These specs all run against a default proxy with impersonation enabled.
+	// The only cluster state they create is cluster-scoped and named by
+	// GenerateName, and none of them assert on its absence, so they share a
+	// single deploy.
+	Describe("enabled", Ordered, ContinueOnFailure, func() {
+		f := framework.NewOrderedDefaultFramework("impersonation")
 
-	It("should allow an authenticated user to impersonate an authorized user when az by rbac", func() {
+		It("should allow an authenticated user to impersonate an authorized user when az by rbac", func() {
 
-		By("Creating ClusterRole for user ok-to-impersonate@nodomain.dev to list Pods")
-		rolePods, err := f.Helper().KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-user-role-pods-impersonate-",
-			},
-			Rules: []rbacv1.PolicyRule{
-				{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Creating ClusterRoleBinding for user ok-to-impersonate@nodomain.dev")
-		_, err = f.Helper().KubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(),
-			&rbacv1.ClusterRoleBinding{
+			By("Creating ClusterRole for user ok-to-impersonate@nodomain.dev to list Pods")
+			rolePods, err := f.Helper().KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-user-binding-impersonate",
+					GenerateName: "test-user-role-pods-impersonate-",
 				},
-				Subjects: []rbacv1.Subject{{Name: "ok-to-impersonate@nodomain.dev", Kind: "User"}},
-				RoleRef:  rbacv1.RoleRef{Name: rolePods.Name, Kind: "ClusterRole"},
+				Rules: []rbacv1.PolicyRule{
+					{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
+				},
 			}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Impersonating a user, group, and extra")
-		tryImpersonationClient(f, rest.ImpersonationConfig{
-			UserName: "ok-to-impersonate@nodomain.dev",
-			Groups: []string{
-				"ok-to-impersonate-group",
-			},
-			Extra: map[string][]string{
-				"oktoimpersonateextra": {
-					"foo",
+			By("Creating ClusterRoleBinding for user ok-to-impersonate@nodomain.dev")
+			_, err = f.Helper().KubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(),
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "test-user-binding-impersonate",
+					},
+					Subjects: []rbacv1.Subject{{Name: "ok-to-impersonate@nodomain.dev", Kind: "User"}},
+					RoleRef:  rbacv1.RoleRef{Name: rolePods.Name, Kind: "ClusterRole"},
+				}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Impersonating a user, group, and extra")
+			tryImpersonationClient(f, rest.ImpersonationConfig{
+				UserName: "ok-to-impersonate@nodomain.dev",
+				Groups: []string{
+					"ok-to-impersonate-group",
 				},
-			},
-		}, http.StatusOK, "")
+				Extra: map[string][]string{
+					"oktoimpersonateextra": {
+						"foo",
+					},
+				},
+			}, http.StatusOK, "")
 
+		})
+
+		It("should error at proxy when impersonation enabled but a user is not specified", func() {
+			By("Impersonating as a group")
+			tryImpersonationClient(f, rest.ImpersonationConfig{
+				Groups: []string{
+					"group-1",
+					"group-2",
+				},
+			}, http.StatusInternalServerError, "no Impersonation-User header found for request")
+
+			By("Impersonating as a extra")
+			tryImpersonationClient(f, rest.ImpersonationConfig{
+				Extra: map[string][]string{
+					"foo": {
+						"k1", "k2", "k3",
+					},
+					"bar": {
+						"k1", "k2", "k3",
+					},
+				},
+			}, http.StatusInternalServerError, "no Impersonation-User header found for request")
+		})
+
+		It("should return error from proxy when impersonation enabled and impersonation is not authorized by the cluster's RBAC", func() {
+			By("Impersonating as a user")
+			tryImpersonationClient(f, rest.ImpersonationConfig{
+				UserName: "foo@example.com",
+			}, http.StatusForbidden, "user@example.com is not allowed to impersonate user 'foo@example.com'")
+
+			By("Impersonating as a user, group")
+			tryImpersonationClient(f, rest.ImpersonationConfig{
+				UserName: "ok-to-impersonate@nodomain.dev",
+				Groups: []string{
+					"group-1",
+				},
+			}, http.StatusForbidden, "user@example.com is not allowed to impersonate group 'group-1'")
+
+			By("Impersonating as a user, extra")
+			tryImpersonationClient(f, rest.ImpersonationConfig{
+				UserName: "ok-to-impersonate@nodomain.dev",
+				Extra: map[string][]string{
+					"foo": {
+						"k1", "k2", "k3",
+					},
+				},
+			}, http.StatusForbidden, "user@example.com is not allowed to impersonate extra info 'foo'='k1'")
+
+		})
 	})
 
-	It("should error at proxy when impersonation enabled but a user is not specified", func() {
-		By("Impersonating as a group")
-		tryImpersonationClient(f, rest.ImpersonationConfig{
-			Groups: []string{
-				"group-1",
-				"group-2",
-			},
-		}, http.StatusInternalServerError, "no Impersonation-User header found for request")
+	// This spec swaps the proxy configuration, so it keeps a deploy of its own.
+	Describe("disabled", func() {
+		f := framework.NewDefaultFramework("impersonation")
 
-		By("Impersonating as a extra")
-		tryImpersonationClient(f, rest.ImpersonationConfig{
-			Extra: map[string][]string{
-				"foo": {
-					"k1", "k2", "k3",
-				},
-				"bar": {
-					"k1", "k2", "k3",
-				},
-			},
-		}, http.StatusInternalServerError, "no Impersonation-User header found for request")
-	})
+		It("should not error at proxy when impersonation is disabled and impersonation is attempted on a request", func() {
+			By("Enabling the disabling of impersonation")
+			f.DeployProxyWith(nil, "--disable-impersonation")
 
-	It("should return error from proxy when impersonation enabled and impersonation is not authorized by the cluster's RBAC", func() {
-		By("Impersonating as a user")
-		tryImpersonationClient(f, rest.ImpersonationConfig{
-			UserName: "foo@example.com",
-		}, http.StatusForbidden, "user@example.com is not allowed to impersonate user 'foo@example.com'")
-
-		By("Impersonating as a user, group")
-		tryImpersonationClient(f, rest.ImpersonationConfig{
-			UserName: "ok-to-impersonate@nodomain.dev",
-			Groups: []string{
-				"group-1",
-			},
-		}, http.StatusForbidden, "user@example.com is not allowed to impersonate group 'group-1'")
-
-		By("Impersonating as a user, extra")
-		tryImpersonationClient(f, rest.ImpersonationConfig{
-			UserName: "ok-to-impersonate@nodomain.dev",
-			Extra: map[string][]string{
-				"foo": {
-					"k1", "k2", "k3",
-				},
-			},
-		}, http.StatusForbidden, "user@example.com is not allowed to impersonate extra info 'foo'='k1'")
-
-	})
-
-	It("should not error at proxy when impersonation is disabled and impersonation is attempted on a request", func() {
-		By("Enabling the disabling of impersonation")
-		f.DeployProxyWith(nil, "--disable-impersonation")
-
-		By("Creating ClusterRole for system:anonymous to impersonate")
-		roleImpersonate, err := f.Helper().KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-user-role-impersonate-",
-			},
-			Rules: []rbacv1.PolicyRule{
-				{APIGroups: []string{""}, Resources: []string{"users"}, Verbs: []string{"impersonate"}},
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Creating Role for user foo to list Pods")
-		rolePods, err := f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Create(context.TODO(), &rbacv1.Role{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "test-user-role-pods-",
-			},
-			Rules: []rbacv1.PolicyRule{
-				{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("Creating ClusterRoleBinding for user system:anonymous")
-		rolebindingImpersonate, err := f.Helper().KubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(),
-			&rbacv1.ClusterRoleBinding{
+			By("Creating ClusterRole for system:anonymous to impersonate")
+			roleImpersonate, err := f.Helper().KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-user-binding-system-anonymous",
+					GenerateName: "test-user-role-impersonate-",
 				},
-				Subjects: []rbacv1.Subject{{Name: "system:anonymous", Kind: "User"}},
-				RoleRef:  rbacv1.RoleRef{Name: roleImpersonate.Name, Kind: "ClusterRole"},
+				Rules: []rbacv1.PolicyRule{
+					{APIGroups: []string{""}, Resources: []string{"users"}, Verbs: []string{"impersonate"}},
+				},
 			}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Creating RoleBinding for user foo@example.com")
-		rolebindingPods, err := f.Helper().KubeClient.RbacV1().RoleBindings(f.Namespace.Name).Create(context.TODO(),
-			&rbacv1.RoleBinding{
+			By("Creating Role for user foo to list Pods")
+			rolePods, err := f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Create(context.TODO(), &rbacv1.Role{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "test-user-binding-user-foo-example-com",
+					GenerateName: "test-user-role-pods-",
 				},
-				Subjects: []rbacv1.Subject{{Name: "foo@example.com", Kind: "User"}},
-				RoleRef:  rbacv1.RoleRef{Name: rolePods.Name, Kind: "Role"},
+				Rules: []rbacv1.PolicyRule{
+					{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
+				},
 			}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
-		// build client with impersonation
-		config := f.NewProxyRestConfig()
-		config.Impersonate = rest.ImpersonationConfig{
-			UserName: "foo@example.com",
-		}
-		client, err := kubernetes.NewForConfig(config)
-		Expect(err).NotTo(HaveOccurred())
+			By("Creating ClusterRoleBinding for user system:anonymous")
+			rolebindingImpersonate, err := f.Helper().KubeClient.RbacV1().ClusterRoleBindings().Create(context.TODO(),
+				&rbacv1.ClusterRoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "test-user-binding-system-anonymous",
+					},
+					Subjects: []rbacv1.Subject{{Name: "system:anonymous", Kind: "User"}},
+					RoleRef:  rbacv1.RoleRef{Name: roleImpersonate.Name, Kind: "ClusterRole"},
+				}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
 
-		// Should not error since we have authorized system:anonymous to
-		// impersonate and foo@example.com to list pods
-		_, err = client.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
-		Expect(err).NotTo(HaveOccurred())
+			By("Creating RoleBinding for user foo@example.com")
+			rolebindingPods, err := f.Helper().KubeClient.RbacV1().RoleBindings(f.Namespace.Name).Create(context.TODO(),
+				&rbacv1.RoleBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "test-user-binding-user-foo-example-com",
+					},
+					Subjects: []rbacv1.Subject{{Name: "foo@example.com", Kind: "User"}},
+					RoleRef:  rbacv1.RoleRef{Name: rolePods.Name, Kind: "Role"},
+				}, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Deleting RoleBinding for user foo@example.com")
-		err = f.Helper().KubeClient.RbacV1().RoleBindings(f.Namespace.Name).Delete(context.TODO(), rolebindingPods.Name, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
+			// build client with impersonation
+			config := f.NewProxyRestConfig()
+			config.Impersonate = rest.ImpersonationConfig{
+				UserName: "foo@example.com",
+			}
+			client, err := kubernetes.NewForConfig(config)
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Deleting Role for list Pods")
-		err = f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Delete(context.TODO(), rolePods.Name, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
+			// Should not error since we have authorized system:anonymous to
+			// impersonate and foo@example.com to list pods
+			_, err = client.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Deleting ClusterRoleBinding for user system:anonymous")
-		err = f.Helper().KubeClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), rolebindingImpersonate.Name, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
+			By("Deleting RoleBinding for user foo@example.com")
+			err = f.Helper().KubeClient.RbacV1().RoleBindings(f.Namespace.Name).Delete(context.TODO(), rolebindingPods.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 
-		By("Deleting ClusterRole for Impersonate")
-		err = f.Helper().KubeClient.RbacV1().ClusterRoles().Delete(context.TODO(), roleImpersonate.Name, metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
+			By("Deleting Role for list Pods")
+			err = f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Delete(context.TODO(), rolePods.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting ClusterRoleBinding for user system:anonymous")
+			err = f.Helper().KubeClient.RbacV1().ClusterRoleBindings().Delete(context.TODO(), rolebindingImpersonate.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Deleting ClusterRole for Impersonate")
+			err = f.Helper().KubeClient.RbacV1().ClusterRoles().Delete(context.TODO(), roleImpersonate.Name, metav1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })
 

--- a/test/e2e/suite/cases/passthrough/passthrough.go
+++ b/test/e2e/suite/cases/passthrough/passthrough.go
@@ -17,8 +17,12 @@ import (
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
-var _ = framework.CasesDescribe("Passthrough", func() {
-	f := framework.NewDefaultFramework("passthrough")
+// The specs share the initial issuer and proxy deploy; the second redeploys the
+// proxy itself to enable passthrough. The per-spec Role and RoleBinding below
+// are still created and deleted around every spec, so the shared namespace
+// looks the same to each of them.
+var _ = framework.CasesDescribe("Passthrough", Ordered, ContinueOnFailure, func() {
+	f := framework.NewOrderedDefaultFramework("passthrough")
 
 	var saToken string
 

--- a/test/e2e/suite/cases/token/token.go
+++ b/test/e2e/suite/cases/token/token.go
@@ -2,11 +2,15 @@
 package token
 
 import (
+	. "github.com/onsi/ginkgo/v2"
+
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/sharedtests"
 )
 
-var _ = framework.CasesDescribe("Token", func() {
-	f := framework.NewDefaultFramework("token")
+// Every spec here reads through the same default proxy deployment and mutates
+// no cluster state, so they all share a single deploy.
+var _ = framework.CasesDescribe("Token", Ordered, ContinueOnFailure, func() {
+	f := framework.NewOrderedDefaultFramework("token")
 	sharedtests.RunTokenValidationTests(f)
 })

--- a/test/e2e/suite/cases/upgrade/upgrade.go
+++ b/test/e2e/suite/cases/upgrade/upgrade.go
@@ -30,11 +30,16 @@ import (
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
-var _ = framework.CasesDescribe("Upgrade", func() {
-	f := framework.NewDefaultFramework("upgrade")
+// Both specs stream through the same default proxy deployment to the same echo
+// server pod without mutating it, so the deploy and the echo server setup are
+// shared. The setup has to be shared rather than per-spec: the Role and
+// RoleBinding below have fixed names and are never deleted, so recreating them
+// for a second spec in the same namespace would fail as already existing.
+var _ = framework.CasesDescribe("Upgrade", Ordered, ContinueOnFailure, func() {
+	f := framework.NewOrderedDefaultFramework("upgrade")
 
 	var pod *corev1.Pod
-	JustBeforeEach(func() {
+	BeforeAll(func() {
 		By("Deploying echo server to exec to")
 
 		var err error


### PR DESCRIPTION
## Why

`framework.NewFramework` registers its deploy as `JustBeforeEach`, so **every** spec built a fresh namespace + mock issuer + proxy and tore it down again — including the hardcoded `time.Sleep(2 * time.Second)` per deployed app in `deploy.go`. Most specs in a case share one proxy configuration and only read through it, so those redeploys bought nothing.

This groups same-config specs into `Ordered` containers that deploy once in `BeforeAll`. **Test-only change; no production code touched.**

> **Scope note:** `test/e2e/suite/cases/audit/audit.go` is deliberately **not** touched by this PR, to avoid conflicting with the distroless base image rework in #86. Audit keeps its 2 deploys and can be grouped in a follow-up once #86 lands — the `NewOrderedFramework` helper added here is all it needs.

### On the spec count: 23 `It(` literals, 29 specs

The task brief said ~23 redeploys, which is the count of `It(` literals. The real number is **29**: `sharedtests.RunTokenValidationTests` registers 6 specs into *each* of `token` and `authconfig`, so 23 literals become 29 specs — and 29 framework deploys. Confirmed by `--ginkgo.dry-run` on `main`.

## What was grouped

| Case | Specs | Deploys before → after | Notes |
|---|---|---|---|
| `token` | 6 | 6 → 1 | All read-only against one default proxy. |
| `authconfig` | 7 | 7 → 1 | All read-only against one AuthenticationConfiguration proxy. |
| `impersonation` (enabled) | 3 | 3 → 1 | Only creates cluster-scoped objects via `GenerateName`; none assert on their absence. |
| `passthrough` | 2 | 2 → 1 | Second spec redeploys with `--token-passthrough`; the per-spec Role/RoleBinding are still created and deleted around each spec. |
| `upgrade` | 2 | 2 → 1 | Also moves the echo-server `JustBeforeEach` → `BeforeAll` (required, see below). |

**Total: 29 → 14 framework deploys, 29 → 29 specs.** In-test `DeployProxyWith` redeploys are unchanged.

`upgrade`'s setup move was not optional: its `e2e-test-exec` Role and RoleBinding use *fixed* names and are never deleted, so a per-spec `JustBeforeEach` in a now-shared namespace would fail `AlreadyExists` on the second spec.

## What was deliberately left ungrouped

- **`audit` (2 specs)** — out of scope for this PR; see the scope note above.
- **`probe` (2 specs)** — spec 1 deletes the issuer *and* the proxy and deploys one expected never to become ready; spec 2 needs a live issuer and a ready proxy. Directly incompatible.
- **`rbac` (2 specs)** — spec 1 asserts that requests are forbidden in a namespace with *no* RBAC, i.e. it asserts on pristine state, while spec 2 creates Roles/RoleBindings there. Safe under `Ordered` in principle since declaration order is guaranteed, but it is exactly the "asserts on fresh state" case, so it keeps its own deploy.
- **`headers` (2 specs)** — each deploys a fake API server, and `JustAfterEach` deletes it. `deleteApp` does **not** wait for deletion while `deployApp` uses fixed names, so spec 2 recreating `fake-apiserver` in the same namespace would race spec 1's delete (`AlreadyExists`). The codebase's own `WaitForDeploymentToDelete` in `DeployProxyWith` is evidence this race is real. Only worth 1 deploy.
- **`impersonation` spec 4** — redeploys with `--disable-impersonation`, so it is split into its own `Describe` with its own deploy.

## `ContinueOnFailure` is load-bearing

In Ginkgo v2, when a spec in an `Ordered` container fails, **all subsequent specs in that container are skipped**. Plain `Ordered` would therefore have traded deploy time for coverage. Measured on a throwaway suite (3-spec `Ordered` container, first spec fails, plus 2 unrelated specs), with `RandomizeAllSpecs = true` matching `suite_test.go`:

- `Ordered` alone → `Ran 3 of 5 Specs` (2 skipped)
- `Ordered, ContinueOnFailure` → `Ran 5 of 5 Specs` — `4 Passed | 1 Failed | 0 Skipped`

The same probe confirmed `BeforeAll`/`AfterAll` ran exactly once, `AfterEach` ran per spec, and specs inside the container ran in declaration order despite `RandomizeAllSpecs`.

`ContinueOnFailure` is safe in every group here because each grouped spec either is read-only (`token`, `authconfig`, `impersonation/enabled`, `upgrade`) or redeploys the proxy itself at its top (`passthrough` spec 2).

## Teardown was split, not just moved

`f.AfterEach` did two unrelated things. Moving it wholesale to `AfterAll` would have lost per-spec proxy logs — and for a case like `passthrough`, where a spec redeploys the proxy, the earlier deployment's logs entirely. So it is split: `gatherProxyLogs` still runs **after every spec**, and only `DeleteProxy`/`DeleteIssuer`/`DeleteKubeNamespace` moved to `AfterAll`. `gatherProxyLogs` contains no `Expect`, so it cannot newly fail a spec.

## Verification

Ran locally; the full suite needs kind/docker, so **the `e2e-kind` check on this PR is what actually validates this end-to-end in a real cluster.**

```
gofmt -l ./test/ ./pkg/ ./cmd/     # clean, no output
go build ./...                     # OK
go vet ./test/...                  # OK
go test -c -o /dev/null ./test/e2e/suite/...   # OK, all packages compile
```

Spec inventory via `--ginkgo.dry-run` (walks the tree, runs no node bodies, needs no cluster), captured on `main` and on this branch, sorted and diffed:

```
before=29  after=29
```

The only differences are the 4 impersonation specs gaining an `enabled`/`disabled` segment from the container split — the other 25 spec names are byte-identical, so JUnit history is preserved for them:

```
< [TEST] Impersonation should allow an authenticated user to impersonate an authorized user when az by rbac
< [TEST] Impersonation should error at proxy when impersonation enabled but a user is not specified
< [TEST] Impersonation should not error at proxy when impersonation is disabled and impersonation is attempted on a request
< [TEST] Impersonation should return error from proxy when impersonation enabled and impersonation is not authorized by the cluster's RBAC
---
> [TEST] Impersonation disabled should not error at proxy when impersonation is disabled and impersonation is attempted on a request
> [TEST] Impersonation enabled should allow an authenticated user to impersonate an authorized user when az by rbac
> [TEST] Impersonation enabled should error at proxy when impersonation enabled but a user is not specified
> [TEST] Impersonation enabled should return error from proxy when impersonation enabled and impersonation is not authorized by the cluster's RBAC
```

Deploy count per container, from `--ginkgo.json-report` on this branch (Ordered containers count 1, others count their spec total):

```
 2 deploy(s)  2 spec(s)  [TEST] Audit                                   (untouched, see scope note)
 1 deploy(s)  7 spec(s)  [TEST] AuthenticationConfiguration multi-issuer
 2 deploy(s)  2 spec(s)  [TEST] Headers
 1 deploy(s)  1 spec(s)  [TEST] Impersonation / disabled
 1 deploy(s)  3 spec(s)  [TEST] Impersonation / enabled
 1 deploy(s)  2 spec(s)  [TEST] Passthrough
 2 deploy(s)  2 spec(s)  [TEST] RBAC
 2 deploy(s)  2 spec(s)  [TEST] Readiness Probe
 1 deploy(s)  6 spec(s)  [TEST] Token
 1 deploy(s)  2 spec(s)  [TEST] Upgrade
TOTAL deploys: 14   specs: 29
```

No assertion, spec, or `It` was deleted, weakened or skipped — only the deploy cadence changed. **No wall-clock measurement is claimed**; the mechanism is 15 fewer issuer+proxy deploy/teardown cycles, each of which includes deployment-ready waits plus two hardcoded 2s sleeps.

Note: `CreateKubeNamespace` uses `GenerateName`, so the two impersonation containers sharing the baseName `impersonation` get distinct namespaces.
