### PR TITLE
fix(security): refuse reserved system: identities from token claims

### DIFF
--- a/.changes/unreleased/20260818-fixed-oidc-validation-logging.yaml
+++ b/.changes/unreleased/20260818-fixed-oidc-validation-logging.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Log OIDC token validation failures at `-v=2` with the resolved remote address, instead of `-v=5`. An error from the bearer-token authenticator always means a token was present and failed validation, so it was previously invisible at any verbosity operators run. Request routing is unchanged.

--- a/.changes/unreleased/20260818-security-reserved-identities.yaml
+++ b/.changes/unreleased/20260818-security-reserved-identities.yaml
@@ -1,0 +1,2 @@
+kind: Security
+body: Refuse authenticated identities carrying the Kubernetes-reserved `system:` prefix from token claims, so an OIDC issuer can no longer mint `system:masters` or a service-account username through the proxy's blanket impersonation rights. The check runs before the SubjectAccessReview that authorizes inbound impersonation, and the 403 is audited against the identity that was presented. `system:authenticated` remains permitted as a group because the proxy adds it to every request itself. Opt out with `--allow-reserved-identity-claims`.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,7 +46,7 @@ jobs:
           - shard: b
             cases: "authconfig, upgrade, audit"
           - shard: c
-            cases: "passthrough, token, rbac"
+            cases: "passthrough, token, rbac, reserved identity"
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -25,6 +25,8 @@ type KubeOIDCProxyOptions struct {
 	TokenPassthrough   TokenPassthroughOptions
 
 	TrustedProxies []string
+
+	AllowReservedIdentityClaims bool
 }
 
 type TokenPassthroughOptions struct {
@@ -78,6 +80,16 @@ func (k *KubeOIDCProxyOptions) AddFlags(fs *pflag.FlagSet) *KubeOIDCProxyOptions
 			"address is always used, so clients cannot spoof their IP via forwarded "+
 			"headers. Set this only to the addresses of proxies you operate in front of "+
 			"kube-oidc-proxy.")
+
+	fs.BoolVar(&k.AllowReservedIdentityClaims, "allow-reserved-identity-claims", false,
+		"If true, an authentication token may mint identities carrying the "+
+			"Kubernetes-reserved 'system:' prefix — including the cluster-admin group "+
+			"'system:masters' and any service account "+
+			"('system:serviceaccount:<namespace>:<name>') as a username. The proxy is "+
+			"granted blanket impersonation rights, so enabling this makes the OIDC "+
+			"issuer's claims a path to those privileges. By default (false) such an "+
+			"identity is refused with 403; 'system:authenticated' remains permitted as "+
+			"a group because the proxy adds it to every request itself.")
 
 	k.TokenPassthrough.AddFlags(fs)
 	k.ExtraHeaderOptions.AddFlags(fs)

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -36,6 +37,42 @@ import (
 
 const oidcHTTPTimeout = 30 * time.Second
 
+// reservedIdentityPrefix is the username/group prefix Kubernetes reserves for
+// its own identities. Kept in sync with the runtime guard in
+// pkg/proxy/handlers.go (checkReservedIdentity), which is the load-bearing one.
+const reservedIdentityPrefix = "system:"
+
+// checkReservedIdentityPrefixes refuses to start when the operator's own
+// username or group prefix would itself mint reserved identities for every
+// authenticated user. It is a startup nicety, not the guard: the runtime check
+// in the proxy catches everything this misses, including reserved values that
+// arrive in the claim rather than the prefix.
+//
+// Only the single-issuer path is checked. --oidc-username-prefix and
+// --oidc-groups-prefix are ignored entirely when --authentication-config is set,
+// where prefixes come from the configuration document instead.
+func checkReservedIdentityPrefixes(opts *options.Options) error {
+	if opts.App.AllowReservedIdentityClaims || opts.AuthenticationConfig.ConfigFile != "" {
+		return nil
+	}
+
+	for _, prefix := range []struct {
+		flag  string
+		value string
+	}{
+		{flag: "--oidc-username-prefix", value: opts.OIDCAuthentication.UsernamePrefix},
+		{flag: "--oidc-groups-prefix", value: opts.OIDCAuthentication.GroupsPrefix},
+	} {
+		if strings.HasPrefix(prefix.value, reservedIdentityPrefix) {
+			return fmt.Errorf("%s=%q would prefix every authenticated identity with the "+
+				"Kubernetes-reserved %q; refusing to start (set --allow-reserved-identity-claims to override)",
+				prefix.flag, prefix.value, reservedIdentityPrefix)
+		}
+	}
+
+	return nil
+}
+
 func NewRunCommand(stopCh <-chan struct{}) *cobra.Command {
 	// Build options
 	opts := options.New()
@@ -56,6 +93,10 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 		Long: "kube-oidc-proxy is a reverse proxy to authenticate users to Kubernetes API servers with Open ID Connect Authentication.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(cmd); err != nil {
+				return err
+			}
+
+			if err := checkReservedIdentityPrefixes(opts); err != nil {
 				return err
 			}
 
@@ -112,6 +153,8 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 				ExtraUserHeadersClientIPEnabled: opts.App.ExtraHeaderOptions.EnableClientIPExtraUserHeader,
 
 				TrustedProxies: opts.App.TrustedProxies,
+
+				AllowReservedIdentityClaims: opts.App.AllowReservedIdentityClaims,
 			}
 
 			// Setup Subject Access Review

--- a/cmd/app/run_test.go
+++ b/cmd/app/run_test.go
@@ -298,3 +298,60 @@ func TestBuildTokenAuther_AuthConfig_InvalidFile(t *testing.T) {
 		t.Error("buildTokenAuther() expected error for missing config file, got nil")
 	}
 }
+
+func TestCheckReservedIdentityPrefixes(t *testing.T) {
+	tests := map[string]struct {
+		usernamePrefix string
+		groupsPrefix   string
+		configFile     string
+		allowReserved  bool
+		wantErr        bool
+	}{
+		"no prefixes": {},
+		"ordinary prefixes": {
+			usernamePrefix: "oidc:",
+			groupsPrefix:   "oidc:",
+		},
+		"reserved username prefix": {
+			usernamePrefix: "system:",
+			wantErr:        true,
+		},
+		"reserved groups prefix": {
+			groupsPrefix: "system:serviceaccount:",
+			wantErr:      true,
+		},
+		"reserved prefix with the opt-out set": {
+			usernamePrefix: "system:",
+			groupsPrefix:   "system:",
+			allowReserved:  true,
+		},
+		// --oidc-* prefixes are ignored entirely when an authentication
+		// configuration file is in use, so they must not fail startup.
+		"reserved prefix ignored in multi-issuer mode": {
+			usernamePrefix: "system:",
+			configFile:     "/etc/kube-oidc-proxy/authentication.yaml",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := &options.Options{
+				OIDCAuthentication: &options.OIDCAuthenticationOptions{
+					UsernamePrefix: test.usernamePrefix,
+					GroupsPrefix:   test.groupsPrefix,
+				},
+				AuthenticationConfig: &options.AuthenticationConfigOptions{ConfigFile: test.configFile},
+				App:                  &options.KubeOIDCProxyOptions{AllowReservedIdentityClaims: test.allowReserved},
+			}
+
+			err := checkReservedIdentityPrefixes(opts)
+
+			if test.wantErr && err == nil {
+				t.Error("checkReservedIdentityPrefixes() = nil, want an error")
+			}
+			if !test.wantErr && err != nil {
+				t.Errorf("checkReservedIdentityPrefixes() = %v, want nil", err)
+			}
+		})
+	}
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -119,6 +119,12 @@ than silently stripped: a caller served without the group they claimed has been
 told the wrong thing about who they are. The rejection is audited against the
 identity that was presented.
 
+Because the check sits in the authentication handler, it applies to **every**
+authenticated request, including under `--disable-impersonation`, where such a
+request was previously forwarded for the API server to authenticate itself. It
+does not apply to requests authenticated by `--token-passthrough`: those never
+reach the OIDC claim mapping, and the API server validates the token itself.
+
 This is defense in depth. The operator-side mitigations remain the primary
 control and are unchanged: set `--oidc-groups-prefix` (and
 `--oidc-username-prefix`) so claims cannot collide with cluster identities, or

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,7 @@ not require a pod restart.
 | `--extra-user-headers` | — | (Alpha) Extra `key=value` user headers to add to the impersonated request. |
 | `--trusted-proxies` | — | Comma-separated trusted proxy CIDRs (IPv4/IPv6). `X-Forwarded-For` is honoured for client-IP resolution only when the immediate peer is within one of these networks. Empty (default) trusts no proxy. See [Trusted proxies and client IP](#trusted-proxies-and-client-ip). |
 | `--subject-access-review-timeout` | `5s` | Timeout for authorizing inbound impersonation via `SubjectAccessReview` — a single shared budget across all SAR calls for one request (not per-call). Must be greater than 0. |
+| `--allow-reserved-identity-claims` | `false` | Allow an authentication token to mint `system:`-prefixed identities. See [Reserved `system:` identities](#reserved-system-identities). |
 
 ### Serving / TLS & misc
 
@@ -92,6 +93,45 @@ The proxy also honours impersonation headers on **inbound** requests, so
 the proxy first checks — via `SubjectAccessReview` against the API server — that
 the authenticated user may assume that identity, then forwards the impersonated
 identity instead of the caller's own.
+
+### Reserved `system:` identities
+
+Kubernetes reserves the `system:` prefix for its own identities: `system:masters`
+is bound to `cluster-admin` by default, and `system:serviceaccount:<ns>:<name>`
+is any service account. The chart grants the proxy `impersonate` on `users`,
+`groups` and `serviceaccounts` without `resourceNames`, so an identity carrying
+one of those values is impersonated as-is.
+
+Kubernetes does **not** guard this on claim mappings. By default the proxy
+therefore refuses, with `403`, any authenticated request whose identity carries
+the reserved prefix:
+
+| Field | Rule |
+| --- | --- |
+| Username | Every `system:`-prefixed value is refused — no exceptions, including `system:authenticated`, which an RBAC binding can name as a `User`. |
+| Groups | `system:authenticated` is permitted (the proxy appends it to every request itself); any other `system:` group is refused. |
+
+The check runs in the authentication handler, **before** the `SubjectAccessReview`
+that authorizes inbound impersonation — that review is built with the requester's
+own groups, so a forged `system:` group would otherwise feed the authorization
+decision and not merely the impersonation headers. The identity is refused rather
+than silently stripped: a caller served without the group they claimed has been
+told the wrong thing about who they are. The rejection is audited against the
+identity that was presented.
+
+This is defense in depth. The operator-side mitigations remain the primary
+control and are unchanged: set `--oidc-groups-prefix` (and
+`--oidc-username-prefix`) so claims cannot collide with cluster identities, or
+express `userValidationRules` in an `--authentication-config` document. The proxy
+refuses to start when either prefix flag itself begins with `system:`.
+
+`Impersonate-*` targets authorized by `SubjectAccessReview` are deliberately left
+alone: an operator who bound RBAC permitting impersonation of `system:masters`
+made that call on purpose, and blocking it would break break-glass access.
+
+Set `--allow-reserved-identity-claims` to opt out and restore the previous
+behaviour. It permits a token claim to mint `system:masters` and any service
+account identity; only enable it if you fully control the issuer's claims.
 
 ### Original-user audit headers
 

--- a/pkg/proxy/audit/handler.go
+++ b/pkg/proxy/audit/handler.go
@@ -5,16 +5,18 @@ import (
 	"net/http"
 )
 
-// This struct is used to implement an http.Handler interface. This will not
-// actually serve but instead implements auditing during unauthenticated
-// requests. It is expected that consumers of this type will call `ServeHTTP`
-// when an unauthenticated request is received.
-type unauthenticatedHandler struct {
+// funcHandler adapts a serve func to http.Handler so it can be wrapped by the
+// audit filters. It does not proxy anything; consumers call ServeHTTP when the
+// proxy answers a request itself instead of forwarding it.
+type funcHandler struct {
 	serveFunc func(http.ResponseWriter, *http.Request)
 }
 
+// NewUnauthenticatedHandler returns a handler for a request that failed
+// authentication. It is expected that consumers of this type will call
+// `ServeHTTP` when an unauthenticated request is received.
 func NewUnauthenticatedHandler(a *Audit, serveFunc func(http.ResponseWriter, *http.Request)) http.Handler {
-	u := &unauthenticatedHandler{
+	u := &funcHandler{
 		serveFunc: serveFunc,
 	}
 
@@ -26,6 +28,26 @@ func NewUnauthenticatedHandler(a *Audit, serveFunc func(http.ResponseWriter, *ht
 	return a.WithUnauthorized(u)
 }
 
-func (u *unauthenticatedHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+// NewForbiddenHandler returns a handler for a request that authenticated
+// successfully and is then refused by the proxy. Unlike NewUnauthenticatedHandler
+// it audits through the ordinary request chain, so the event carries the
+// authenticated identity — which the caller MUST have placed in the request
+// context (genericapirequest.WithUser) before serving. WithFailedAuthenticationAudit
+// is deliberately not used here: it records the event as an authentication
+// failure and evaluates the audit policy against an empty user.
+func NewForbiddenHandler(a *Audit, serveFunc func(http.ResponseWriter, *http.Request)) http.Handler {
+	h := &funcHandler{
+		serveFunc: serveFunc,
+	}
+
+	// if auditor is nil then return without wrapping
+	if a == nil {
+		return h
+	}
+
+	return a.WithRequest(h)
+}
+
+func (u *funcHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	u.serveFunc(rw, r)
 }

--- a/pkg/proxy/audit/handler_test.go
+++ b/pkg/proxy/audit/handler_test.go
@@ -109,6 +109,16 @@ func readForbiddenAuditEvents(t *testing.T, a *Audit, path string) []forbiddenAu
 // successfully and was then refused by the proxy, so the audit record must name
 // the identity that was presented and must not read as an authentication
 // failure.
+//
+// The assertions are deliberately confined to what this handler decides: the
+// stage, the identity, the status code, and the absence of an
+// authentication-failure message. The event's verb and objectRef are not
+// asserted because they are decided by the RequestInfo resolver, so they move
+// with its configuration — a core-group path like the one below is classified
+// as a non-resource request (verb "get", no objectRef) unless the resolver is
+// given the legacy API group prefixes, which turns it into a resource request
+// (verb "list", objectRef present). Assert on those only against the resolver
+// this package actually builds.
 func TestNewForbiddenHandlerAuditsAuthenticatedIdentity(t *testing.T) {
 	a, logPath := newForbiddenTestAudit(t)
 

--- a/pkg/proxy/audit/handler_test.go
+++ b/pkg/proxy/audit/handler_test.go
@@ -1,0 +1,185 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package audit
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	authuser "k8s.io/apiserver/pkg/authentication/user"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/server"
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+
+	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
+)
+
+// forbiddenAuditEvent is the subset of an audit.k8s.io/v1 Event this test
+// asserts on. Decoding into a local struct keeps the assertions independent of
+// the apiserver's internal/external event conversions.
+type forbiddenAuditEvent struct {
+	Stage string `json:"stage"`
+	User  struct {
+		Username string   `json:"username"`
+		Groups   []string `json:"groups"`
+	} `json:"user"`
+	ResponseStatus *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"responseStatus"`
+}
+
+// forbiddenAuditPolicy is a Metadata-level policy for every request.
+// RequestReceived is omitted so the backend emits exactly one event per
+// request, keeping the assertions unambiguous.
+const forbiddenAuditPolicy = `apiVersion: audit.k8s.io/v1
+kind: Policy
+omitStages:
+  - RequestReceived
+rules:
+  - level: Metadata
+`
+
+// newForbiddenTestAudit builds a real Audit backed by a file log backend and a
+// Metadata policy, returning it alongside the path the events are written to.
+func newForbiddenTestAudit(t *testing.T) (*Audit, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.yaml")
+	if err := os.WriteFile(policyPath, []byte(forbiddenAuditPolicy), 0600); err != nil {
+		t.Fatalf("writing audit policy: %s", err)
+	}
+	logPath := filepath.Join(dir, "audit.log")
+
+	opts := &options.AuditOptions{AuditOptions: apiserveroptions.NewAuditOptions()}
+	opts.PolicyFile = policyPath
+	opts.LogOptions.Path = logPath
+
+	a, err := New(opts, "0.0.0.0:1234", new(server.SecureServingInfo))
+	if err != nil {
+		t.Fatalf("creating auditor: %s", err)
+	}
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	if err := a.Run(stopCh); err != nil {
+		t.Fatalf("running audit backend: %s", err)
+	}
+
+	return a, logPath
+}
+
+// readForbiddenAuditEvents flushes the backend and returns every event written
+// to path.
+func readForbiddenAuditEvents(t *testing.T, a *Audit, path string) []forbiddenAuditEvent {
+	t.Helper()
+
+	if err := a.Shutdown(); err != nil {
+		t.Fatalf("shutting down audit backend: %s", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading audit log %q: %s", path, err)
+	}
+
+	var events []forbiddenAuditEvent
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if line == "" {
+			continue
+		}
+		var event forbiddenAuditEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			t.Fatalf("decoding audit event %q: %s", line, err)
+		}
+		events = append(events, event)
+	}
+
+	return events
+}
+
+// TestNewForbiddenHandlerAuditsAuthenticatedIdentity is the regression guard
+// against wiring the forbidden handler through WithFailedAuthenticationAudit
+// (i.e. reverting it to NewUnauthenticatedHandler). The request authenticated
+// successfully and was then refused by the proxy, so the audit record must name
+// the identity that was presented and must not read as an authentication
+// failure.
+func TestNewForbiddenHandlerAuditsAuthenticatedIdentity(t *testing.T) {
+	a, logPath := newForbiddenTestAudit(t)
+
+	handler := NewForbiddenHandler(a, func(rw http.ResponseWriter, r *http.Request) {
+		http.Error(rw, "forbidden", http.StatusForbidden)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	// A bearer token is present so that, were the handler wired through
+	// WithFailedAuthenticationAudit, the event would carry its
+	// "Authentication failed, attempted: bearer" message.
+	req.Header.Set("Authorization", "bearer fake-token")
+	req = req.WithContext(genericapirequest.WithUser(req.Context(), &authuser.DefaultInfo{
+		Name:   "alice",
+		Groups: []string{"system:masters"},
+	}))
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if got, want := rw.Result().StatusCode, http.StatusForbidden; got != want {
+		t.Errorf("unexpected response code, exp=%d got=%d", want, got)
+	}
+
+	events := readForbiddenAuditEvents(t, a, logPath)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one audit event, got %d: %+v", len(events), events)
+	}
+	event := events[0]
+
+	if event.Stage != "ResponseComplete" {
+		t.Errorf("expected a ResponseComplete audit event, got stage %q", event.Stage)
+	}
+
+	// The regression guard: the authenticated identity, not an empty user.
+	if event.User.Username != "alice" {
+		t.Errorf("audit event does not carry the authenticated user, exp=alice got=%q", event.User.Username)
+	}
+	if len(event.User.Groups) != 1 || event.User.Groups[0] != "system:masters" {
+		t.Errorf("audit event does not carry the authenticated groups, exp=[system:masters] got=%v", event.User.Groups)
+	}
+
+	if event.ResponseStatus == nil {
+		t.Fatal("audit event has no responseStatus")
+	}
+	if got, want := event.ResponseStatus.Code, http.StatusForbidden; got != want {
+		t.Errorf("unexpected audited response code, exp=%d got=%d", want, got)
+	}
+
+	// Not an authentication-failure record.
+	if strings.Contains(event.ResponseStatus.Message, "Authentication failed") {
+		t.Errorf("audit event reads as an authentication failure: %q", event.ResponseStatus.Message)
+	}
+}
+
+// TestNewForbiddenHandlerWithoutAuditor asserts the handler still serves its
+// response when no audit backend is configured, matching the nil-safety of
+// NewUnauthenticatedHandler.
+func TestNewForbiddenHandlerWithoutAuditor(t *testing.T) {
+	handler := NewForbiddenHandler(nil, func(rw http.ResponseWriter, r *http.Request) {
+		http.Error(rw, "forbidden", http.StatusForbidden)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, req)
+
+	if got, want := rw.Result().StatusCode, http.StatusForbidden; got != want {
+		t.Errorf("unexpected response code, exp=%d got=%d", want, got)
+	}
+	if got := strings.TrimSpace(rw.Body.String()); got != "forbidden" {
+		t.Errorf("unexpected response body, exp=forbidden got=%q", got)
+	}
+}

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -45,8 +45,16 @@ func (p *Proxy) withAuthenticateRequest(handler http.Handler) http.Handler {
 		// Auth request and handle unauthed
 		info, ok, err := p.oidcRequestAuther.AuthenticateRequest(req)
 		if err != nil {
-			klog.V(5).Infof("Authenticated request failed: %s", err)
+			// An error here means a token was present and failed validation;
+			// an absent or unparseable token yields ok == false with a nil
+			// error. Log it at the level operators run at, not V(5).
+			var remoteAddr string
+			req, remoteAddr = context.RemoteAddr(req)
+			klog.V(2).Infof("failed to authenticate request (%s): %s", remoteAddr, err)
+
 			// Since we have failed OIDC auth, we will try a token review, if enabled.
+			// Routing is deliberately unchanged: falling through to token
+			// passthrough is documented alpha behaviour, not a defect.
 			tokenReviewHandler.ServeHTTP(rw, req)
 			return
 		}

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -5,6 +5,7 @@ import (
 	stdcontext "context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strings"
@@ -19,6 +20,10 @@ import (
 	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/logging"
 	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
 )
+
+// reservedIdentityPrefix is the username/group prefix Kubernetes reserves for
+// its own identities.
+const reservedIdentityPrefix = "system:"
 
 func (p *Proxy) withHandlers(handler http.Handler) http.Handler {
 	// Set up proxy handlers
@@ -57,10 +62,57 @@ func (p *Proxy) withAuthenticateRequest(handler http.Handler) http.Handler {
 
 		klog.V(4).Infof("authenticated request: %s", remoteAddr)
 
-		// Add the user info to the request context
+		// Add the user info to the request context. Done before the
+		// reserved-identity check so a rejection is audited against the identity
+		// that was presented.
 		req = req.WithContext(genericapirequest.WithUser(req.Context(), info.User))
+
+		if !p.config.AllowReservedIdentityClaims {
+			if err := checkReservedIdentity(info.User); err != nil {
+				p.handleError(rw, req, err)
+				return
+			}
+		}
+
 		handler.ServeHTTP(rw, req)
 	})
+}
+
+// checkReservedIdentity refuses an identity that a token claim must never be
+// able to produce. system: is reserved by Kubernetes: system:masters is
+// cluster-admin by default, and system:serviceaccount:<ns>:<name> is any
+// service account, both of which this proxy is granted blanket impersonate
+// rights over. Kubernetes does not enforce this on claim mappings.
+//
+// Username has no exception: even system:authenticated can be granted rights by
+// an RBAC binding naming it as a User. Groups permit exactly AllAuthenticated,
+// because withImpersonateRequest appends it to every request anyway, so an IdP
+// that also emits it must not 403 the whole cluster.
+//
+// The identity is refused, not stripped: a caller quietly served without the
+// group they claimed has been told the wrong thing about who they are, and the
+// resulting RBAC denial then looks like a policy bug.
+//
+// This is not implemented as UserValidationRules (CEL) on the JWTAuthenticator,
+// the Kubernetes-native option, because a validation-rule failure surfaces as an
+// authentication error and withAuthenticateRequest routes err != nil into the
+// token-review path: with --token-passthrough on, the rejection would be
+// swallowed and the request silently retried against TokenReview.
+func checkReservedIdentity(info authuser.Info) error {
+	if strings.HasPrefix(info.GetName(), reservedIdentityPrefix) {
+		return fmt.Errorf("%w: username %q", errReservedIdentity, info.GetName())
+	}
+
+	for _, group := range info.GetGroups() {
+		if group == authuser.AllAuthenticated {
+			continue
+		}
+		if strings.HasPrefix(group, reservedIdentityPrefix) {
+			return fmt.Errorf("%w: group %q", errReservedIdentity, group)
+		}
+	}
+
+	return nil
 }
 
 // withTokenReview will attempt a token review on the incoming request, if
@@ -214,6 +266,15 @@ func (p *Proxy) newErrorHandler() func(rw http.ResponseWriter, r *http.Request, 
 		http.Error(rw, "Unauthorized", http.StatusUnauthorized)
 	})
 
+	// Audited through the ordinary request chain rather than the
+	// failed-authentication one: the request authenticated successfully and was
+	// then refused, and the caller has already put the identity in the request
+	// context. The client body carries no claim values; they are logged and
+	// audited instead.
+	forbiddenHandler := audit.NewForbiddenHandler(p.auditor, func(rw http.ResponseWriter, r *http.Request) {
+		http.Error(rw, "identities with the reserved \"system:\" prefix are not accepted from an authentication token", http.StatusForbidden)
+	})
+
 	return func(rw http.ResponseWriter, r *http.Request, err error) {
 
 		if err == nil {
@@ -231,6 +292,12 @@ func (p *Proxy) newErrorHandler() func(rw http.ResponseWriter, r *http.Request, 
 		case errors.Is(err, errUnauthorized):
 			// If Unauthorized then error and report to audit
 			unauthedHandler.ServeHTTP(rw, r)
+			return
+
+			// Authenticated, but the identity is one a token must never mint.
+		case errors.Is(err, errReservedIdentity):
+			klog.V(2).Infof("rejecting reserved identity (%s): %s", r.RemoteAddr, err)
+			forbiddenHandler.ServeHTTP(rw, r)
 			return
 
 			// No name given or available in oidc request

--- a/pkg/proxy/handlers_test.go
+++ b/pkg/proxy/handlers_test.go
@@ -2,10 +2,13 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"flag"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -17,6 +20,7 @@ import (
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 	authuser "k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
 
 	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
 	fakesubjectaccessreview "github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview/fake"
@@ -69,6 +73,75 @@ func TestWithImpersonateRequestDoesNotMutateAuthenticatorUser(t *testing.T) {
 	if !reflect.DeepEqual(usr.Extra, wantExtra) {
 		t.Errorf("authenticator extra map mutated: got %#v, want %#v", usr.Extra, wantExtra)
 	}
+}
+
+// TestWithAuthenticateRequestLogsValidationFailureAtV2 asserts that a token
+// that was present and failed OIDC validation is reported at a verbosity
+// operators actually run at, with the resolved remote address. Routing is
+// unchanged: the request still falls through to the token-review path.
+func TestWithAuthenticateRequestLogsValidationFailureAtV2(t *testing.T) {
+	buf := captureKlogAtV2(t)
+
+	p := newTestProxy(t)
+
+	p.fakeToken.EXPECT().AuthenticateToken(gomock.Any(), "fake-token").Return(
+		nil, false, errors.New("oidc: token is expired"))
+
+	handler := p.withAuthenticateRequest(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("inner handler was reached for a token that failed validation")
+	}))
+
+	rw := httptest.NewRecorder()
+	req := reservedIdentityRequest(t, nil)
+	req.RemoteAddr = "8.8.8.8:1234"
+	handler.ServeHTTP(rw, req)
+
+	// Routing is unchanged: token review is disabled here, so the request is
+	// still answered as unauthorized rather than being rejected outright.
+	if got, want := rw.Result().StatusCode, http.StatusUnauthorized; got != want {
+		t.Errorf("unexpected response code, exp=%d got=%d", want, got)
+	}
+
+	klog.Flush()
+	logged := buf.String()
+	if !strings.Contains(logged, "oidc: token is expired") {
+		t.Errorf("validation failure was not logged at V(2), got: %q", logged)
+	}
+	if !strings.Contains(logged, "8.8.8.8") {
+		t.Errorf("validation failure log does not name the remote address, got: %q", logged)
+	}
+
+	p.ctrl.Finish()
+}
+
+// captureKlogAtV2 redirects klog to a buffer at verbosity 2 for the duration of
+// the test. klog's verbosity and output are process-global, so the cleanup
+// restores both — including the output writer, which would otherwise leave
+// later klog calls in this package writing into a dead buffer.
+func captureKlogAtV2(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var fs flag.FlagSet
+	klog.InitFlags(&fs)
+	previousVerbosity := fs.Lookup("v").Value.String()
+	if err := fs.Set("v", "2"); err != nil {
+		t.Fatalf("setting klog verbosity: %s", err)
+	}
+
+	buf := new(bytes.Buffer)
+	klog.LogToStderr(false)
+	klog.SetOutput(buf)
+
+	t.Cleanup(func() {
+		klog.Flush()
+		if err := fs.Set("v", previousVerbosity); err != nil {
+			t.Errorf("restoring klog verbosity: %s", err)
+		}
+		klog.SetOutput(os.Stderr)
+		klog.LogToStderr(true)
+	})
+
+	return buf
 }
 
 // TestCheckReservedIdentity covers the username/group asymmetry. Username has

--- a/pkg/proxy/handlers_test.go
+++ b/pkg/proxy/handlers_test.go
@@ -2,13 +2,24 @@
 package proxy
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
+	"sync/atomic"
 	"testing"
 
+	"go.uber.org/mock/gomock"
+	azv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
 	authuser "k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	"github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview"
+	fakesubjectaccessreview "github.com/rafpe/kube-oidc-proxy/pkg/proxy/subjectaccessreview/fake"
 )
 
 // TestWithImpersonateRequestDoesNotMutateAuthenticatorUser is the regression
@@ -58,4 +69,207 @@ func TestWithImpersonateRequestDoesNotMutateAuthenticatorUser(t *testing.T) {
 	if !reflect.DeepEqual(usr.Extra, wantExtra) {
 		t.Errorf("authenticator extra map mutated: got %#v, want %#v", usr.Extra, wantExtra)
 	}
+}
+
+// TestCheckReservedIdentity covers the username/group asymmetry. Username has
+// no exception at all; groups permit exactly AllAuthenticated because the proxy
+// appends it to every request itself.
+func TestCheckReservedIdentity(t *testing.T) {
+	tests := map[string]struct {
+		info    authuser.Info
+		wantErr bool
+	}{
+		"system:masters group": {
+			info:    &authuser.DefaultInfo{Name: "alice", Groups: []string{"system:masters"}},
+			wantErr: true,
+		},
+		"system:authenticated group": {
+			info:    &authuser.DefaultInfo{Name: "alice", Groups: []string{authuser.AllAuthenticated}},
+			wantErr: false,
+		},
+		"system:unauthenticated group": {
+			info:    &authuser.DefaultInfo{Name: "alice", Groups: []string{"system:unauthenticated"}},
+			wantErr: true,
+		},
+		"system: username": {
+			info:    &authuser.DefaultInfo{Name: "system:masters"},
+			wantErr: true,
+		},
+		// The group-side exception must NOT leak to the username: a reserved
+		// username can be granted rights by an RBAC binding naming it as a User.
+		"system:authenticated username": {
+			info:    &authuser.DefaultInfo{Name: authuser.AllAuthenticated},
+			wantErr: true,
+		},
+		"system:serviceaccount username": {
+			info:    &authuser.DefaultInfo{Name: "system:serviceaccount:kube-system:default"},
+			wantErr: true,
+		},
+		"ordinary identity": {
+			info:    &authuser.DefaultInfo{Name: "alice", Groups: []string{"dev"}},
+			wantErr: false,
+		},
+		"lookalike identity": {
+			info:    &authuser.DefaultInfo{Name: "system-admin", Groups: []string{"systemd:ops"}},
+			wantErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := checkReservedIdentity(test.info)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("checkReservedIdentity(%#v) = nil, want an error", test.info)
+				}
+				if !errors.Is(err, errReservedIdentity) {
+					t.Errorf("checkReservedIdentity(%#v) error = %v, want errReservedIdentity", test.info, err)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("checkReservedIdentity(%#v) = %v, want nil", test.info, err)
+			}
+		})
+	}
+}
+
+// reservedIdentityRequest builds a bearer-token request that the fake
+// authenticator wired by newTestProxy is primed to answer.
+func reservedIdentityRequest(t *testing.T, extraHeaders map[string]string) *http.Request {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/default/pods", nil)
+	req.Header.Set("Authorization", "bearer fake-token")
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	return req
+}
+
+func TestWithAuthenticateRequestRejectsReservedIdentity(t *testing.T) {
+	p := newTestProxy(t)
+
+	p.fakeToken.EXPECT().AuthenticateToken(gomock.Any(), "fake-token").Return(
+		&authenticator.Response{
+			User: &authuser.DefaultInfo{Name: "alice", Groups: []string{"system:masters"}},
+		}, true, nil)
+
+	var served bool
+	handler := p.withAuthenticateRequest(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		served = true
+	}))
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, reservedIdentityRequest(t, nil))
+
+	if served {
+		t.Error("inner handler was reached for a reserved identity")
+	}
+	if got, want := rw.Result().StatusCode, http.StatusForbidden; got != want {
+		t.Errorf("unexpected response code, exp=%d got=%d", want, got)
+	}
+	if got := rw.Body.String(); !strings.Contains(got, "system:") {
+		t.Errorf("response body does not explain the rejection: %q", got)
+	}
+
+	p.ctrl.Finish()
+}
+
+func TestWithAuthenticateRequestAllowsReservedIdentityWhenOptedIn(t *testing.T) {
+	p := newTestProxy(t)
+	p.config.AllowReservedIdentityClaims = true
+
+	p.fakeToken.EXPECT().AuthenticateToken(gomock.Any(), "fake-token").Return(
+		&authenticator.Response{
+			User: &authuser.DefaultInfo{Name: "alice", Groups: []string{"system:masters"}},
+		}, true, nil)
+
+	var served bool
+	handler := p.withAuthenticateRequest(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		served = true
+
+		user, ok := genericapirequest.UserFrom(req.Context())
+		if !ok {
+			t.Error("no user in request context")
+			return
+		}
+		if user.GetName() != "alice" {
+			t.Errorf("unexpected user in request context, exp=alice got=%q", user.GetName())
+		}
+	}))
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, reservedIdentityRequest(t, nil))
+
+	if !served {
+		t.Error("inner handler was not reached with --allow-reserved-identity-claims set")
+	}
+	if got, want := rw.Result().StatusCode, http.StatusOK; got != want {
+		t.Errorf("unexpected response code, exp=%d got=%d", want, got)
+	}
+
+	p.ctrl.Finish()
+}
+
+// countingReviewer records how many SubjectAccessReviews were submitted while
+// delegating the decision itself to the shared fake.
+type countingReviewer struct {
+	*fakesubjectaccessreview.FakeReviewer
+
+	reviews atomic.Int64
+}
+
+func (c *countingReviewer) Create(ctx context.Context, req *azv1.SubjectAccessReview, co metav1.CreateOptions) (*azv1.SubjectAccessReview, error) {
+	c.reviews.Add(1)
+	return c.FakeReviewer.Create(ctx, req, co)
+}
+
+// TestReservedIdentityRejectedBeforeSubjectAccessReview is the ordering
+// property that makes the guard meaningful. CheckAuthorizedForImpersonation
+// builds its SubjectAccessReview with the requester's own groups, so a forged
+// system: group would otherwise feed the authorization decision — not merely
+// the impersonation headers. No review may be submitted at all.
+func TestReservedIdentityRejectedBeforeSubjectAccessReview(t *testing.T) {
+	p := newTestProxy(t)
+
+	reviewer := &countingReviewer{FakeReviewer: fakesubjectaccessreview.New(nil)}
+	sar, err := subjectaccessreview.New(reviewer, subjectaccessreview.DefaultTimeout)
+	if err != nil {
+		t.Fatalf("creating subject access reviewer: %s", err)
+	}
+	p.subjectAccessReviewer = sar
+
+	p.fakeToken.EXPECT().AuthenticateToken(gomock.Any(), "fake-token").Return(
+		&authenticator.Response{
+			User: &authuser.DefaultInfo{Name: "alice", Groups: []string{"system:masters"}},
+		}, true, nil)
+
+	var served bool
+	handler := p.withHandlers(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		served = true
+	}))
+
+	rw := httptest.NewRecorder()
+	handler.ServeHTTP(rw, reservedIdentityRequest(t, map[string]string{
+		"Impersonate-User": "jjackson",
+	}))
+
+	if served {
+		t.Error("inner handler was reached for a reserved identity")
+	}
+	if got, want := rw.Result().StatusCode, http.StatusForbidden; got != want {
+		t.Errorf("unexpected response code, exp=%d got=%d", want, got)
+	}
+	if got := rw.Body.String(); !strings.Contains(got, "system:") {
+		t.Errorf("response body does not explain the rejection: %q", got)
+	}
+	if got := reviewer.reviews.Load(); got != 0 {
+		t.Errorf("SubjectAccessReviews were submitted for a reserved identity, exp=0 got=%d", got)
+	}
+
+	p.ctrl.Finish()
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -39,11 +39,22 @@ var (
 	errUnauthorized          = errors.New("unauthorized")
 	errNoName                = errors.New("no name in OIDC info")
 	errNoImpersonationConfig = errors.New("no impersonation configuration in context")
+
+	// errReservedIdentity classifies an authenticated identity whose username or
+	// groups carry the Kubernetes-reserved "system:" prefix. Such an identity may
+	// never originate from a token claim; see checkReservedIdentity.
+	errReservedIdentity = errors.New("reserved identity in authentication token")
 )
 
 type Config struct {
 	DisableImpersonation bool
 	TokenReview          bool
+
+	// AllowReservedIdentityClaims opts out of the reserved-identity guard,
+	// permitting a token claim to mint "system:"-prefixed usernames and groups —
+	// including system:masters and any service account. Off by default; see
+	// checkReservedIdentity for why the guard exists.
+	AllowReservedIdentityClaims bool
 
 	FlushInterval   time.Duration
 	ExternalAddress string

--- a/test/e2e/framework/helper/token.go
+++ b/test/e2e/framework/helper/token.go
@@ -4,6 +4,7 @@ package helper
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -63,6 +64,29 @@ func (h *Helper) SignToken(issuerBundle *util.KeyBundle, tokenPayload []byte) (s
 	}
 
 	return signedToken, nil
+}
+
+// NewTokenPayloadForIdentity returns a token payload for an arbitrary identity,
+// for cases that need claims NewTokenPayload's fixed ones cannot express. The
+// username goes in the "email" claim and the groups in the "groups" claim,
+// matching the --oidc-username-claim/--oidc-groups-claim the suite deploys the
+// proxy with. Marshalled rather than formatted so a value containing a quote or
+// a backslash cannot produce a malformed (or a differently shaped) token.
+func (h *Helper) NewTokenPayloadForIdentity(issuerURL *url.URL, clientID, username string,
+	groups []string, exp time.Time) ([]byte, error) {
+
+	payload, err := json.Marshal(map[string]interface{}{
+		"iss":    issuerURL.String(),
+		"aud":    []string{clientID, "aud-2"},
+		"email":  username,
+		"groups": groups,
+		"exp":    exp.Unix(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal token payload: %s", err)
+	}
+
+	return payload, nil
 }
 
 func (h *Helper) NewTokenPayload(issuerURL *url.URL, clientID string, exp time.Time) []byte {

--- a/test/e2e/suite/cases/doc.go
+++ b/test/e2e/suite/cases/doc.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/passthrough"
 	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/probe"
 	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/rbac"
+	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/reservedidentity"
 	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/token"
 	_ "github.com/rafpe/kube-oidc-proxy/test/e2e/suite/cases/upgrade"
 )

--- a/test/e2e/suite/cases/reservedidentity/reservedidentity.go
+++ b/test/e2e/suite/cases/reservedidentity/reservedidentity.go
@@ -1,0 +1,236 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package reservedidentity
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/framework"
+	"github.com/rafpe/kube-oidc-proxy/test/kind"
+)
+
+const (
+	// defaultUsername is the username the suite's OIDC identity normally
+	// carries, and the one the proxy's e2e RBAC binds impersonation rights to.
+	defaultUsername = "user@example.com"
+
+	// impersonationTarget is deliberately a user that defaultUsername has *no*
+	// standing right to impersonate: the proxy's e2e RBAC grants that only for
+	// ok-to-impersonate@nodomain.dev. The only authorization that can pass the
+	// SubjectAccessReview for this target is the forged system:masters group in
+	// the token, which is what makes the opt-out spec a real falsifier rather
+	// than a request that would have succeeded anyway.
+	impersonationTarget = "foo@example.com"
+
+	// reservedGroup is cluster-admin by default in any kubeadm-built cluster,
+	// kind included, through the cluster-admin ClusterRoleBinding.
+	reservedGroup = "system:masters"
+
+	// reservedUsername is the username-side escalation: the proxy is granted
+	// impersonate on serviceaccounts with no resourceNames, so a username claim
+	// of this shape is any service account in the cluster.
+	reservedUsername = "system:serviceaccount:kube-system:default"
+
+	// forbiddenBody is the tail of the body the proxy writes when it refuses a
+	// reserved identity. Matched as a substring, and without the quoted
+	// "system:" fragment of the full message, so the assertion does not depend
+	// on how quotes survive the client's error decoding. It is distinct from
+	// every other 403 the proxy can produce, in particular from the
+	// "is not allowed to impersonate" denial a SubjectAccessReview yields —
+	// which is the 403 this request would get if the guard ran after the SAR
+	// instead of before it.
+	forbiddenBody = "are not accepted from an authentication token"
+
+	// sarRequestPath identifies a SubjectAccessReview in the proxy's own logs.
+	// The suite deploys the proxy with --v=10, at which client-go logs every
+	// request it makes to the API server (transport.DebugWrappers installs its
+	// debugging round tripper from V(6) up), so a submitted SAR appears as the
+	// path of the logged request. The API server the suite runs against is a
+	// kind cluster with no audit log enabled, so the proxy's own logs are where
+	// "no SubjectAccessReview was submitted" is observable end to end; the
+	// paired opt-out spec asserts the same string *does* appear, so this
+	// mechanism cannot silently stop working and leave the assertion below
+	// passing for the wrong reason.
+	sarRequestPath = "subjectaccessreviews"
+)
+
+var _ = framework.CasesDescribe("Reserved identity", Label("shard-c"), func() {
+	// The guard is on by default. None of these specs gets past it, so none of
+	// them leaves residue another depends on and they share a single deploy.
+	Describe("refused", Ordered, ContinueOnFailure, func() {
+		f := framework.NewOrderedDefaultFramework("reserved-identity")
+
+		BeforeAll(func() {
+			By("Granting pod list to the impersonation target and to the token's own user")
+			grantPodList(f, impersonationTarget)
+			grantPodList(f, defaultUsername)
+		})
+
+		It("should refuse a token whose groups claim contains system:masters, without reaching the SubjectAccessReview", func() {
+			By("Listing pods with a system:masters group claim and an Impersonate-User header")
+			code, body := listPods(f, signedTokenFor(f, defaultUsername, []string{reservedGroup}), impersonationTarget)
+
+			Expect(code).To(Equal(http.StatusForbidden), body)
+			Expect(body).To(ContainSubstring(forbiddenBody))
+
+			By("Checking no SubjectAccessReview was submitted for the request")
+			// Any SAR would have been submitted before the response the proxy
+			// has already written; the pause is only to let the container
+			// runtime catch up with the proxy's stderr.
+			time.Sleep(time.Second * 2)
+			Expect(proxyLogs(f)).NotTo(ContainSubstring(sarRequestPath),
+				"the proxy submitted a SubjectAccessReview for an identity it refused; the guard must run before the SAR, "+
+					"which builds its review from the requester's own (forged) groups")
+		})
+
+		It("should refuse a token whose username claim has the reserved system: prefix", func() {
+			By("Listing pods as a service account username, with no impersonation")
+			code, body := listPods(f, signedTokenFor(f, reservedUsername, []string{"group-1"}), "")
+
+			Expect(code).To(Equal(http.StatusForbidden), body)
+			Expect(body).To(ContainSubstring(forbiddenBody))
+		})
+
+		It("should accept a token whose groups claim contains system:authenticated", func() {
+			// The one exception on the group side: the proxy appends
+			// system:authenticated to every request itself, so an issuer that
+			// also emits it must not be refused. The username rule has no such
+			// exception, which the spec above covers.
+			By("Listing pods with a system:authenticated group claim")
+			code, body := listPods(f, signedTokenFor(f, defaultUsername, []string{"system:authenticated", "group-1"}), "")
+
+			Expect(code).To(Equal(http.StatusOK), body)
+		})
+	})
+
+	// The falsifier. Same token, same request, same cluster state as the first
+	// spec above; the only difference is the opt-out flag. The request has to
+	// reach the API server and succeed here, which is what makes the 403 and
+	// the absent SubjectAccessReview above attributable to the guard rather
+	// than to anything else about the request.
+	Describe("allowed by --allow-reserved-identity-claims", func() {
+		f := framework.NewDefaultFramework("reserved-identity-optout")
+
+		It("should let a system:masters group claim authorize an impersonation it otherwise could not", func() {
+			By("Redeploying the proxy with --allow-reserved-identity-claims")
+			f.DeployProxyWith(nil, "--allow-reserved-identity-claims")
+
+			By("Granting pod list to the impersonation target")
+			grantPodList(f, impersonationTarget)
+
+			By("Listing pods with a system:masters group claim and an Impersonate-User header")
+			code, body := listPods(f, signedTokenFor(f, defaultUsername, []string{reservedGroup}), impersonationTarget)
+
+			// 200 only because the SubjectAccessReview authorizing the
+			// impersonation was built with the token's forged system:masters
+			// group. This is the escalation the guard exists to prevent.
+			Expect(code).To(Equal(http.StatusOK), body)
+
+			By("Checking the SubjectAccessReview did reach the API server")
+			Eventually(func() string { return proxyLogs(f) }, time.Second*15, time.Second).
+				Should(ContainSubstring(sarRequestPath),
+					"no SubjectAccessReview was logged even with the guard opted out, so the zero-SAR assertion "+
+						"in the refused specs cannot be trusted to fail")
+		})
+	})
+})
+
+// grantPodList gives username permission to list pods in the test namespace.
+func grantPodList(f *framework.Framework, username string) {
+	role, err := f.Helper().KubeClient.RbacV1().Roles(f.Namespace.Name).Create(context.TODO(), &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "reserved-identity-pods-",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list"}},
+		},
+	}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = f.Helper().KubeClient.RbacV1().RoleBindings(f.Namespace.Name).Create(context.TODO(),
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "reserved-identity-pods-",
+			},
+			Subjects: []rbacv1.Subject{{Name: username, Kind: "User"}},
+			RoleRef:  rbacv1.RoleRef{Name: role.Name, Kind: "Role"},
+		}, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// signedTokenFor mints a token for the given identity, signed by the suite's
+// mock issuer.
+func signedTokenFor(f *framework.Framework, username string, groups []string) string {
+	payload, err := f.Helper().NewTokenPayloadForIdentity(f.IssuerURL(), f.ClientID(),
+		username, groups, time.Now().Add(time.Minute*10))
+	Expect(err).NotTo(HaveOccurred())
+
+	signedToken, err := f.Helper().SignToken(f.IssuerKeyBundle(), payload)
+	Expect(err).NotTo(HaveOccurred())
+
+	return signedToken
+}
+
+// listPods lists pods in the test namespace through the proxy with the given
+// token, impersonating impersonateUser when it is non-empty. It returns the
+// response status code and, for a failure, the message the proxy wrote.
+func listPods(f *framework.Framework, signedToken, impersonateUser string) (int, string) {
+	config := f.NewProxyRestConfig()
+	config.BearerToken = signedToken
+	if impersonateUser != "" {
+		config.Impersonate = rest.ImpersonationConfig{UserName: impersonateUser}
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = client.CoreV1().Pods(f.Namespace.Name).List(context.TODO(), metav1.ListOptions{})
+	if err == nil {
+		return http.StatusOK, ""
+	}
+
+	var statusErr *k8sErrors.StatusError
+	if !errors.As(err, &statusErr) {
+		Expect(fmt.Errorf("expected a status error from the proxy, got=%s", err)).NotTo(HaveOccurred())
+	}
+
+	// A body the proxy wrote itself is not a Status object, so the client
+	// carries it as an unexpected-response cause rather than in the message.
+	body := statusErr.Error()
+	if details := statusErr.Status().Details; details != nil && len(details.Causes) > 0 {
+		body = details.Causes[0].Message
+	}
+
+	return int(statusErr.ErrStatus.Code), body
+}
+
+// proxyLogs returns the logs of the proxy container currently deployed in the
+// test namespace.
+func proxyLogs(f *framework.Framework) string {
+	pods, err := f.Helper().KubeClient.CoreV1().Pods(f.Namespace.Name).List(context.TODO(),
+		metav1.ListOptions{LabelSelector: "app=" + kind.ProxyImageName})
+	Expect(err).NotTo(HaveOccurred())
+	if len(pods.Items) != 1 {
+		Expect(fmt.Errorf("expected single kube-oidc-proxy pod running, got=%d", len(pods.Items))).NotTo(HaveOccurred())
+	}
+
+	logs, err := f.Helper().KubeClient.CoreV1().Pods(f.Namespace.Name).
+		GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{Container: kind.ProxyImageName}).
+		DoRaw(context.TODO())
+	Expect(err).NotTo(HaveOccurred())
+
+	return string(logs)
+}


### PR DESCRIPTION
## The escalation path being closed

`withAuthenticateRequest` took the OIDC username and groups claims into the request
context unchecked, and `withImpersonateRequest` passes those groups straight into
`ImpersonationConfig`. `chart/kube-oidc-proxy/templates/clusterrole.yaml` grants the
proxy `impersonate` on `users`, `groups` and `serviceaccounts` with **no
`resourceNames`**, so whatever the token says is impersonated as-is.

An IdP that can be induced to emit:

- `system:masters` in the groups claim — bound to `cluster-admin` by default; or
- `system:serviceaccount:<namespace>:<name>` as the username claim

reaches the `Impersonate-*` headers and obtains those privileges. Kubernetes does not
guard this: `userValidationRules` (CEL) exist for the *operator* to write, and nothing
else applies to claim mappings.

This PR refuses such an identity with `403` by default.

## Why the guard sits in `withAuthenticateRequest`, before the SubjectAccessReview

**Ordering is the actual fix, not the header filtering.**
`CheckAuthorizedForImpersonation` builds its SubjectAccessReview with
`Groups: requester.GetGroups()`. A forged `system:` group would otherwise feed the
*authorization* decision, not merely the impersonation headers — if any RBAC in the
cluster binds a right to `system:masters`, the claim grants it. The guard must run
before the SAR is submitted, and the authenticate handler is unambiguously before it.

`withImpersonateRequest` was rejected as the location for a second reason: it has three
exits before group assembly (`NoImpersonation`, `DisableImpersonation`, the `!ok` name
check), so a guard placed after them is correct today and one refactor away from being
bypassable.

`TestReservedIdentityRejectedBeforeSubjectAccessReview` pins this: a request carrying
both a `system:masters` group claim and `Impersonate-User` headers must 403 **and** the
fake reviewer must record **zero** reviews.

## The username/group asymmetry

| Field | Rule |
| --- | --- |
| Username | Every `system:`-prefixed value is refused — **no exceptions**, including `system:authenticated`. |
| Groups | `system:authenticated` is permitted; any other `system:` value is refused. |

The group exception exists for exactly one reason: `withImpersonateRequest` appends
`AllAuthenticated` to every request itself, so an IdP that also emits it would otherwise
403 every request in the cluster. It must not leak to the username, because a reserved
username can receive privileges through a user-specific RBAC binding
(`kind: User, name: system:authenticated`). The table test covers that row explicitly.

Identities are **refused, not stripped**: a caller quietly served without the group they
claimed has been told the wrong thing about who they are, and the resulting RBAC denial
then looks like a policy bug.

SAR-authorized `Impersonate-*` targets are deliberately left alone — an operator who
bound RBAC permitting impersonation of `system:masters` made that call on purpose, and
blocking it would break break-glass access. The token-side guard is what makes that
grant trustworthy.

## The opt-out

`--allow-reserved-identity-claims` (default `false`) restores the previous behaviour.
Its help text states plainly what enabling it permits. The proxy additionally refuses to
start when `--oidc-username-prefix` or `--oidc-groups-prefix` itself begins with
`system:` unless the opt-out is set — single-issuer path only, since those flags are
ignored when `--authentication-config` is in use.

This is defense in depth. `userValidationRules` and `--oidc-groups-prefix` remain the
operator-side mitigations and are unchanged.

## Commits

1. **`feat(audit): audit authenticated requests the proxy forbids`** — adds
   `audit.NewForbiddenHandler`, which audits through the ordinary request chain
   (`WithRequestInfo → WithAuditInit → WithAudit`) rather than
   `WithFailedAuthenticationAudit`. The latter presets the response-status message to the
   attempted auth methods, so the record reads as an authentication failure, and it
   evaluates the audit policy against the identity in the context. A separate handler is
   needed because `withHandlers` applies the auditor first, leaving it innermost: a
   rejection in the authenticate handler is outside the audit filter entirely. Renames
   `unauthenticatedHandler` → `funcHandler` (behaviour unchanged).
2. **`fix(security): refuse reserved system: identities from token claims`** — the guard,
   the flag, the startup check, tests and docs.
3. **`fix(logging): log OIDC validation failures at V(2)`** — an error from the
   bearer-token authenticator always means a token was present and failed validation, so
   it was invisible at any verbosity operators run. Now `V(2)` with the resolved remote
   address. **Routing is unchanged**: falling through to token passthrough is documented
   alpha behaviour.

## Audit semantics

A rejected request emits an ordinary audit event naming the real username and groups,
with `responseStatus.code: 403` — not an "authentication failed, unknown user" record
about a request where authentication *succeeded*. `pkg/proxy/audit/handler_test.go`
asserts this against a real file-backed audit backend and a `level: Metadata` policy.

## Testing

- `pkg/proxy/handlers_test.go`: the `checkReservedIdentity` table (including the
  `system:authenticated` **username** row and the `systemd:ops` / `system-admin`
  lookalikes), plus three handler-level tests — rejection, opt-out passthrough, and the
  zero-SAR ordering property.
- `pkg/proxy/audit/handler_test.go`: the forbidden handler emits one `ResponseComplete`
  event carrying `user.username`, `responseStatus.code == 403`, and no
  authentication-failure message; plus a nil-auditor case.
- `cmd/app/run_test.go`: the startup prefix check, including that it does not fire in
  multi-issuer mode.
- `go build ./... && go vet ./... && go test ./pkg/... ./cmd/...` all pass.
  `golangci-lint` reports 0 issues in the changed packages.

## Out of scope

Auditing SAR-denied `403`s from `withImpersonateRequest` (the same mechanism would close
it) is deliberately not included here; it changes audit volume and semantics for an
existing code path and belongs in its own change.
