### PR TITLE
ci(e2e): shard e2e-kind across a matrix

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,12 +24,23 @@ jobs:
   # cases. hack/verify-e2e-shards.sh (run in test.yaml) keeps a new case from
   # landing without a label and silently running in no shard at all.
   e2e-shard:
+    # The display name lists the cases in each shard so the check is readable in
+    # the UI (e.g. "e2e (impersonation, headers, probe)") instead of a bare
+    # letter. Keep `cases` in sync with the Ginkgo shard-<x> labels on the
+    # matching framework.CasesDescribe containers.
+    name: e2e (${{ matrix.cases }})
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        shard: [a, b, c]
+        include:
+          - shard: a
+            cases: "impersonation, headers, probe"
+          - shard: b
+            cases: "authconfig, upgrade, audit"
+          - shard: c
+            cases: "passthrough, token, rbac"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,9 +18,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-kind:
+  # The suite is split across shards by Ginkgo label (Label("shard-a") etc. on
+  # each framework.CasesDescribe container). Every shard stands up its own kind
+  # cluster, so wall-clock is the slowest shard rather than the sum of all
+  # cases. hack/verify-e2e-shards.sh (run in test.yaml) keeps a new case from
+  # landing without a label and silently running in no shard at all.
+  e2e-shard:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [a, b, c]
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -48,14 +57,38 @@ jobs:
           kind version
 
       - name: Run e2e suite
-        run: make e2e
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: make e2e "GINKGO_LABEL_FILTER=shard-$SHARD"
 
       - name: Upload e2e artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: e2e-artifacts
+          # Artifact names must be unique within a run; v7 rejects duplicates.
+          name: e2e-artifacts-${{ matrix.shard }}
           path: |
             artifacts/**
           if-no-files-found: ignore
           retention-days: 7
+
+  # Branch protection requires a check literally named "e2e-kind". The job id
+  # is the check name (no `name:` key here on purpose), so this aggregator keeps
+  # that single required check stable while the work happens in the matrix above.
+  # It is green only when every shard succeeded.
+  e2e-kind:
+    runs-on: ubuntu-latest
+    needs: [e2e-shard]
+    if: always()
+    steps:
+      - name: Check shard results
+        env:
+          # For a matrix job this is the aggregate result across all legs, so a
+          # single failed/cancelled/skipped shard fails the required check.
+          SHARDS_RESULT: ${{ needs.e2e-shard.result }}
+        run: |
+          echo "e2e-shard result: $SHARDS_RESULT"
+          if [ "$SHARDS_RESULT" != "success" ]; then
+            echo "::error::e2e shards did not all succeed (result: $SHARDS_RESULT)"
+            exit 1
+          fi

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,6 +44,11 @@ jobs:
       - name: go test
         run: go test ./cmd/... ./pkg/...
 
+      # e2e.yaml runs the suite as three label-filtered shards; an unlabelled
+      # case would run in none of them. Cheap text check, no cluster needed.
+      - name: Verify e2e shard labels
+        run: make verify-e2e-shards
+
   lint:
     # golangci-lint carries pre-existing findings across the repo that are being
     # retired incrementally, so gate on issues introduced by the PR. This makes

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export GO111MODULE=on
 help:  ## display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-.PHONY: help build docker_build test depend verify all clean generate e2e e2e-clean
+.PHONY: help build docker_build test depend verify all clean generate e2e e2e-clean verify-e2e-shards
 
 # golangci-lint is installed via the upstream, GOOS/GOARCH-aware installer,
 # pinned to a supported v2 release. Keep this in lockstep with the version the
@@ -96,6 +96,16 @@ test: generate verify ## run all go tests
 E2E_CLUSTER_NAME := kube-oidc-proxy-e2e
 E2E_TIMEOUT      ?= 30m
 
+# Optional Ginkgo label filter, forwarded to the suite binary as
+# --ginkgo.label-filter. CI uses it to split the suite across a matrix of
+# shards (`make e2e GINKGO_LABEL_FILTER=shard-a`, see .github/workflows/e2e.yaml).
+# Empty (the default) runs every case.
+GINKGO_LABEL_FILTER ?=
+ifneq ($(strip $(GINKGO_LABEL_FILTER)),)
+# -args passes everything after it to the test binary, so it must come last.
+E2E_GOTEST_ARGS := -args --ginkgo.label-filter='$(GINKGO_LABEL_FILTER)'
+endif
+
 # Prerequisites (local runs): go, docker (daemon running), kind, and kubectl on
 # PATH. The suite builds and side-loads the proxy + test-tool images itself and
 # creates/destroys its own kind cluster, so no pre-existing cluster is needed.
@@ -104,7 +114,7 @@ e2e: $(BINDIR)/kubectl ## run the e2e suite hermetically (creates + destroys its
 	@echo "e2e: removing any stale cluster from a previous run"
 	@$(MAKE) --no-print-directory e2e-clean
 	trap '$(MAKE) --no-print-directory e2e-clean' EXIT INT TERM; \
-	KUBE_OIDC_PROXY_ROOT_PATH="$$(pwd)" go test -timeout $(E2E_TIMEOUT) -v --count=1 ./test/e2e/suite/. 2>&1 | tee $(ARTIFACTS)/e2e.log
+	KUBE_OIDC_PROXY_ROOT_PATH="$$(pwd)" go test -timeout $(E2E_TIMEOUT) -v --count=1 ./test/e2e/suite/. $(E2E_GOTEST_ARGS) 2>&1 | tee $(ARTIFACTS)/e2e.log
 
 e2e-clean: ## delete the e2e kind cluster if present (safe to run anytime)
 	@command -v kind >/dev/null 2>&1 || { \
@@ -113,6 +123,9 @@ e2e-clean: ## delete the e2e kind cluster if present (safe to run anytime)
 		exit 1; \
 	}
 	@kind delete cluster --name $(E2E_CLUSTER_NAME) >/dev/null 2>&1 || true
+
+verify-e2e-shards: ## check every e2e case container carries exactly one shard label
+	./hack/verify-e2e-shards.sh
 
 build: generate ## build kube-oidc-proxy
 	mkdir -p ./bin/amd64

--- a/hack/verify-e2e-shards.sh
+++ b/hack/verify-e2e-shards.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Copyright Jetstack Ltd. See LICENSE for details.
+#
+# The e2e suite is sharded across a GitHub Actions matrix by Ginkgo label (see
+# .github/workflows/e2e.yaml). A case container that carries no shard label
+# runs in *zero* shards and silently stops gating PRs, so this check asserts
+# that every framework.CasesDescribe() container declares exactly one label
+# from the known shard set.
+#
+# Keep SHARDS in lockstep with the matrix values in .github/workflows/e2e.yaml.
+set -euo pipefail
+
+CASES_DIR="${1:-test/e2e/suite/cases}"
+SHARDS=(shard-a shard-b shard-c)
+
+shard_pattern="$(IFS='|'; echo "${SHARDS[*]}")"
+rc=0
+total=0
+
+while IFS= read -r file; do
+  containers="$(grep -c 'framework\.CasesDescribe(' "$file" || true)"
+  [ "$containers" -gt 0 ] || continue
+  total=$((total + containers))
+
+  # Every shard label, valid or not, so typos are reported rather than ignored.
+  labels="$(grep -oE 'Label\("shard-[A-Za-z0-9_-]*"\)' "$file" || true)"
+  valid="$(printf '%s\n' "$labels" | grep -cE "Label\(\"($shard_pattern)\"\)" || true)"
+  invalid="$(printf '%s\n' "$labels" | grep -vE "Label\(\"($shard_pattern)\"\)" | grep -c . || true)"
+
+  if [ "$invalid" -ne 0 ]; then
+    echo "$file: unknown shard label(s): $(printf '%s\n' "$labels" | grep -vE "Label\(\"($shard_pattern)\"\)" | tr '\n' ' ')" >&2
+    echo "  known shards: ${SHARDS[*]}" >&2
+    rc=1
+  fi
+
+  if [ "$valid" -ne "$containers" ]; then
+    echo "$file: $containers CasesDescribe container(s) but $valid shard label(s); each container needs exactly one Label(\"shard-*\")" >&2
+    rc=1
+  fi
+done < <(find "$CASES_DIR" -type f -name '*.go' | sort)
+
+if [ "$total" -eq 0 ]; then
+  echo "no framework.CasesDescribe() containers found under $CASES_DIR; is the path right?" >&2
+  exit 1
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "verify-e2e-shards: $total e2e case container(s) each carry exactly one of: ${SHARDS[*]}"
+fi
+
+exit "$rc"

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -38,7 +38,7 @@ const (
 	webhookAuditPath = "/audit-log"
 )
 
-var _ = framework.CasesDescribe("Audit", func() {
+var _ = framework.CasesDescribe("Audit", Label("shard-b"), func() {
 	f := framework.NewDefaultFramework("audit")
 
 	It("should be able to write audit logs to file", func() {

--- a/test/e2e/suite/cases/authconfig/authconfig.go
+++ b/test/e2e/suite/cases/authconfig/authconfig.go
@@ -26,7 +26,7 @@ const (
 
 // Every spec here reads through the same AuthenticationConfiguration proxy
 // deployment and mutates no cluster state, so they all share a single deploy.
-var _ = framework.CasesDescribe("AuthenticationConfiguration multi-issuer", Ordered, ContinueOnFailure, func() {
+var _ = framework.CasesDescribe("AuthenticationConfiguration multi-issuer", Ordered, ContinueOnFailure, Label("shard-b"), func() {
 	f := framework.NewOrderedDefaultFramework("authconfig")
 
 	var (

--- a/test/e2e/suite/cases/headers/headers.go
+++ b/test/e2e/suite/cases/headers/headers.go
@@ -14,7 +14,7 @@ import (
 	testutil "github.com/rafpe/kube-oidc-proxy/test/util"
 )
 
-var _ = framework.CasesDescribe("Headers", func() {
+var _ = framework.CasesDescribe("Headers", Label("shard-a"), func() {
 	f := framework.NewDefaultFramework("headers")
 
 	JustAfterEach(func() {

--- a/test/e2e/suite/cases/impersonation/impersonation.go
+++ b/test/e2e/suite/cases/impersonation/impersonation.go
@@ -18,7 +18,7 @@ import (
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
-var _ = framework.CasesDescribe("Impersonation", func() {
+var _ = framework.CasesDescribe("Impersonation", Label("shard-a"), func() {
 	// These specs all run against a default proxy with impersonation enabled.
 	// The only cluster state they create is cluster-scoped and named by
 	// GenerateName, and none of them assert on its absence, so they share a

--- a/test/e2e/suite/cases/passthrough/passthrough.go
+++ b/test/e2e/suite/cases/passthrough/passthrough.go
@@ -21,7 +21,7 @@ import (
 // proxy itself to enable passthrough. The per-spec Role and RoleBinding below
 // are still created and deleted around every spec, so the shared namespace
 // looks the same to each of them.
-var _ = framework.CasesDescribe("Passthrough", Ordered, ContinueOnFailure, func() {
+var _ = framework.CasesDescribe("Passthrough", Ordered, ContinueOnFailure, Label("shard-c"), func() {
 	f := framework.NewOrderedDefaultFramework("passthrough")
 
 	var saToken string

--- a/test/e2e/suite/cases/probe/probe.go
+++ b/test/e2e/suite/cases/probe/probe.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rafpe/kube-oidc-proxy/test/kind"
 )
 
-var _ = framework.CasesDescribe("Readiness Probe", func() {
+var _ = framework.CasesDescribe("Readiness Probe", Label("shard-a"), func() {
 	f := framework.NewDefaultFramework("readiness-probe")
 
 	It("Should not become ready if the issuer is unavailable", func() {

--- a/test/e2e/suite/cases/rbac/rbac.go
+++ b/test/e2e/suite/cases/rbac/rbac.go
@@ -15,7 +15,7 @@ import (
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 )
 
-var _ = framework.CasesDescribe("RBAC", func() {
+var _ = framework.CasesDescribe("RBAC", Label("shard-c"), func() {
 	f := framework.NewDefaultFramework("rbac")
 
 	It("should return with a forbidden request with a valid token without rbac", func() {

--- a/test/e2e/suite/cases/token/token.go
+++ b/test/e2e/suite/cases/token/token.go
@@ -10,7 +10,7 @@ import (
 
 // Every spec here reads through the same default proxy deployment and mutates
 // no cluster state, so they all share a single deploy.
-var _ = framework.CasesDescribe("Token", Ordered, ContinueOnFailure, func() {
+var _ = framework.CasesDescribe("Token", Ordered, ContinueOnFailure, Label("shard-c"), func() {
 	f := framework.NewOrderedDefaultFramework("token")
 	sharedtests.RunTokenValidationTests(f)
 })

--- a/test/e2e/suite/cases/upgrade/upgrade.go
+++ b/test/e2e/suite/cases/upgrade/upgrade.go
@@ -35,7 +35,7 @@ import (
 // shared. The setup has to be shared rather than per-spec: the Role and
 // RoleBinding below have fixed names and are never deleted, so recreating them
 // for a second spec in the same namespace would fail as already existing.
-var _ = framework.CasesDescribe("Upgrade", Ordered, ContinueOnFailure, func() {
+var _ = framework.CasesDescribe("Upgrade", Ordered, ContinueOnFailure, Label("shard-b"), func() {
 	f := framework.NewOrderedDefaultFramework("upgrade")
 
 	var pod *corev1.Pod


### PR DESCRIPTION
> Stacked on #87 (`test/e2e-group-deploys`). Review that one first; this PR's diff is against it.

The e2e suite runs as a single job, so wall-clock is the sum of every case's deploys. This splits it across three matrix legs by Ginkgo label. Each leg stands up its own kind cluster, so wall-clock becomes the **slowest shard rather than the sum** — roughly a third of the work per leg, minus the fixed cluster-bring-up cost each leg now pays. (No measured numbers yet; the first CI run on this PR will show the real shape.)

## Shard mapping

Every `framework.CasesDescribe` container carries exactly one `Label("shard-…")`. The three heaviest cases (impersonation, audit, and token — which drives the six `sharedtests` specs) are deliberately in different shards.

| Shard | Cases | Dry-run specs |
|---|---|---|
| `shard-a` | impersonation, headers, probe | 8 |
| `shard-b` | audit, authconfig, upgrade | 11 |
| `shard-c` | token, passthrough, rbac | 10 |

8 + 11 + 10 = 29 = the unfiltered total, so the three shards partition the suite with nothing orphaned or double-run.

> **Note on the case list:** `cases/sharedtests` is a helper package (`RunTokenValidationTests`), not a Ginkgo container — it has no `CasesDescribe` and so takes no label; its specs run under `token`. The ninth container is `cases/rbac`, which is labelled here.

## Preserving the `e2e-kind` required check

Branch protection requires a check literally named `e2e-kind`, and a matrix job would publish three differently-named checks. So:

- the matrix job is `e2e-shard`, with `fail-fast: false` so one failing shard still reports the others;
- a dependent job with the job id **`e2e-kind`** (no `name:` key — the job id *is* the check name) `needs: [e2e-shard]`, runs `if: always()`, and exits 1 unless `needs.e2e-shard.result == 'success'`.

For a matrix job that `result` is the aggregate across all legs, so `failure`, `cancelled` and `skipped` are all caught by the single comparison. Net effect: `e2e-kind` is green only when all three shards pass. **No branch-protection settings need to change.**

## Artifact name collision

`actions/upload-artifact@v7` rejects duplicate artifact names within a run, so all three legs uploading `e2e-artifacts` would fail. Renamed to `e2e-artifacts-${{ matrix.shard }}`.

## Guard against unsharded cases

A new case that forgets a label would run in **zero** shards and silently stop gating PRs. `hack/verify-e2e-shards.sh` asserts, per file, that the number of `Label("shard-…")` occurrences equals the number of `CasesDescribe(` containers, and that every label is in the known set `{shard-a, shard-b, shard-c}` — an allowlist, not a `shard-` prefix match, so a typo like `shard-ab` fails rather than passing into oblivion. It only inspects files that actually declare a container, so helper files like `sharedtests.go` are correctly ignored.

Wired into the `test` job (`make verify-e2e-shards`), not the shards: it is a seconds-long text check that needs no Docker or kind and shouldn't run three times.

## Makefile

New `GINKGO_LABEL_FILTER ?=`, forwarded to the existing `go test` invocation as `-args --ginkgo.label-filter='…'` **only when non-empty**. `make e2e` with no filter still runs everything. Still `go test`, not the ginkgo CLI.

## Verification

`kind` isn't available locally, so the suite itself runs in CI. Everything else was checked:

- `go build ./...`, `go vet ./test/e2e/...`, `gofmt -l .` — all clean; `go test -c ./test/e2e/suite/` compiles.
- **Label plumbing proven offline** via `--ginkgo.dry-run`, which builds the real spec tree without a cluster. This confirms `--ginkgo.label-filter` is accepted through `go test -args` and produces the 8/11/10 = 29 partition above.
- `make -n e2e GINKGO_LABEL_FILTER=shard-a` emits `… ./test/e2e/suite/. -args --ginkgo.label-filter='shard-a' …`; `make -n e2e` emits no `-args` at all.
- `actionlint` passes on both changed workflows.
- The guard was tested against a deliberately unlabelled case and a `shard-ab` typo; it fails both with a pointed message.

Actions stay SHA-pinned and the workflow-level `permissions: contents: read` is unchanged; the aggregator uses no actions. `e2e-oidc-gha.yaml` is untouched.
