### PR TITLE
ci: fix the release PR

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # push release/next and let release-drafter stage a draft
+      issues: read # read-only: confirm the autorelease label exists, never create it
       pull-requests: write # open/update the release PR
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -30,6 +31,15 @@ jobs:
           test -n "${VERSION}" || { echo "::error::release-drafter produced no version"; exit 1; }
           mapfile -d '' fragments < <(find .changes/unreleased -maxdepth 1 -name '*.yaml' -print0 | sort -z)
           test "${#fragments[@]}" -gt 0 || { echo "::notice::No releasable fragments"; exit 0; }
+          # gh resolves label names before it creates a pull request, so a missing
+          # label aborts the create with release/next already force-pushed.
+          if ! label=$(gh api "repos/${GITHUB_REPOSITORY}/labels/autorelease%3A%20pending" 2>&1); then
+            case "${label}" in
+              *"Not Found"*) echo "::error::repository lacks the 'autorelease: pending' label; see the repository setup section of docs/releases.md" ;;
+              *) echo "::error::could not verify the 'autorelease: pending' label: ${label}" ;;
+            esac
+            exit 1
+          fi
           notes=$(for file in "${fragments[@]}"; do yq -r '"- " + .body' "${file}"; done)
           grep -q '<!-- next-release -->' CHANGELOG.md || { echo "::error::missing changelog marker"; exit 1; }
           { sed -n '1,/<!-- next-release -->/p' CHANGELOG.md; printf '\n## [%s] - %s\n\n%s\n' "${VERSION#v}" "$(date -u +%F)" "${notes}"; sed -n '/<!-- next-release -->/,$p' CHANGELOG.md | tail -n +2; } > CHANGELOG.md.new
@@ -38,5 +48,12 @@ jobs:
           git config user.name github-actions[bot]; git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git add CHANGELOG.md .changes; git commit -m "chore: release ${VERSION}"; git push --force origin release/next
           printf '%s\n' "${RELEASE_BODY}" > release-pr-body.md
-          gh pr create --base main --head release/next --title "chore: release ${VERSION}" --label "autorelease: pending" --body-file release-pr-body.md 2>/dev/null ||
-            gh pr edit release/next --title "chore: release ${VERSION}" --add-label "autorelease: pending" --body-file release-pr-body.md
+          # Branch on whether the release PR exists rather than falling back from a
+          # failed create: `create || edit` discards the create's error and reports
+          # whatever the edit then trips on instead.
+          existing=$(gh pr list --head release/next --base main --state open --json number --jq '.[0].number // ""')
+          if [ -n "${existing}" ]; then
+            gh pr edit "${existing}" --title "chore: release ${VERSION}" --add-label "autorelease: pending" --body-file release-pr-body.md
+          else
+            gh pr create --base main --head release/next --title "chore: release ${VERSION}" --label "autorelease: pending" --body-file release-pr-body.md
+          fi

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -56,5 +56,39 @@ The workflow verifies that tag belongs to `main`, reruns checks and E2E, and
 resumes publication. It refuses to move a tag or overwrite an already published
 release.
 
+## Repository setup
+
+Prepare Release depends on repository state that is not in this repository.
+Both of the following must be in place or the workflow pushes `release/next`
+and then fails without opening a PR.
+
+Create the four `release/*` labels and `autorelease: pending`:
+
+```sh
+for label in release/major release/minor release/patch release/skip; do
+  gh label create "$label" --force
+done
+gh label create 'autorelease: pending' --color ededed \
+  --description 'Generated release PR awaiting maintainer approval' --force
+```
+
+Prepare Release refuses to run without `autorelease: pending`, because a
+release PR that does not carry it can never be published by **Release**.
+
+Allow Actions to open the release pull request. Without this, `GITHUB_TOKEN`
+may push a branch but not open a PR, and `gh pr create` fails:
+
+```sh
+gh api --method PUT "repos/${OWNER}/${REPO}/actions/permissions/workflow" \
+  -f default_workflow_permissions=read -F can_approve_pull_request_reviews=true
+```
+
+Keep `default_workflow_permissions` at `read`: every workflow here declares its
+own `permissions:` block. The same flag also permits Actions to approve pull
+requests, so protecting `main` is what keeps a release PR from being approved
+by automation.
+
+## Maintainer checks
+
 Keep actions and Kind pinned, protect `main`, require **PR Release Metadata**,
 and run `sh scripts/release-contract-check.sh` for release automation changes.

--- a/scripts/release-contract-check.sh
+++ b/scripts/release-contract-check.sh
@@ -14,6 +14,7 @@ grep -q '^  workflow_dispatch:' .github/workflows/prepare-release.yml || fail "P
 grep -q 'group: prepare-release' .github/workflows/prepare-release.yml || fail "Prepare Release must be serialized"
 grep -q 'release/next' .github/workflows/prepare-release.yml || fail "Prepare Release must own release/next"
 grep -q 'autorelease: pending' .github/workflows/prepare-release.yml || fail "release PR must carry autorelease: pending"
+grep -q 'labels/autorelease%3A%20pending' .github/workflows/prepare-release.yml || fail "Prepare Release must confirm the automation label exists before it pushes"
 grep -q "head.ref == 'release/next'" .github/workflows/release.yaml || fail "Release must only accept release/next"
 grep -q "contains(github.event.pull_request.labels.*.name, 'autorelease: pending')" .github/workflows/release.yaml || fail "Release must require the automation label"
 grep -q '^  group: release' .github/workflows/release.yaml || fail "Release must be serialized"


### PR DESCRIPTION
## What went wrong

The [Prepare Release run](https://github.com/RafPe/kube-oidc-proxy/actions/runs/32226832767)
failed with `no pull requests found for branch "release/next"` after it had
already pushed `release/next`. That message describes the fallback, not the
failure. `gh pr create` failed first, its stderr went to `/dev/null`, and the
`||` fallback then ran `gh pr edit` against a PR that had never been created.

Two independent blockers were sitting behind that single masked command:

- the repository had no `autorelease: pending` label, and `gh` resolves label
  names before it creates a PR, so the create aborted outright;
- `can_approve_pull_request_reviews` was `false`, so `GITHUB_TOKEN` could push
  a branch under `contents: write` but not open a pull request.

Both are repository state rather than code. The same pair broke
`pod-certificate-signer`; the fix there is
[RafPe/pod-certificate-signer#121](https://github.com/RafPe/pod-certificate-signer/pull/121).

## Changes

**Branch on whether the release PR exists, instead of falling back from a
failed create.** The fallback had a legitimate job — re-running Prepare Release
has to update an open release PR rather than fail — but as written it discarded
the create's error and reported whatever the edit tripped on. An explicit
`gh pr list` check keeps the idempotency and lets a real create failure speak
for itself. No stderr redirection anywhere in the step.

**Confirm the label exists before `release/next` is pushed.** A missing label
otherwise aborts the create with the branch already force-pushed. The check
distinguishes a missing label from an API call that failed for another reason,
rather than asserting a diagnosis it has not made — the same mistake as the
masking it replaces. Reading labels needs the issues scope, so the job gains
`issues: read`; read-only, so it can report the label missing but not create
it. The workflow-level `permissions: {}` is unchanged.

**Document both setup steps.** `docs/releases.md` gains a `## Repository setup`
section. Neither step was written down: the `release/*` labels and
`autorelease: pending` were assumed to exist, and the Actions pull-request
permission was not mentioned anywhere. The existing trailing maintainer
sentence moves under `## Maintainer checks` unchanged.

`release-contract-check.sh` asserts the preflight is present. It is grep-only
and offline — which is why it passed while the repository lacked the label — so
it cannot check GitHub state, but it can check that the workflow does.

## Verification

`sh scripts/release-contract-check.sh` passes, the workflow YAML parses, the
job `permissions` block resolves to `contents: write` / `issues: read` /
`pull-requests: write`, and the extracted `run:` script passes `bash -n`.

The hardened path is unexecuted. Re-dispatching Prepare Release would
force-push `release/next` underneath the open release PR, so this is verified
by the next release cycle rather than now.
