### PR TITLE
docs: install from the published OCI chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ A reverse proxy that brings OIDC login to managed Kubernetes clusters, with mult
 
 Prerequisites: a Kubernetes cluster, `kubectl`, Helm 3+, and one or more OIDC issuers (see [prerequisites](./docs/getting-started.md#prerequisites)).
 
-Install the local chart — it pulls the published `ghcr.io/rafpe/kube-oidc-proxy:1.1.0` image:
+Install from the published, signed OCI chart:
 
 ```sh
-helm install kube-oidc-proxy ./chart/kube-oidc-proxy \
+helm install kube-oidc-proxy oci://ghcr.io/rafpe/charts/kube-oidc-proxy \
   --namespace kube-oidc-proxy --create-namespace \
   --set oidc.clientId=<client-id> \
   --set oidc.issuerUrl=https://<issuer-url> \
   --set oidc.usernameClaim=email
 ```
 
-Once the OCI chart is published, `oci://ghcr.io/rafpe/charts/kube-oidc-proxy` will work as a drop-in replacement for `./chart/kube-oidc-proxy` (same `--set` flags). Until then, use the local chart above.
+Add `--version <x.y.z>` to pin a specific [release](https://github.com/rafpe/kube-oidc-proxy/releases); omit it for the latest. To install from a local checkout instead, swap the chart reference for `./chart/kube-oidc-proxy`.
 
 Verify — port-forward the proxy and ask the cluster who you are:
 

--- a/chart/kube-oidc-proxy/README.md
+++ b/chart/kube-oidc-proxy/README.md
@@ -24,14 +24,16 @@ values are ignored. Do not configure both modes at once.
 
 ## Install
 
-Once the release pipeline is live the chart is published as an OCI artifact at
-`oci://ghcr.io/rafpe/charts/kube-oidc-proxy` (not yet published). Until then,
-install it from a checkout of this repository.
+The chart is published as a signed OCI artifact at
+`oci://ghcr.io/rafpe/charts/kube-oidc-proxy`. Add `--version <x.y.z>` to pin a
+specific release (see [releases](https://github.com/rafpe/kube-oidc-proxy/releases));
+omit it for the latest. To work from a local checkout instead, replace the chart
+reference with `./chart/kube-oidc-proxy`.
 
 Single-issuer:
 
 ```sh
-helm install kube-oidc-proxy ./chart/kube-oidc-proxy \
+helm install kube-oidc-proxy oci://ghcr.io/rafpe/charts/kube-oidc-proxy \
   --set oidc.clientId=my-client \
   --set oidc.issuerUrl=https://accounts.google.com \
   --set oidc.usernameClaim=email
@@ -40,7 +42,7 @@ helm install kube-oidc-proxy ./chart/kube-oidc-proxy \
 Or with a values file:
 
 ```sh
-helm install kube-oidc-proxy ./chart/kube-oidc-proxy -f my-values.yaml
+helm install kube-oidc-proxy oci://ghcr.io/rafpe/charts/kube-oidc-proxy -f my-values.yaml
 ```
 
 Uninstall:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,29 +15,26 @@ values reference.
 - Optional: [cert-manager](https://github.com/jetstack/cert-manager), to issue
   the proxy's serving certificate.
 
-> [!IMPORTANT]
-> The image `ghcr.io/rafpe/kube-oidc-proxy:1.1.0` is **published** — the local
-> chart (option 1) pulls it and works today. The OCI chart
-> `oci://ghcr.io/rafpe/charts/kube-oidc-proxy` is not published yet; use it only
-> once the release pipeline lands.
-
 ## Install
 
-### 1. From a local checkout
+### 1. From the OCI registry (recommended)
 
 ```sh
-helm install kube-oidc-proxy ./chart/kube-oidc-proxy \
+helm install kube-oidc-proxy oci://ghcr.io/rafpe/charts/kube-oidc-proxy \
   --namespace kube-oidc-proxy --create-namespace \
   --set oidc.clientId=<client-id> \
   --set oidc.issuerUrl=https://<issuer-url> \
   --set oidc.usernameClaim=email
 ```
 
-### 2. From the OCI registry (once published)
+The chart and image are signed (cosign, keyless). Add `--version <x.y.z>` to pin
+a specific [release](https://github.com/rafpe/kube-oidc-proxy/releases); omit it
+for the latest.
+
+### 2. From a local checkout
 
 ```sh
-helm install kube-oidc-proxy \
-  oci://ghcr.io/rafpe/charts/kube-oidc-proxy \
+helm install kube-oidc-proxy ./chart/kube-oidc-proxy \
   --namespace kube-oidc-proxy --create-namespace \
   --set oidc.clientId=<client-id> \
   --set oidc.issuerUrl=https://<issuer-url> \

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -213,7 +213,7 @@ authenticationConfig:
           expression: '["github:" + claims.repository_owner]'
 EOF
 
-helm install kube-oidc-proxy ./chart/kube-oidc-proxy \
+helm install kube-oidc-proxy oci://ghcr.io/rafpe/charts/kube-oidc-proxy \
   -n kube-oidc-proxy --create-namespace -f /tmp/values-test.yaml
 kubectl -n kube-oidc-proxy rollout status deploy/kube-oidc-proxy --timeout=180s
 


### PR DESCRIPTION
The chart is published and signed at `oci://ghcr.io/rafpe/charts/kube-oidc-proxy` (latest 1.1.2), but the docs still said it was *not yet published* and told people to install from a local checkout — including the **chart README that Artifact Hub renders**.

## Changes
- **chart/kube-oidc-proxy/README.md** — Install section now leads with the OCI chart (this is what Artifact Hub shows).
- **README.md** — Quickstart installs from OCI; removed the hardcoded `:1.1.0` image tag and the 'once the OCI chart is published…' sentence.
- **docs/getting-started.md** — OCI is option 1 (recommended); dropped the stale IMPORTANT note.
- **docs/operations.md** — the multi-issuer walkthrough installs from OCI.

All install commands use `--version <x.y.z>` guidance (pin or latest) instead of hardcoding a version, so they don't drift again.

## Why release/patch
Artifact Hub renders the README packaged **in the chart**, so it only refreshes when a new chart version is published. Merging this cuts the next patch (v1.1.3), which republishes the chart with the corrected README — after which Artifact Hub updates.