### PR TITLE
fix(probe): stay unready until the proxy is serving

### DIFF
--- a/.changes/unreleased/20260818-fixed-readiness-serving-gate.yaml
+++ b/.changes/unreleased/20260818-fixed-readiness-serving-gate.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: The readiness endpoint now reports not-ready until the proxy is actually serving, instead of reporting ready as soon as an OIDC issuer initialized. Previously the readiness server started before the proxy's handler chain did, so a pod could join its Service while requests to the proxy port could only queue.

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -184,6 +184,13 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				return err
 			}
 
+			// The handler chain is built and the secure server is serving its
+			// listener. Only now may the pod be advertised as ready: the port
+			// has been bound since SecureServing.ApplyTo above, so before this
+			// point a client connect succeeds and then sits in the backlog
+			// unanswered, and a failure in Run would leave it that way.
+			probeServer.SetServing()
+
 			<-waitCh
 			<-listenerStoppedCh
 

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -1,8 +1,8 @@
 // Copyright Jetstack Ltd. See LICENSE for details.
 
 // Package probe implements the proxy's readiness and liveness HTTP endpoints,
-// reporting readiness once the configured OIDC issuers' authenticators have
-// completed initialization.
+// reporting readiness once the proxy is serving and the configured OIDC
+// issuers' authenticators have completed initialization.
 package probe
 
 import (
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -48,15 +49,27 @@ type IssuerReadiness struct {
 }
 
 // HealthCheck tracks per-issuer OIDC initialization and answers readiness
-// checks. It is safe for concurrent use: its mutable state is guarded by mu.
+// checks. It is safe for concurrent use: its issuer state is guarded by mu.
+//
+// serving is deliberately atomic rather than guarded by mu: Check releases mu
+// before the potentially slow AuthenticateToken calls (#53), and the serving
+// flag must stay readable without re-entangling it with that lock.
 type HealthCheck struct {
 	oidcAuther authenticator.Token
 	issuers    []IssuerReadiness
 	requireAll bool
 
+	serving atomic.Bool
+
 	mu          sync.Mutex
 	ready       bool
 	initialized map[string]bool
+}
+
+// SetServing records that the proxy has started serving. Until it is called,
+// Check reports not-ready regardless of issuer state.
+func (h *HealthCheck) SetServing() {
+	h.serving.Store(true)
 }
 
 // Server owns the readiness HTTP listener and gives it an explicit lifecycle:
@@ -94,9 +107,18 @@ func NewServer(port string, issuers []IssuerReadiness, requireAll bool, oidcAuth
 	}
 }
 
+// SetServing records that the proxy has started serving, so readiness may now
+// depend solely on issuer initialization. It is a pass-through to the
+// underlying HealthCheck, which keeps that type out of the caller's surface.
+func (s *Server) SetServing() {
+	s.hc.SetServing()
+}
+
 // handler builds the readiness listener's HTTP handler. It exposes a liveness
-// endpoint that is always healthy once the process is serving and a readiness
-// endpoint driven by Check. Both endpoints only answer GET (returning 405
+// endpoint that is always healthy once this probe listener is up — it is
+// deliberately not gated on SetServing, since the process is alive long before
+// the proxy serves and gating it would invite restarts during startup — and a
+// readiness endpoint driven by Check. Both endpoints only answer GET (returning 405
 // otherwise, matching the previous healthcheck handler); unknown paths yield
 // 404 via the ServeMux default.
 func (h *HealthCheck) handler() http.Handler {
@@ -208,12 +230,21 @@ func isTransient(err error) bool {
 	return false
 }
 
-// Check probes every issuer that has not yet been observed as initialized,
-// logs per-issuer transitions and any still-pending issuers, and reports
-// readiness. Once readiness latches (h.ready is set true under h.mu) it always
-// returns nil, but probing and pending-issuer logging continue on every
-// call so operators keep seeing progress for issuers that initialize late.
+// Check reports readiness. It first requires the proxy to be serving, then
+// probes every issuer that has not yet been observed as initialized, logging
+// per-issuer transitions and any still-pending issuers. Once readiness latches
+// (h.ready is set true under h.mu) it always returns nil, but probing and
+// pending-issuer logging continue on every call so operators keep seeing
+// progress for issuers that initialize late.
 func (h *HealthCheck) Check() error {
+	// Checked first: it is cheap, and it is the more fundamental condition. An
+	// initialized issuer on a process that is not yet answering requests is not
+	// readiness — advertising it would put the pod into its Service while
+	// requests could only queue.
+	if !h.serving.Load() {
+		return errors.New("proxy is not yet serving")
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 

--- a/pkg/probe/probe_test.go
+++ b/pkg/probe/probe_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -102,6 +103,9 @@ func TestCheckReadiness(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			h := newTestHealthCheck(tc.requireAll, tc.notInit, issuerA, issuerB)
+			// This table covers issuer readiness, so open the serving gate;
+			// TestCheckNotReadyBeforeServing covers the gate itself.
+			h.SetServing()
 			err := h.Check()
 			if tc.wantReady && err != nil {
 				t.Fatalf("expected ready, got error: %v", err)
@@ -113,10 +117,82 @@ func TestCheckReadiness(t *testing.T) {
 	}
 }
 
+// TestCheckNotReadyBeforeServing verifies the serving gate: even with every
+// issuer initialized, readiness stays false until the proxy is actually
+// serving. An initialized issuer on a process that is not yet answering
+// requests is not readiness.
+func TestCheckNotReadyBeforeServing(t *testing.T) {
+	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
+	h := newTestHealthCheck(true, nil, issuerA)
+
+	err := h.Check()
+	if err == nil {
+		t.Fatal("expected not-ready before the proxy is serving, got nil")
+	}
+	if !strings.Contains(err.Error(), "serving") {
+		t.Fatalf("expected the error to name the serving condition, got: %v", err)
+	}
+	if h.ready {
+		t.Fatal("readiness must not latch before the proxy is serving")
+	}
+}
+
+// TestCheckReadyAfterServing verifies the gate opens: the same health check
+// that reports not-ready before serving reports ready once SetServing is
+// called, so the gate delays readiness rather than blocking it permanently.
+func TestCheckReadyAfterServing(t *testing.T) {
+	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
+	h := newTestHealthCheck(true, nil, issuerA)
+
+	if err := h.Check(); err == nil {
+		t.Fatal("expected not-ready before the proxy is serving, got nil")
+	}
+
+	h.SetServing()
+	if err := h.Check(); err != nil {
+		t.Fatalf("expected ready once serving with the issuer initialized, got: %v", err)
+	}
+}
+
+// TestReadyEndpointReportsNotServing verifies the gate is visible over HTTP:
+// /ready answers 503 and names the serving condition, so an operator reading
+// the probe response can tell why the pod is held back.
+func TestReadyEndpointReportsNotServing(t *testing.T) {
+	h := newTestHealthCheck(false, nil,
+		IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"})
+	handler := h.handler()
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("GET /ready before serving: got %d, want %d", rec.Code, http.StatusServiceUnavailable)
+	}
+	if !strings.Contains(rec.Body.String(), "serving") {
+		t.Fatalf("expected the body to name the serving condition, got: %q", rec.Body.String())
+	}
+
+	// Liveness is not gated: the process is alive well before it serves, and
+	// gating it would invite the kubelet to restart the pod during startup.
+	liveRec := httptest.NewRecorder()
+	handler.ServeHTTP(liveRec, httptest.NewRequest(http.MethodGet, "/live", nil))
+	if liveRec.Code != http.StatusOK {
+		t.Fatalf("GET /live before serving: got %d, want %d", liveRec.Code, http.StatusOK)
+	}
+
+	// Once serving, the same endpoint reports ready.
+	h.SetServing()
+	readyRec := httptest.NewRecorder()
+	handler.ServeHTTP(readyRec, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if readyRec.Code != http.StatusOK {
+		t.Fatalf("GET /ready after serving: got %d, want %d", readyRec.Code, http.StatusOK)
+	}
+}
+
 func TestCheckReadinessIsSticky(t *testing.T) {
 	issuerA := IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"}
 	notInit := map[string]bool{}
 	h := newTestHealthCheck(false, notInit, issuerA)
+	h.SetServing()
 
 	if err := h.Check(); err != nil {
 		t.Fatalf("expected ready, got: %v", err)
@@ -140,6 +216,7 @@ func TestCheckContinuesProbingPendingAfterLatch(t *testing.T) {
 
 	notInit := map[string]bool{"jwt-b": true}
 	h := newTestHealthCheck(false, notInit, issuerA, issuerB)
+	h.SetServing()
 	fake := h.oidcAuther.(*fakeAuther)
 
 	if err := h.Check(); err != nil {
@@ -198,6 +275,7 @@ func TestCheckAlternatePhrasingKeepsPending(t *testing.T) {
 		},
 	}
 	h := newTestHealthCheckWithAuther(true, auther, issuerA)
+	h.SetServing()
 
 	if err := h.Check(); err == nil {
 		t.Fatal("expected not-ready for alternate 'is not initialized' phrasing, got nil")
@@ -226,6 +304,7 @@ func TestCheckTransientErrorDoesNotLatch(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			auther := &fakeAuther{override: map[string]error{"jwt-a": retErr}}
 			h := newTestHealthCheckWithAuther(true, auther, issuerA)
+			h.SetServing()
 
 			if err := h.Check(); err == nil {
 				t.Fatal("expected not-ready for transient error, got nil")
@@ -245,6 +324,8 @@ func TestCheckTransientErrorDoesNotLatch(t *testing.T) {
 func TestHandlerRejectsNonGET(t *testing.T) {
 	h := newTestHealthCheck(false, nil,
 		IssuerReadiness{IssuerURL: "https://a.example.com", FakeJWT: "jwt-a"})
+	// Serving, so GET /ready exercises the readiness path rather than the gate.
+	h.SetServing()
 	handler := h.handler()
 
 	for _, path := range []string{"/live", "/ready"} {
@@ -440,6 +521,8 @@ func TestCheckDoesNotHoldLockDuringAuth(t *testing.T) {
 		release: make(chan struct{}),
 	}
 	h := newTestHealthCheckWithAuther(true, auther, issuerA)
+	// Check returns before reaching the authenticator unless it is serving.
+	h.SetServing()
 
 	var wg sync.WaitGroup
 	for i := 0; i < 2; i++ {


### PR DESCRIPTION
## What

`HealthCheck.Check()` now reports not-ready until the proxy is actually serving, via a new `serving` flag set from `cmd/app/run.go` once `p.Run` has returned.

- `pkg/probe/probe.go` — `serving atomic.Bool` on `HealthCheck`, `HealthCheck.SetServing()`, a `Server.SetServing()` pass-through, and the gate at the top of `Check()`.
- `cmd/app/run.go` — `probeServer.SetServing()` immediately after the `p.Run(stopCh)` error check.
- `pkg/probe/probe_test.go` — three new tests, plus `SetServing()` in the setup of the existing readiness tests.

## Why

`cmd/app/run.go` starts the readiness server before `p.Run` builds the handler chain and hands the listener to the secure server. `Check()` only asked whether an OIDC issuer had initialized, so `/ready` could answer 200 in that window.

The proxy's own port is bound earlier still, at `SecureServing.ApplyTo`. During the window a client connect therefore completes and then sits in the accept backlog unanswered: the pod could join its Service while requests could only queue. If `p.Run` then failed, the pod had been advertised as ready for a process that never served at all.

The flag is an `atomic.Bool` rather than `mu`-guarded state on purpose: `Check()` deliberately releases `mu` before the slow `AuthenticateToken` calls (#53), and the serving flag must stay readable without re-entangling with that lock. The gate is checked first because it is cheap and it is the more fundamental condition.

### Deviation from the reviewed plan, worth flagging

The plan specified the comment "Run has returned, so the secure listener is accepting." That overclaims. `apiserver@v0.36` `RunServer` is documented "This function does not block" and starts `server.Serve(listener)` in a goroutine, so `p.Run` returning means the serve goroutine has been launched, not that `Accept()` has been entered; and the listener has been bound since `SecureServing.ApplyTo`. The placement of the call is unchanged and the fix is unaffected — only the comment wording was corrected to match what the code actually guarantees.

## Deliberately not changed

- **`--readiness-require-all-issuers` still defaults to `false`.** Untouched.
- **Liveness is not gated.** The process is alive well before it serves; gating `/live` would invite the kubelet to restart the pod during startup. A test asserts `/live` stays 200 before serving.
- **No `SetNotServing()` on shutdown.** During drain the pod still reports ready until the probe server is cancelled. That is unchanged behaviour — `h.ready` already latched true through shutdown — so it is not a regression introduced here, and it was out of scope.
- **Chart/docs wording** (`chart/kube-oidc-proxy/README.md:228`, `docs/multi-issuer.md:230`, `values.yaml:137`) describes the issuer half of readiness. Still true as far as it goes, now incomplete; left for a docs pass.

## How verified

- **TDD.** `TestCheckNotReadyBeforeServing` was written first and run against unmodified source: it failed on the assertion (`expected not-ready before the proxy is serving, got nil`, with the log line `OIDC issuer initialized ... (1/1 ready)` above it) — a real assertion failure, not a build error. It passes after the change.
- `go build ./...`, `go vet ./...` — clean.
- `go test ./pkg/probe/... ./cmd/...` — pass. `go test ./pkg/probe/... -race -count=1` — all 13 tests pass, covering the new `atomic.Bool` under concurrent `Check()`.
- `go test ./cmd/... ./pkg/... ./test/tools/...` (the set PR CI runs) — pass.
- `gofmt -l ./cmd ./pkg ./test` — clean.
- `golangci-lint run ./...` (v2.12.2) — one finding, `G112` on the `http.Server` literal in `NewServer`. Pre-existing: it fires identically on unmodified `main`, is on a line this PR does not modify, and CI runs with `only-new-issues: true`. Not fixed here, to avoid a drive-by.
- `make verify` fails at `verify_boilerplate` on `demo/run.sh` and `demo/cleanup.sh`. Confirmed pre-existing on clean `main` and unrelated to these files; PR CI (`test.yaml`) does not run the boilerplate check at all — only `release.yaml` does.
- Note for local runs: `pkg/mocks` is generated and not committed, so `make generate` is required before `go vet ./...` succeeds repo-wide.

## e2e

`test/e2e/suite/cases/probe/probe.go` needs no change: the first case expects `DeployProxy` to error and still does, and the second runs against an already-serving proxy.
