### PR TITLE
test(fuzz): fuzz attacker-controlled parsers, clear the unfixable OSV advisory

### DIFF
--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -1,0 +1,66 @@
+name: fuzz
+
+# Go native fuzzing for the parsers that sit on attacker-controlled input.
+# The seed corpora already run on every PR as part of `go test` in test.yaml;
+# this workflow spends real fuzzing time on a schedule instead of per-PR, so it
+# never gates a merge on a nondeterministic search.
+on:
+  schedule:
+    - cron: "42 5 * * 3" # weekly, Wednesday 05:42 UTC
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: "Duration to fuzz each target (Go duration, e.g. 10m)"
+        required: false
+        default: "5m"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: ./pkg/util/token
+            target: FuzzParseFromRequest
+          - package: ./pkg/proxy
+            target: FuzzParseTrustedProxies
+          - package: ./pkg/util/flags
+            target: FuzzStringToStringSliceSet
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Generate mocks
+        run: go run go.uber.org/mock/mockgen -package=mocks -destination pkg/mocks/authenticator.go k8s.io/apiserver/pkg/authentication/authenticator Token
+
+      # Inputs go through env rather than ${{ }} interpolation in the shell, so
+      # a dispatch value can never be spliced into the command line.
+      - name: Fuzz
+        env:
+          PACKAGE: ${{ matrix.package }}
+          TARGET: ${{ matrix.target }}
+          FUZZTIME: ${{ inputs.fuzztime || '5m' }}
+        run: go test "$PACKAGE" -run '^$' -fuzz "^${TARGET}\$" -fuzztime "$FUZZTIME"
+
+      # A failing input is written to testdata/fuzz/<target>/; publish it so the
+      # crasher can be committed as a regression seed.
+      - name: Upload failing corpus
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-corpus-${{ matrix.target }}
+          path: ${{ matrix.package }}/testdata/fuzz/
+          if-no-files-found: error
+          retention-days: 14

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,14 @@
+# Vulnerability exceptions for OSV-based scanners (OSV-Scanner, OpenSSF
+# Scorecard's Vulnerabilities check). Entries here must state why the advisory
+# does not apply to this project.
+
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = """
+golang.org/x/crypto/openpgp is unmaintained and unsafe by design. The advisory
+has no fixed version, so it cannot be remediated by upgrading. This project does
+not import golang.org/x/crypto/openpgp: x/crypto is an indirect dependency
+pulled in by k8s.io/apiserver, which uses golang.org/x/crypto/cryptobyte only.
+govulncheck (run in .github/workflows/security.yaml) confirms no vulnerable
+symbol is reachable from this codebase.
+"""

--- a/pkg/proxy/proxy_fuzz_test.go
+++ b/pkg/proxy/proxy_fuzz_test.go
@@ -1,0 +1,62 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package proxy
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// FuzzParseTrustedProxies drives trusted-proxy CIDR parsing with arbitrary
+// input. Getting this wrong decides whether X-Forwarded-For is believed, so a
+// malformed entry must fail loudly rather than yield a partial or unexpectedly
+// wide set of networks.
+func FuzzParseTrustedProxies(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"10.0.0.0/8",
+		" 192.168.0.1/32 ",
+		"2001:db8::/32",
+		"not-a-cidr",
+		"10.0.0.0/8,not-a-cidr",
+		"10.0.0.0/8, ,192.168.0.0/16",
+		"10.0.0.1/0",
+		"::/0",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, joined string) {
+		cidrs := strings.Split(joined, ",")
+
+		nets, err := parseTrustedProxies(cidrs)
+		if err != nil {
+			if nets != nil {
+				t.Fatalf("networks returned alongside error %q: %v", err, nets)
+			}
+			return
+		}
+
+		if len(nets) != len(cidrs) {
+			t.Fatalf("parsed %d networks from %d entries (%q)", len(nets), len(cidrs), joined)
+		}
+
+		for i, n := range nets {
+			if n == nil {
+				t.Fatalf("entry %d (%q) parsed to a nil network", i, cidrs[i])
+			}
+			// A parsed network is always the masked base address, so it must
+			// contain itself and survive a canonical-form round trip.
+			if !n.Contains(n.IP) {
+				t.Fatalf("network %s does not contain its own base address", n)
+			}
+			_, again, err := net.ParseCIDR(n.String())
+			if err != nil {
+				t.Fatalf("re-parsing %s from entry %q: %s", n, cidrs[i], err)
+			}
+			if again.String() != n.String() {
+				t.Fatalf("round trip changed %s into %s", n, again)
+			}
+		}
+	})
+}

--- a/pkg/util/flags/string_to_string_slice_fuzz_test.go
+++ b/pkg/util/flags/string_to_string_slice_fuzz_test.go
@@ -1,0 +1,77 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package flags
+
+import (
+	"encoding/csv"
+	"strings"
+	"testing"
+)
+
+// FuzzStringToStringSliceSet drives the map[string][]string flag parser with
+// arbitrary values. Set feeds a CSV reader and splits on "=", so it must reject
+// malformed input cleanly — leaving no half-populated map behind — and String
+// must stay panic-free on whatever it accepted.
+func FuzzStringToStringSliceSet(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"a=1",
+		"a=-7,b=2,a=3",
+		"a",
+		"a=1=2",
+		"a=",
+		"=1",
+		`"a,b"=1`,
+		"a=1,\n",
+		`"unterminated`,
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, val string) {
+		m := map[string][]string{}
+		v := NewStringToStringSliceValue(&m)
+
+		if err := v.Set(val); err != nil {
+			if len(m) != 0 {
+				t.Fatalf("map left populated after error %q: %v", err, m)
+			}
+			return
+		}
+
+		// String panics on a CSV write failure; make sure nothing Set accepted
+		// can reach that.
+		_ = v.String()
+
+		var stored int
+		for k, vs := range m {
+			if strings.Contains(k, "=") {
+				t.Fatalf("key %q contains a separator", k)
+			}
+			for _, s := range vs {
+				if strings.Contains(s, "=") {
+					t.Fatalf("value %q for key %q contains a separator", s, k)
+				}
+			}
+			stored += len(vs)
+		}
+
+		// Every accepted CSV field must have produced exactly one entry;
+		// silently dropping one would widen or narrow the resulting config.
+		if want := countFields(val); stored != want {
+			t.Fatalf("stored %d entries for %d fields in %q", stored, want, val)
+		}
+	})
+}
+
+// countFields reports how many comma-separated fields Set would have read from
+// val, mirroring its CSV reader as an independent oracle.
+func countFields(val string) int {
+	if len(val) == 0 {
+		return 0
+	}
+	fields, err := csv.NewReader(strings.NewReader(val)).Read()
+	if err != nil {
+		return 0
+	}
+	return len(fields)
+}

--- a/pkg/util/token/token_fuzz_test.go
+++ b/pkg/util/token/token_fuzz_test.go
@@ -1,0 +1,63 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package token
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// FuzzParseFromRequest drives bearer-token extraction with arbitrary
+// Authorization headers. The header is fully attacker-controlled on every
+// request the proxy serves, so extraction must never panic and must only hand
+// back a token when the header really is a "bearer <token>" pair.
+func FuzzParseFromRequest(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"bearer abc",
+		"Bearer abc",
+		"BEARER  abc",
+		"bearer",
+		"bearer ",
+		"  bearer abc  ",
+		"basic abc",
+		"bearer abc def",
+		"bearer\tabc",
+		"bearerabc",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, auth string) {
+		req, err := http.NewRequest(http.MethodGet, "http://localhost/", nil)
+		if err != nil {
+			t.Fatalf("building request: %s", err)
+		}
+		// Assign directly: Header.Set would reject values the wire can carry.
+		req.Header["Authorization"] = []string{auth}
+
+		token, ok := ParseFromRequest(req)
+
+		if !ok {
+			if token != "" {
+				t.Fatalf("token %q returned alongside ok=false", token)
+			}
+			return
+		}
+
+		if token == "" {
+			t.Fatal("ok=true with an empty token")
+		}
+		if strings.Contains(token, " ") {
+			t.Fatalf("token %q contains a space", token)
+		}
+
+		trimmed := strings.TrimSpace(auth)
+		if !strings.HasPrefix(strings.ToLower(trimmed), "bearer ") {
+			t.Fatalf("token accepted from a non-bearer header %q", auth)
+		}
+		if !strings.Contains(trimmed, token) {
+			t.Fatalf("token %q is not a substring of header %q", token, auth)
+		}
+	})
+}


### PR DESCRIPTION
## What & why

Clears the two OpenSSF Scorecard code-scanning alerts that are actually fixable by a change to this repository.

**Vulnerabilities (#5, high) — 9 → 10.** `GO-2026-5932` (`golang.org/x/crypto/openpgp` is unmaintained) has **no fixed version**, so no dependency bump can clear it. `x/crypto` is indirect via `k8s.io/apiserver`, which uses `cryptobyte` only, and `govulncheck` confirms no vulnerable symbol is reachable. Recorded as a justified exception in `osv-scanner.toml` next to `go.mod` — the remediation both OSV-Scanner and Scorecard read.

**Fuzzing (#6, medium) — 0 → 10.** Go native fuzz targets on the three parsers that sit on input the proxy does not control:

| Target | Parser | Why it matters |
|---|---|---|
| `FuzzParseFromRequest` | `ParseFromRequest` | the `Authorization` header of every request |
| `FuzzParseTrustedProxies` | `parseTrustedProxies` | decides whether `X-Forwarded-For` is believed |
| `FuzzStringToStringSliceSet` | `stringToStringSliceValue.Set` | the `map[string][]string` flag parser |

Each asserts the parser's contract, not just the absence of a panic — no token from a non-bearer header, no partial network set behind an error, no silently dropped CSV field, and nothing `Set` accepts that can reach the `panic` in `String`.

Seed corpora run on every PR through the existing `go test`. `fuzz.yaml` spends real fuzzing time weekly and on demand, so a nondeterministic search never gates a merge; a crasher is uploaded as an artifact for committing as a regression seed.

Both scores verified locally before pushing:

```
$ scorecard --local . --checks=Fuzzing,Vulnerabilities
"score":10, "reason":"project is fuzzed"
"score":10, "reason":"0 existing vulnerabilities detected"
```

No shipped code changes — tests, a workflow, and a scanner config only.

### The other five alerts

Not fixable here, recorded so they aren't re-investigated:

- **SAST (#14, medium)** — "10 of 30 commits" is exactly the number of commits since CodeQL landed in 3c0f85c9 (#85). Config is already correct; self-heals.
- **Maintained (#16, high)** — repository age only. Clears once the repo is over 90 days old.
- **Code-Review (#15, high)** — needs approvals from a second person; not achievable on a single-maintainer repo.
- **Branch-Protection (#1, high)** — 3 → 4, addressed out-of-band by enabling stale-review dismissal and last-push approval on the `main` ruleset. The remaining warnings (required approvers, CODEOWNERS review) would lock a solo maintainer out of merging.
- **CII-Best-Practices (#17, low)** — a manual questionnaire at bestpractices.dev.

## Checklist

- [x] Tests added or updated where it makes sense
- [x] `go test ./cmd/... ./pkg/...` passes (and `make e2e` if behaviour changed)
- [x] Docs / chart values updated if flags or behaviour changed — n/a, no flags or behaviour change
- [x] Commits are focused, with no unrelated changes
- [x] Exactly one `release/*` label is set.
- [x] Non-skip changes include a `.changes/unreleased/*.yaml` fragment; skip changes include none.
