### PR TITLE
fix(audit): record streaming requests as long-running, and classify core group requests correctly

### DIFF
--- a/.changes/unreleased/20260818-security-audit-long-running.yaml
+++ b/.changes/unreleased/20260818-security-audit-long-running.yaml
@@ -1,0 +1,2 @@
+kind: Security
+body: Audit streaming requests as long-running — exec, attach, portforward, log and proxy are now recorded when the response starts instead of only when the stream ends, so a long session is no longer missing from the audit log while it runs, or entirely if the proxy dies first. These requests now emit a ResponseStarted event as well as ResponseComplete, so audit volume for exec, attach and portforward increases.

--- a/.changes/unreleased/20260819-security-audit-request-classification.yaml
+++ b/.changes/unreleased/20260819-security-audit-request-classification.yaml
@@ -1,0 +1,11 @@
+kind: Security
+body: >-
+  Audit requests to the core API group (/api/...) are now classified correctly.
+  The audit server config named no legacy API prefix, so every core group
+  request — which is where pods, and therefore exec, attach, portforward and
+  log, live — was recorded as a non-resource request, with the lowercased HTTP
+  method as its verb and no objectRef, and the long-running check could never
+  match a streaming subresource. Audit events for these requests now carry the
+  Kubernetes verb (list, create, watch and so on) and an objectRef naming the
+  resource, namespace, name and subresource. If you parse audit logs or write
+  audit policy rules matching on verb or resource, expect the corrected values.

--- a/.changes/unreleased/20260819-security-audit-request-classification.yaml
+++ b/.changes/unreleased/20260819-security-audit-request-classification.yaml
@@ -2,10 +2,10 @@ kind: Security
 body: >-
   Audit requests to the core API group (/api/...) are now classified correctly.
   The audit server config named no legacy API prefix, so every core group
-  request — which is where pods, and therefore exec, attach, portforward and
-  log, live — was recorded as a non-resource request, with the lowercased HTTP
-  method as its verb and no objectRef, and the long-running check could never
-  match a streaming subresource. Audit events for these requests now carry the
+  request — which is where pods and services live, and with them exec, attach,
+  portforward, log and proxy — was recorded as a non-resource request, with the
+  lowercased HTTP method as its verb and no objectRef, and neither the
+  long-running check nor a watch could ever be recognised. Audit events for these requests now carry the
   Kubernetes verb (list, create, watch and so on) and an objectRef naming the
   resource, namespace, name and subresource. If you parse audit logs or write
   audit policy rules matching on verb or resource, expect the corrected values.

--- a/pkg/proxy/audit/audit.go
+++ b/pkg/proxy/audit/audit.go
@@ -52,9 +52,10 @@ func New(opts *options.AuditOptions, externalAddress string, secureServingInfo *
 		// request: no resource, no subresource, and a verb that is only the
 		// lowercased HTTP method. The audit event then carries "post" rather
 		// than "create" and no objectRef, and longRunningRequests never sees
-		// the subresource it matches on, so exec, attach, portforward and log
-		// (all of them core group pod subresources) are never treated as long
-		// running however the set above is written.
+		// the verb or subresource it matches on, so exec, attach, portforward,
+		// log and proxy are never treated as long running however the set above
+		// is written — nor is a core group watch, which the generic default
+		// already covered. All of them live under /api.
 		LegacyAPIGroupPrefixes: sets.NewString(server.DefaultLegacyAPIPrefix),
 	}
 

--- a/pkg/proxy/audit/audit.go
+++ b/pkg/proxy/audit/audit.go
@@ -17,6 +17,19 @@ import (
 	"k8s.io/component-base/version"
 )
 
+// longRunningRequests reports whether a request streams for as long as the
+// caller holds it open. It decides when the audit log hears about a request: a
+// short request is recorded once, at completion; a long-running one is recorded
+// when the response starts and again when the stream ends. The generic
+// apiserver default treats only watch this way because a generic API server has
+// no inherent long-running subresources — but everything this proxy forwards
+// goes to a kube-apiserver, so kube-apiserver's own set is the set that applies.
+// Without this, an hour-long exec leaves nothing in the audit log for that hour,
+// and nothing at all if the proxy is killed before the session ends.
+var longRunningRequests = genericfilters.BasicLongRunningRequestCheck(
+	sets.NewString("watch", "proxy"),
+	sets.NewString("attach", "exec", "proxy", "log", "portforward"))
+
 type Audit struct {
 	opts         *options.AuditOptions
 	serverConfig *server.CompletedConfig
@@ -30,11 +43,7 @@ func New(opts *options.AuditOptions, externalAddress string, secureServingInfo *
 		ExternalAddress: externalAddress,
 		SecureServing:   secureServingInfo,
 
-		// Default to treating watch as a long-running operation.
-		// Generic API servers have no inherent long-running subresources.
-		// This is so watch requests are handled correctly in the audit log.
-		LongRunningFunc: genericfilters.BasicLongRunningRequestCheck(
-			sets.NewString("watch"), sets.NewString()),
+		LongRunningFunc: longRunningRequests,
 	}
 
 	// We do not support dynamic auditing, so leave nil

--- a/pkg/proxy/audit/audit.go
+++ b/pkg/proxy/audit/audit.go
@@ -44,6 +44,18 @@ func New(opts *options.AuditOptions, externalAddress string, secureServingInfo *
 		SecureServing:   secureServingInfo,
 
 		LongRunningFunc: longRunningRequests,
+
+		// Complete() derives the RequestInfo resolver from this, and
+		// server.NewRequestInfoResolver seeds the resolver with the group
+		// prefix (/apis) plus these legacy, groupless prefixes. Left empty, a
+		// request under /api — the whole core group — parses as a non-resource
+		// request: no resource, no subresource, and a verb that is only the
+		// lowercased HTTP method. The audit event then carries "post" rather
+		// than "create" and no objectRef, and longRunningRequests never sees
+		// the subresource it matches on, so exec, attach, portforward and log
+		// (all of them core group pod subresources) are never treated as long
+		// running however the set above is written.
+		LegacyAPIGroupPrefixes: sets.NewString(server.DefaultLegacyAPIPrefix),
 	}
 
 	// We do not support dynamic auditing, so leave nil

--- a/pkg/proxy/audit/audit_test.go
+++ b/pkg/proxy/audit/audit_test.go
@@ -74,6 +74,17 @@ func TestLongRunningRequests(t *testing.T) {
 			},
 			want: true,
 		},
+		// The proxy verb allows no subresource, so the verb alone has to carry
+		// the decision. See the legacy path case in TestRequestInfoLongRunning
+		// for the URL form that produces it.
+		"proxy verb": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "proxy",
+				Resource:          "services",
+			},
+			want: true,
+		},
 		"get pods": {
 			info: &request.RequestInfo{
 				IsResourceRequest: true,
@@ -134,6 +145,7 @@ func TestRequestInfoLongRunning(t *testing.T) {
 		url             string
 		wantVerb        string
 		wantResource    string
+		wantName        string
 		wantSubresource string
 		wantLongRunning bool
 	}{
@@ -142,6 +154,7 @@ func TestRequestInfoLongRunning(t *testing.T) {
 			url:             "/api/v1/namespaces/ns-1/pods/pod-1/exec?command=sh&container=c-1&stdout=true",
 			wantVerb:        "create",
 			wantResource:    "pods",
+			wantName:        "pod-1",
 			wantSubresource: "exec",
 			wantLongRunning: true,
 		},
@@ -150,6 +163,7 @@ func TestRequestInfoLongRunning(t *testing.T) {
 			url:             "/api/v1/namespaces/ns-1/pods/pod-1/attach?container=c-1",
 			wantVerb:        "create",
 			wantResource:    "pods",
+			wantName:        "pod-1",
 			wantSubresource: "attach",
 			wantLongRunning: true,
 		},
@@ -158,6 +172,7 @@ func TestRequestInfoLongRunning(t *testing.T) {
 			url:             "/api/v1/namespaces/ns-1/pods/pod-1/portforward",
 			wantVerb:        "create",
 			wantResource:    "pods",
+			wantName:        "pod-1",
 			wantSubresource: "portforward",
 			wantLongRunning: true,
 		},
@@ -166,7 +181,52 @@ func TestRequestInfoLongRunning(t *testing.T) {
 			url:             "/api/v1/namespaces/ns-1/pods/pod-1/log?follow=true",
 			wantVerb:        "get",
 			wantResource:    "pods",
+			wantName:        "pod-1",
 			wantSubresource: "log",
+			wantLongRunning: true,
+		},
+		"proxy to a service": {
+			method:          http.MethodGet,
+			url:             "/api/v1/namespaces/ns-1/services/svc-1/proxy",
+			wantVerb:        "get",
+			wantResource:    "services",
+			wantName:        "svc-1",
+			wantSubresource: "proxy",
+			wantLongRunning: true,
+		},
+		// A service proxy usually names a port and a path to reach inside the
+		// service. The port travels in the object name and the path is a
+		// trailing part the resolver does not interpret, so neither disturbs
+		// the subresource the long-running check matches on.
+		"proxy to a service port and path": {
+			method:          http.MethodGet,
+			url:             "/api/v1/namespaces/ns-1/services/svc-1:8080/proxy/healthz",
+			wantVerb:        "get",
+			wantResource:    "services",
+			wantName:        "svc-1:8080",
+			wantSubresource: "proxy",
+			wantLongRunning: true,
+		},
+		"proxy to a node": {
+			method:          http.MethodGet,
+			url:             "/api/v1/nodes/node-1/proxy/logs",
+			wantVerb:        "get",
+			wantResource:    "nodes",
+			wantName:        "node-1",
+			wantSubresource: "proxy",
+			wantLongRunning: true,
+		},
+		// The proxy verb, as opposed to the proxy subresource above, only ever
+		// arrives through the deprecated verb-via-path form the resolver still
+		// parses (specialVerbs). It allows no subresource, so it is the verb
+		// alone that has to make the request long running — which is why the
+		// verb set carries proxy as well as watch.
+		"proxy verb through the legacy path": {
+			method:          http.MethodGet,
+			url:             "/api/v1/proxy/namespaces/ns-1/services/svc-1",
+			wantVerb:        "proxy",
+			wantResource:    "services",
+			wantName:        "svc-1",
 			wantLongRunning: true,
 		},
 		"watch pods in the core group": {
@@ -194,6 +254,7 @@ func TestRequestInfoLongRunning(t *testing.T) {
 			url:          "/api/v1/namespaces/ns-1/pods/pod-1",
 			wantVerb:     "get",
 			wantResource: "pods",
+			wantName:     "pod-1",
 		},
 		"create a pod": {
 			method:       http.MethodPost,
@@ -222,6 +283,10 @@ func TestRequestInfoLongRunning(t *testing.T) {
 
 			if info.Resource != test.wantResource {
 				t.Errorf("resource for %s = %q, want %q", test.url, info.Resource, test.wantResource)
+			}
+
+			if info.Name != test.wantName {
+				t.Errorf("name for %s = %q, want %q", test.url, info.Name, test.wantName)
 			}
 
 			if info.Subresource != test.wantSubresource {

--- a/pkg/proxy/audit/audit_test.go
+++ b/pkg/proxy/audit/audit_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 
 	"k8s.io/apiserver/pkg/endpoints/request"
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+
+	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
 )
 
 // TestLongRunningRequests pins the set of requests the audit filter treats as
@@ -103,6 +106,130 @@ func TestLongRunningRequests(t *testing.T) {
 
 			if got := longRunningRequests(req, test.info); got != test.want {
 				t.Errorf("longRunningRequests(%+v) = %t, want %t", test.info, got, test.want)
+			}
+		})
+	}
+}
+
+// TestRequestInfoLongRunning drives real request URLs through the RequestInfo
+// resolver that New builds, rather than a hand written RequestInfo. The
+// distinction matters: the resolver is what decides whether a URL is a resource
+// request at all, and a request it does not recognise arrives at the check
+// above with no subresource and the bare HTTP method as its verb, so the check
+// can only ever answer false however its sets are written. Everything under
+// /api — the core group, where every long-running pod subresource lives — is
+// exactly such a request unless the server config names the legacy prefix.
+func TestRequestInfoLongRunning(t *testing.T) {
+	// An external address with a port, since without one Complete() insists on
+	// deriving the port from a secure serving info this test has no use for.
+	auditor, err := New(&options.AuditOptions{AuditOptions: apiserveroptions.NewAuditOptions()}, "127.0.0.1:6443", nil)
+	if err != nil {
+		t.Fatalf("failed to create auditor: %s", err)
+	}
+
+	resolver := auditor.serverConfig.RequestInfoResolver
+
+	tests := map[string]struct {
+		method          string
+		url             string
+		wantVerb        string
+		wantResource    string
+		wantSubresource string
+		wantLongRunning bool
+	}{
+		"exec into a pod": {
+			method:          http.MethodPost,
+			url:             "/api/v1/namespaces/ns-1/pods/pod-1/exec?command=sh&container=c-1&stdout=true",
+			wantVerb:        "create",
+			wantResource:    "pods",
+			wantSubresource: "exec",
+			wantLongRunning: true,
+		},
+		"attach to a pod": {
+			method:          http.MethodPost,
+			url:             "/api/v1/namespaces/ns-1/pods/pod-1/attach?container=c-1",
+			wantVerb:        "create",
+			wantResource:    "pods",
+			wantSubresource: "attach",
+			wantLongRunning: true,
+		},
+		"port forward to a pod": {
+			method:          http.MethodPost,
+			url:             "/api/v1/namespaces/ns-1/pods/pod-1/portforward",
+			wantVerb:        "create",
+			wantResource:    "pods",
+			wantSubresource: "portforward",
+			wantLongRunning: true,
+		},
+		"follow pod logs": {
+			method:          http.MethodGet,
+			url:             "/api/v1/namespaces/ns-1/pods/pod-1/log?follow=true",
+			wantVerb:        "get",
+			wantResource:    "pods",
+			wantSubresource: "log",
+			wantLongRunning: true,
+		},
+		"watch pods in the core group": {
+			method:          http.MethodGet,
+			url:             "/api/v1/namespaces/ns-1/pods?watch=true",
+			wantVerb:        "watch",
+			wantResource:    "pods",
+			wantLongRunning: true,
+		},
+		"watch deployments in a named group": {
+			method:          http.MethodGet,
+			url:             "/apis/apps/v1/namespaces/ns-1/deployments?watch=true",
+			wantVerb:        "watch",
+			wantResource:    "deployments",
+			wantLongRunning: true,
+		},
+		"list pods": {
+			method:       http.MethodGet,
+			url:          "/api/v1/namespaces/ns-1/pods",
+			wantVerb:     "list",
+			wantResource: "pods",
+		},
+		"get a pod": {
+			method:       http.MethodGet,
+			url:          "/api/v1/namespaces/ns-1/pods/pod-1",
+			wantVerb:     "get",
+			wantResource: "pods",
+		},
+		"create a pod": {
+			method:       http.MethodPost,
+			url:          "/api/v1/namespaces/ns-1/pods",
+			wantVerb:     "create",
+			wantResource: "pods",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(test.method, test.url, nil)
+
+			info, err := resolver.NewRequestInfo(req)
+			if err != nil {
+				t.Fatalf("failed to resolve request info for %s: %s", test.url, err)
+			}
+
+			if !info.IsResourceRequest {
+				t.Errorf("%s resolved as a non-resource request, want a resource request", test.url)
+			}
+
+			if info.Verb != test.wantVerb {
+				t.Errorf("verb for %s = %q, want %q", test.url, info.Verb, test.wantVerb)
+			}
+
+			if info.Resource != test.wantResource {
+				t.Errorf("resource for %s = %q, want %q", test.url, info.Resource, test.wantResource)
+			}
+
+			if info.Subresource != test.wantSubresource {
+				t.Errorf("subresource for %s = %q, want %q", test.url, info.Subresource, test.wantSubresource)
+			}
+
+			if got := longRunningRequests(req, info); got != test.wantLongRunning {
+				t.Errorf("longRunningRequests(%s) = %t, want %t", test.url, got, test.wantLongRunning)
 			}
 		})
 	}

--- a/pkg/proxy/audit/audit_test.go
+++ b/pkg/proxy/audit/audit_test.go
@@ -1,0 +1,109 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package audit
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// TestLongRunningRequests pins the set of requests the audit filter treats as
+// long-running. Everything this proxy forwards goes to a kube-apiserver, so the
+// streaming subresources must be recorded when the response starts, not only
+// when the stream finally ends.
+func TestLongRunningRequests(t *testing.T) {
+	tests := map[string]struct {
+		info *request.RequestInfo
+		want bool
+	}{
+		"watch pods": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "watch",
+				Resource:          "pods",
+			},
+			want: true,
+		},
+		"exec into a pod": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "get",
+				Resource:          "pods",
+				Subresource:       "exec",
+			},
+			want: true,
+		},
+		"attach to a pod": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "get",
+				Resource:          "pods",
+				Subresource:       "attach",
+			},
+			want: true,
+		},
+		"port forward to a pod": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "get",
+				Resource:          "pods",
+				Subresource:       "portforward",
+			},
+			want: true,
+		},
+		"follow pod logs": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "get",
+				Resource:          "pods",
+				Subresource:       "log",
+			},
+			want: true,
+		},
+		"service proxy": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "get",
+				Resource:          "services",
+				Subresource:       "proxy",
+			},
+			want: true,
+		},
+		"get pods": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "get",
+				Resource:          "pods",
+			},
+			want: false,
+		},
+		"list pods": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "list",
+				Resource:          "pods",
+			},
+			want: false,
+		},
+		"create pods": {
+			info: &request.RequestInfo{
+				IsResourceRequest: true,
+				Verb:              "create",
+				Resource:          "pods",
+			},
+			want: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			if got := longRunningRequests(req, test.info); got != test.want {
+				t.Errorf("longRunningRequests(%+v) = %t, want %t", test.info, got, test.want)
+			}
+		})
+	}
+}

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,8 +17,12 @@ import (
 
 	authnv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	auditv1 "k8s.io/apiserver/pkg/apis/audit/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
 
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
 	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework/helper"
@@ -42,74 +47,153 @@ var _ = framework.CasesDescribe("Audit", Label("shard-b"), func() {
 	f := framework.NewDefaultFramework("audit")
 
 	It("should be able to write audit logs to file", func() {
-		By("Creating policy file ConfigMap")
-		cm, err := f.Helper().KubeClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), &corev1.ConfigMap{
+		deployProxyWithAuditLogFile(f)
+
+		testAuditLogs(f, "app=kube-oidc-proxy-e2e", auditReaderName, auditLogPath)
+	})
+
+	// A streaming request has to be recorded when the stream starts, not only
+	// when it ends: the proxy treats kube-apiserver's long running verbs and
+	// subresources as long running, so an exec is audited as soon as the
+	// connection is upgraded. Without that, an hour long exec leaves nothing in
+	// the audit log for that hour, and nothing at all if the proxy dies first.
+	It("should write a ResponseStarted audit event when a long running request starts", func() {
+		deployProxyWithAuditLogFile(f)
+
+		By("Deploying echo server to exec to")
+		pod, err := f.Helper().KubeClient.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "kube-oidc-proxy-policy-",
+				GenerateName: "echoserver-",
 			},
-			Data: map[string]string{
-				"audit.yaml": `apiVersion: audit.k8s.io/v1
-kind: Policy
-rules:
-- level: RequestResponse`,
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:            "echoserver",
+						Image:           "gcr.io/google_containers/echoserver:1.10",
+						ImagePullPolicy: corev1.PullIfNotPresent,
+					},
+				},
 			},
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		vols := []corev1.Volume{
-			{
-				Name: "audit",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: cm.Name,
-						},
+		By("Creating Role")
+		_, err = f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Create(context.TODO(), &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "e2e-test-audit-exec",
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{
+						"pods", "pods/exec",
+					},
+					Verbs: []string{
+						"get", "list", "create",
 					},
 				},
 			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating RoleBinding")
+		_, err = f.Helper().KubeClient.RbacV1().RoleBindings(f.Namespace.Name).Create(context.TODO(),
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "e2e-test-audit-exec",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Name: "user@example.com",
+						Kind: "User",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Name: "e2e-test-audit-exec",
+					Kind: "Role",
+				},
+			}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Waiting for the pod after the RBAC is created rather than before also
+		// gives the apiserver's authorizer time to observe the new binding.
+		err = f.Helper().WaitForPodReady(f.Namespace.Name, pod.Name, time.Minute*2)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Running exec into pod through the proxy")
+		restConfig := newExecRestConfig(f)
+
+		restClient, err := rest.RESTClientFor(restConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		req := restClient.Post().
+			Resource("pods").
+			Name(pod.Name).
+			Namespace(pod.Namespace).
+			SubResource("exec").
+			VersionedParams(&corev1.PodExecOptions{
+				Container: "echoserver",
+				Command: []string{
+					"curl", "127.0.0.1:8080", "-s", "-d", "hello world",
+				},
+				Stdout: true,
+				Stderr: true,
+			}, scheme.ParameterCodec)
+
+		executor, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+		Expect(err).NotTo(HaveOccurred())
+
+		execOut, execErr := new(bytes.Buffer), new(bytes.Buffer)
+		err = executor.StreamWithContext(context.TODO(), remotecommand.StreamOptions{
+			Stdout: execOut,
+			Stderr: execErr,
+		})
+		Expect(err).NotTo(HaveOccurred(), "exec through the proxy failed, stderr=%s", execErr.String())
+
+		// The stream has to have carried real traffic, otherwise a
+		// ResponseStarted event would prove nothing about streaming requests.
+		Expect(execOut.String()).To(ContainSubstring("Request Body:\nhello world"),
+			"unexpected echoserver response over the exec stream")
+
+		By("Waiting for audit logs to be written")
+		// 5 seconds here is longer than the proxy flush interval.
+		time.Sleep(time.Second * 5)
+
+		By("Copying audit log from proxy locally")
+		logs := readAuditLog(f, "app=kube-oidc-proxy-e2e", auditReaderName, auditLogPath)
+
+		By("Testing for the expected audit stages of the exec request")
+		// The exec request URI carries the command as a query string, so match
+		// on the path prefix.
+		execURI := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/exec", pod.Namespace, pod.Name)
+
+		var stages []auditv1.Stage
+		scanner := bufio.NewScanner(bytes.NewReader(logs))
+		for scanner.Scan() {
+			var auditEvent auditv1.Event
+			err = json.Unmarshal(scanner.Bytes(), &auditEvent)
+			Expect(err).NotTo(HaveOccurred())
+
+			if !strings.HasPrefix(auditEvent.RequestURI, execURI) {
+				continue
+			}
+
+			Expect(auditEvent.User.Username).To(Equal("user@example.com"))
+			stages = append(stages, auditEvent.Stage)
 		}
+		Expect(scanner.Err()).NotTo(HaveOccurred())
 
-		// The audit log lives in an emptyDir shared with a reader sidecar. The
-		// sidecar uses the audit webhook image because it is alpine based (so it
-		// has cat), runs as root (so it can read the log file written by the
-		// nonroot proxy) and is already loaded into the kind nodes.
-		extras := &helper.ProxyExtras{
-			Volumes: []corev1.Volume{
-				{
-					Name: auditLogVolume,
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-			},
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					MountPath: auditLogDir,
-					Name:      auditLogVolume,
-				},
-			},
-			Containers: []corev1.Container{
-				{
-					Name:            auditReaderName,
-					Image:           kind.AuditWebhookImageName,
-					ImagePullPolicy: corev1.PullNever,
-					Command:         []string{"sleep", "86400"},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							MountPath: auditLogDir,
-							Name:      auditLogVolume,
-							ReadOnly:  true,
-						},
-					},
-				},
-			},
-		}
+		// The event that only a long running request produces. A request that
+		// is not treated as long running is recorded once, at completion, with
+		// no ResponseStarted event at all.
+		Expect(stages).To(ContainElement(auditv1.StageResponseStarted),
+			"exec through the proxy emitted no ResponseStarted audit event, so it was not audited as a long running request\naudit log:\n%s", logs)
 
-		By("Deploying proxy with audit policy enabled")
-		f.DeployProxyWithExtras(vols, extras,
-			"--audit-log-path="+auditLogPath, "--audit-policy-file=/audit/audit.yaml")
-
-		testAuditLogs(f, "app=kube-oidc-proxy-e2e", auditReaderName, auditLogPath)
+		Expect(stages).To(Equal([]auditv1.Stage{
+			auditv1.StageRequestReceived,
+			auditv1.StageResponseStarted,
+			auditv1.StageResponseComplete,
+		}), "unexpected audit stages for %s\naudit log:\n%s", execURI, logs)
 	})
 
 	It("should be able to write audit logs to webhook", func() {
@@ -186,6 +270,125 @@ users: []`,
 	})
 })
 
+// deployProxyWithAuditLogFile redeploys the proxy auditing at level
+// RequestResponse to a file, which is read back with readAuditLog.
+func deployProxyWithAuditLogFile(f *framework.Framework) {
+	By("Creating policy file ConfigMap")
+	cm, err := f.Helper().KubeClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "kube-oidc-proxy-policy-",
+		},
+		Data: map[string]string{
+			"audit.yaml": `apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: RequestResponse`,
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	vols := []corev1.Volume{
+		{
+			Name: "audit",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: cm.Name,
+					},
+				},
+			},
+		},
+	}
+
+	// The audit log lives in an emptyDir shared with a reader sidecar. The
+	// sidecar uses the audit webhook image because it is alpine based (so it
+	// has cat), runs as root (so it can read the log file written by the
+	// nonroot proxy) and is already loaded into the kind nodes.
+	extras := &helper.ProxyExtras{
+		Volumes: []corev1.Volume{
+			{
+				Name: auditLogVolume,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				MountPath: auditLogDir,
+				Name:      auditLogVolume,
+			},
+		},
+		Containers: []corev1.Container{
+			{
+				Name:            auditReaderName,
+				Image:           kind.AuditWebhookImageName,
+				ImagePullPolicy: corev1.PullNever,
+				Command:         []string{"sleep", "86400"},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						MountPath: auditLogDir,
+						Name:      auditLogVolume,
+						ReadOnly:  true,
+					},
+				},
+			},
+		},
+	}
+
+	By("Deploying proxy with audit policy enabled")
+	f.DeployProxyWithExtras(vols, extras,
+		"--audit-log-path="+auditLogPath, "--audit-policy-file=/audit/audit.yaml")
+}
+
+// newExecRestConfig returns a rest config for streaming requests through the
+// proxy. SPDY builds its own transport from TLSClientConfig, so unlike
+// Framework.NewProxyRestConfig this cannot hand over a prebuilt transport.
+func newExecRestConfig(f *framework.Framework) *rest.Config {
+	payload := f.Helper().NewTokenPayload(f.IssuerURL(), f.ClientID(), time.Now().Add(time.Minute*10))
+	signedToken, err := f.Helper().SignToken(f.IssuerKeyBundle(), payload)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &rest.Config{
+		Host:        f.ProxyURL().String(),
+		BearerToken: signedToken,
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: f.ProxyKeyBundle().CertBytes,
+		},
+
+		APIPath: "/api",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion:         &corev1.SchemeGroupVersion,
+			NegotiatedSerializer: scheme.Codecs,
+		},
+	}
+}
+
+// readAuditLog returns the contents of the audit log at logPath in the pod
+// matching podLabelSelector. If containerName is non-empty the log is read
+// from that container, otherwise from the pod's default container.
+func readAuditLog(f *framework.Framework, podLabelSelector, containerName, logPath string) []byte {
+	pods, err := f.Helper().KubeClient.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: podLabelSelector,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	if len(pods.Items) != 1 {
+		Expect(fmt.Errorf("expected single kube-oidc-proxy pod running, got=%d", len(pods.Items))).NotTo(HaveOccurred())
+	}
+
+	execArgs := []string{"exec", pods.Items[0].Name}
+	if containerName != "" {
+		execArgs = append(execArgs, "-c", containerName)
+	}
+	execArgs = append(execArgs, "--", "cat", logPath)
+
+	var auditLogsBuffer bytes.Buffer
+	err = f.Helper().Kubectl(f.Namespace.Name).RunWithStdout(&auditLogsBuffer, execArgs...)
+	Expect(err).NotTo(HaveOccurred())
+
+	return auditLogsBuffer.Bytes()
+}
+
 // testAuditLogs reads the audit log at logPath from the pod matching
 // podLabelSelector. If containerName is non-empty the log is read from that
 // container, otherwise from the pod's default container.
@@ -218,26 +421,7 @@ func testAuditLogs(f *framework.Framework, podLabelSelector, containerName, logP
 	time.Sleep(time.Second * 5)
 
 	By("Copying audit log from proxy locally")
-	// Get pod
-	pods, err := f.Helper().KubeClient.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: podLabelSelector,
-	})
-	Expect(err).NotTo(HaveOccurred())
-	if len(pods.Items) != 1 {
-		Expect(fmt.Errorf("expected single kube-oidc-proxy pod running, got=%d", len(pods.Items))).NotTo(HaveOccurred())
-	}
-
-	execArgs := []string{"exec", pods.Items[0].Name}
-	if containerName != "" {
-		execArgs = append(execArgs, "-c", containerName)
-	}
-	execArgs = append(execArgs, "--", "cat", logPath)
-
-	var auditLogsBuffer bytes.Buffer
-	err = f.Helper().Kubectl(f.Namespace.Name).RunWithStdout(&auditLogsBuffer, execArgs...)
-	Expect(err).NotTo(HaveOccurred())
-
-	logs := auditLogsBuffer.Bytes()
+	logs := readAuditLog(f, podLabelSelector, containerName, logPath)
 	scanner := bufio.NewScanner(bytes.NewReader(logs))
 
 	expAuditEvents := []auditv1.Event{

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -60,25 +60,15 @@ var _ = framework.CasesDescribe("Audit", Label("shard-b"), func() {
 	It("should write a ResponseStarted audit event when a long running request starts", func() {
 		deployProxyWithAuditLogFile(f)
 
-		By("Deploying echo server to exec to")
-		pod, err := f.Helper().KubeClient.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "echoserver-",
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:            "echoserver",
-						Image:           "gcr.io/google_containers/echoserver:1.10",
-						ImagePullPolicy: corev1.PullIfNotPresent,
-					},
-				},
-			},
-		}, metav1.CreateOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		// The exec target is the audit reader sidecar of the proxy pod itself.
+		// It is a shell bearing image that the suite builds for the host
+		// architecture and it is already running, so this needs no further pod
+		// and no image pulled from a registry. The exec still leaves the proxy
+		// as a streaming request to the apiserver, which is what is under test.
+		pod := proxyPod(f)
 
 		By("Creating Role")
-		_, err = f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Create(context.TODO(), &rbacv1.Role{
+		_, err := f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Create(context.TODO(), &rbacv1.Role{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "e2e-test-audit-exec",
 			},
@@ -115,11 +105,6 @@ var _ = framework.CasesDescribe("Audit", Label("shard-b"), func() {
 			}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		// Waiting for the pod after the RBAC is created rather than before also
-		// gives the apiserver's authorizer time to observe the new binding.
-		err = f.Helper().WaitForPodReady(f.Namespace.Name, pod.Name, time.Minute*2)
-		Expect(err).NotTo(HaveOccurred())
-
 		By("Running exec into pod through the proxy")
 		restConfig := newExecRestConfig(f)
 
@@ -132,9 +117,9 @@ var _ = framework.CasesDescribe("Audit", Label("shard-b"), func() {
 			Namespace(pod.Namespace).
 			SubResource("exec").
 			VersionedParams(&corev1.PodExecOptions{
-				Container: "echoserver",
+				Container: auditReaderName,
 				Command: []string{
-					"curl", "127.0.0.1:8080", "-s", "-d", "hello world",
+					"sh", "-c", "echo hello world",
 				},
 				Stdout: true,
 				Stderr: true,
@@ -152,8 +137,8 @@ var _ = framework.CasesDescribe("Audit", Label("shard-b"), func() {
 
 		// The stream has to have carried real traffic, otherwise a
 		// ResponseStarted event would prove nothing about streaming requests.
-		Expect(execOut.String()).To(ContainSubstring("Request Body:\nhello world"),
-			"unexpected echoserver response over the exec stream")
+		Expect(execOut.String()).To(ContainSubstring("hello world"),
+			"exec stream carried no output")
 
 		By("Waiting for audit logs to be written")
 		// 5 seconds here is longer than the proxy flush interval.
@@ -364,26 +349,39 @@ func newExecRestConfig(f *framework.Framework) *rest.Config {
 	}
 }
 
-// readAuditLog returns the contents of the audit log at logPath in the pod
-// matching podLabelSelector. If containerName is non-empty the log is read
-// from that container, otherwise from the pod's default container.
-func readAuditLog(f *framework.Framework, podLabelSelector, containerName, logPath string) []byte {
+// proxyPod returns the single running proxy pod.
+func proxyPod(f *framework.Framework) *corev1.Pod {
+	return singlePod(f, "app=kube-oidc-proxy-e2e")
+}
+
+// singlePod returns the only pod matching podLabelSelector, failing the spec
+// if there is not exactly one.
+func singlePod(f *framework.Framework, podLabelSelector string) *corev1.Pod {
 	pods, err := f.Helper().KubeClient.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: podLabelSelector,
 	})
 	Expect(err).NotTo(HaveOccurred())
 	if len(pods.Items) != 1 {
-		Expect(fmt.Errorf("expected single kube-oidc-proxy pod running, got=%d", len(pods.Items))).NotTo(HaveOccurred())
+		Expect(fmt.Errorf("expected single pod matching %s running, got=%d", podLabelSelector, len(pods.Items))).NotTo(HaveOccurred())
 	}
 
-	execArgs := []string{"exec", pods.Items[0].Name}
+	return &pods.Items[0]
+}
+
+// readAuditLog returns the contents of the audit log at logPath in the pod
+// matching podLabelSelector. If containerName is non-empty the log is read
+// from that container, otherwise from the pod's default container.
+func readAuditLog(f *framework.Framework, podLabelSelector, containerName, logPath string) []byte {
+	pod := singlePod(f, podLabelSelector)
+
+	execArgs := []string{"exec", pod.Name}
 	if containerName != "" {
 		execArgs = append(execArgs, "-c", containerName)
 	}
 	execArgs = append(execArgs, "--", "cat", logPath)
 
 	var auditLogsBuffer bytes.Buffer
-	err = f.Helper().Kubectl(f.Namespace.Name).RunWithStdout(&auditLogsBuffer, execArgs...)
+	err := f.Helper().Kubectl(f.Namespace.Name).RunWithStdout(&auditLogsBuffer, execArgs...)
 	Expect(err).NotTo(HaveOccurred())
 
 	return auditLogsBuffer.Bytes()

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -164,6 +164,16 @@ var _ = framework.CasesDescribe("Audit", Label("shard-b"), func() {
 			}
 
 			Expect(auditEvent.User.Username).To(Equal("user@example.com"))
+
+			// The classification the long running check reads. A POST to a
+			// subresource is the "create" verb, and the subresource is what
+			// makes the request long running, so an event recording neither
+			// means the request was never resolved as a resource request.
+			Expect(auditEvent.Verb).To(Equal("create"))
+			Expect(auditEvent.ObjectRef).NotTo(BeNil(), "audit event carries no objectRef, so the exec was not audited as a resource request")
+			Expect(auditEvent.ObjectRef.Resource).To(Equal("pods"))
+			Expect(auditEvent.ObjectRef.Subresource).To(Equal("exec"))
+
 			stages = append(stages, auditEvent.Stage)
 		}
 		Expect(scanner.Err()).NotTo(HaveOccurred())
@@ -422,26 +432,39 @@ func testAuditLogs(f *framework.Framework, podLabelSelector, containerName, logP
 	logs := readAuditLog(f, podLabelSelector, containerName, logPath)
 	scanner := bufio.NewScanner(bytes.NewReader(logs))
 
+	// A GET of a collection is the "list" verb, not "get" — "get" is a GET of a
+	// single named object — and a resource request carries an objectRef naming
+	// what was addressed. Both follow from the request being resolved as a
+	// resource request in the core group, which is what an audit consumer
+	// writes policy rules against.
+	expObjectRef := &auditv1.ObjectReference{
+		Resource:   "pods",
+		Namespace:  "kube-system",
+		APIVersion: "v1",
+	}
+
 	expAuditEvents := []auditv1.Event{
 		{
 			Level:      auditv1.LevelRequestResponse,
 			Stage:      auditv1.StageRequestReceived,
 			RequestURI: "/api/v1/namespaces/kube-system/pods",
-			Verb:       "get",
+			Verb:       "list",
 			User: authnv1.UserInfo{
 				Username: "user@example.com",
 				Groups:   []string{"group-1", "group-2"},
 			},
+			ObjectRef: expObjectRef,
 		},
 		{
 			Level:      auditv1.LevelRequestResponse,
 			Stage:      auditv1.StageResponseComplete,
 			RequestURI: "/api/v1/namespaces/kube-system/pods",
-			Verb:       "get",
+			Verb:       "list",
 			User: authnv1.UserInfo{
 				Username: "user@example.com",
 				Groups:   []string{"group-1", "group-2"},
 			},
+			ObjectRef: expObjectRef,
 			ResponseStatus: &metav1.Status{
 				Code: 403,
 			},
@@ -486,6 +509,17 @@ func testAuditLogs(f *framework.Framework, podLabelSelector, containerName, logP
 			gotAuditEvent.ResponseStatus = &metav1.Status{
 				Code:    auditEvent.ResponseStatus.Code,
 				Message: auditEvent.ResponseStatus.Message,
+			}
+		}
+
+		if auditEvent.ObjectRef != nil {
+			gotAuditEvent.ObjectRef = &auditv1.ObjectReference{
+				Resource:    auditEvent.ObjectRef.Resource,
+				Namespace:   auditEvent.ObjectRef.Namespace,
+				Name:        auditEvent.ObjectRef.Name,
+				APIGroup:    auditEvent.ObjectRef.APIGroup,
+				APIVersion:  auditEvent.ObjectRef.APIVersion,
+				Subresource: auditEvent.ObjectRef.Subresource,
 			}
 		}
 

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -191,6 +191,110 @@ var _ = framework.CasesDescribe("Audit", Label("shard-b"), func() {
 		}), "unexpected audit stages for %s\naudit log:\n%s", execURI, logs)
 	})
 
+	// Watch is the one long running verb the generic apiserver default already
+	// covered, so this spec is not about the long-running set. It covers the
+	// classification underneath: a watch of a core group resource is only
+	// recognised as a watch — rather than a plain GET — once the audit config
+	// names the legacy API prefix. Until then no core group watch was ever
+	// audited as long running, whatever the set contained.
+	It("should write a ResponseStarted audit event when a watch starts", func() {
+		deployProxyWithAuditLogFile(f)
+
+		By("Creating Role")
+		_, err := f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Create(context.TODO(), &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "e2e-test-audit-watch",
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{"pods"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating RoleBinding")
+		_, err = f.Helper().KubeClient.RbacV1().RoleBindings(f.Namespace.Name).Create(context.TODO(),
+			&rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "e2e-test-audit-watch",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Name: "user@example.com",
+						Kind: "User",
+					},
+				},
+				RoleRef: rbacv1.RoleRef{
+					Name: "e2e-test-audit-watch",
+					Kind: "Role",
+				},
+			}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Watching pods through the proxy")
+		token := f.Helper().NewTokenPayload(f.IssuerURL(), f.ClientID(), time.Now().Add(time.Minute*10))
+		signedToken, err := f.Helper().SignToken(f.IssuerKeyBundle(), token)
+		Expect(err).NotTo(HaveOccurred())
+
+		proxyConfig := f.NewProxyRestConfig()
+		requester := f.Helper().NewRequester(proxyConfig.Transport, signedToken)
+
+		// The watch is held open by the apiserver until timeoutSeconds elapses,
+		// so the request really does stream, and the read of the body below
+		// only returns once the stream has ended.
+		watchPath := fmt.Sprintf("/api/v1/namespaces/%s/pods", f.Namespace.Name)
+		watchURI := watchPath + "?timeoutSeconds=2&watch=true"
+
+		_, resp, err := requester.Get(proxyConfig.Host + watchURI)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp.StatusCode).To(Equal(http.StatusOK),
+			"watch through the proxy was not served, so no stream was ever started")
+
+		By("Waiting for audit logs to be written")
+		// 5 seconds here is longer than the proxy flush interval.
+		time.Sleep(time.Second * 5)
+
+		By("Copying audit log from proxy locally")
+		logs := readAuditLog(f, "app=kube-oidc-proxy-e2e", auditReaderName, auditLogPath)
+
+		By("Testing for the expected audit stages of the watch request")
+		var stages []auditv1.Stage
+		scanner := bufio.NewScanner(bytes.NewReader(logs))
+		for scanner.Scan() {
+			var auditEvent auditv1.Event
+			err = json.Unmarshal(scanner.Bytes(), &auditEvent)
+			Expect(err).NotTo(HaveOccurred())
+
+			if auditEvent.RequestURI != watchURI {
+				continue
+			}
+
+			Expect(auditEvent.User.Username).To(Equal("user@example.com"))
+
+			// A GET carrying watch=true is the "watch" verb, not "get" — which
+			// is the classification the long running check reads.
+			Expect(auditEvent.Verb).To(Equal("watch"))
+			Expect(auditEvent.ObjectRef).NotTo(BeNil(), "audit event carries no objectRef, so the watch was not audited as a resource request")
+			Expect(auditEvent.ObjectRef.Resource).To(Equal("pods"))
+			Expect(auditEvent.ObjectRef.Namespace).To(Equal(f.Namespace.Name))
+
+			stages = append(stages, auditEvent.Stage)
+		}
+		Expect(scanner.Err()).NotTo(HaveOccurred())
+
+		Expect(stages).To(ContainElement(auditv1.StageResponseStarted),
+			"watch through the proxy emitted no ResponseStarted audit event, so it was not audited as a long running request\naudit log:\n%s", logs)
+
+		Expect(stages).To(Equal([]auditv1.Stage{
+			auditv1.StageRequestReceived,
+			auditv1.StageResponseStarted,
+			auditv1.StageResponseComplete,
+		}), "unexpected audit stages for %s\naudit log:\n%s", watchURI, logs)
+	})
+
 	It("should be able to write audit logs to webhook", func() {
 		By("Creating policy file ConfigMap")
 		cmPolicy, err := f.Helper().KubeClient.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), &corev1.ConfigMap{


### PR DESCRIPTION
Two defects kept streaming requests out of the audit log while they ran. Fixing either alone changes nothing, so both are here, with e2e coverage that exercises the whole path.

## What changed

**1. The long-running set** (`pkg/proxy/audit/audit.go`) — the inline `LongRunningFunc` becomes a package-level `longRunningRequests` var built from kube-apiserver's own sets, replacing the generic-apiserver default of `watch` only:

- verbs: `watch`, `proxy`
- subresources: `attach`, `exec`, `proxy`, `log`, `portforward`

**2. Request classification** (`pkg/proxy/audit/audit.go`) — the `server.Config` now names the legacy API prefix:

```go
LegacyAPIGroupPrefixes: sets.NewString(server.DefaultLegacyAPIPrefix),
```

`Config.Complete()` derives the RequestInfo resolver from this, and `server.NewRequestInfoResolver` seeds the resolver with the group prefix (`/apis`) plus these legacy, groupless prefixes. Left empty — as it was — nothing under `/api` parsed as a resource request: the RequestInfo carried no resource and no subresource, and its verb was the bare lowercased HTTP method. Since `BasicLongRunningRequestCheck` matches on verb and subresource, exec, attach, portforward and log — all of them core group pod subresources — could never be detected however the set in (1) was written. A core group `watch` was equally undetectable, so this predates the change in (1).

**Tests**

- `pkg/proxy/audit/audit_test.go` — `TestLongRunningRequests` covers the set itself over hand-built RequestInfos. `TestRequestInfoLongRunning` resolves real request URLs (`/api/v1/namespaces/ns/pods/pod/exec`, `.../log?follow=true`, `.../pods?watch=true`, `/apis/apps/v1/...`, plus get/list/create) through the resolver the `Audit` struct actually builds, asserting the classification and the long-running verdict. Without fix (2) it fails on every core group case.
- `test/e2e/suite/cases/audit/audit.go` — a new e2e spec deploys the proxy with auditing to file, performs a real SPDY exec through the proxy, and asserts the exec is audited as `RequestReceived`, `ResponseStarted`, `ResponseComplete` with verb `create` and `objectRef.subresource: exec`. This is the case that caught defect (2): it joins two things the suite already did separately — `upgrade` execs through the proxy but never reads the audit log, `audit` reads the audit log but only for a plain GET.

Plus two changelog entries in `.changes/unreleased/`.

## Behaviour change

**Streaming requests emit `ResponseStarted` as well as `ResponseComplete`,** so audit volume for exec, attach and portforward roughly doubles. That is the intended effect: the record appears when the session starts rather than only at teardown. Previously an hour-long exec left nothing in the audit log for that hour, and nothing at all if the proxy died first.

**Audit events for core API group requests change shape.** They now carry the Kubernetes verb (`list`, `create`, `watch`, ...) instead of the HTTP method (`get`, `post`), and an `objectRef` naming resource, namespace, name, subresource and group/version. Anyone parsing audit logs or writing audit policy rules that match on verb or resource is affected — this is the corrected value, but it is a change. The pre-existing e2e expectations moved with it (`verb: get` → `list` for a collection GET, plus the new `objectRef`); in the apiserver's RequestInfo semantics `get` is a GET of a single named object, while a GET of a collection is `list`.

No configuration change is required and no flag was added.

## How it was verified

- `go test ./pkg/... ./cmd/...` — pass. `TestRequestInfoLongRunning` fails on every core group case with fix (2) reverted.
- Local kind run of the audit shard (`make e2e E2E_GOTEST_ARGS="-args --ginkgo.focus=Audit"`) — 3 of 3 specs pass, i.e. the new exec spec plus both pre-existing audit specs under their updated expectations.
- Discrimination of the new e2e assertion, by local experiment: with classification correct but the long-running set reverted to `watch` only, the exec is parsed correctly (verb `create`, `objectRef.subresource: exec`) and still emits no `ResponseStarted` — the spec fails. With both fixes, it passes. Neither experiment is in the branch.
- `go build ./...`, `go vet ./...`, `gofmt`, `make verify-e2e-shards` — clean.

Two `make verify` stages fail identically on unmodified `main` and are untouched here: `verify_boilerplate` flags `demo/run.sh` and `demo/cleanup.sh`, and gosec flags a missing `ReadHeaderTimeout` at `pkg/probe/probe.go:89`. Both were confirmed pre-existing against a clean tree; no lint config was modified.

## Out of scope

`Audit.WithUnauthorized` does not wrap `WithAuditInit`, so an unauthenticated 401 emits no audit events at all. That is a separate defect, left alone here, as is the commented-out 401 expectation in the e2e case that documents it.
