### PR TITLE
chore: release v1.3.0

### DIFF
--- a/demo/cleanup.sh
+++ b/demo/cleanup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright Jetstack Ltd. See LICENSE for details.
 #
 # Tear down the demo: delete the kind cluster and remove generated artifacts.
 set -euo pipefail

--- a/demo/run.sh
+++ b/demo/run.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Copyright Jetstack Ltd. See LICENSE for details.
 #
 # One-command, self-contained, multi-issuer demo for kube-oidc-proxy.
 #

--- a/pkg/probe/probe.go
+++ b/pkg/probe/probe.go
@@ -21,6 +21,10 @@ import (
 )
 
 const (
+	// readHeaderTimeout bounds how long a client may take to send request
+	// headers to the readiness listener.
+	readHeaderTimeout = 5 * time.Second
+
 	timeout = time.Second * 10
 
 	// shutdownTimeout bounds the graceful shutdown of the readiness server so a
@@ -102,6 +106,12 @@ func NewServer(port string, issuers []IssuerReadiness, requireAll bool, oidcAuth
 		srv: &http.Server{
 			Addr:    net.JoinHostPort("0.0.0.0", port),
 			Handler: h.handler(),
+
+			// Bound how long a client may take to send its headers. The
+			// readiness endpoint is reachable by anything that can dial the
+			// probe port, so an unbounded header read lets idle connections
+			// accumulate (gosec G112, Slowloris).
+			ReadHeaderTimeout: readHeaderTimeout,
 		},
 		served: make(chan struct{}),
 	}


### PR DESCRIPTION
Re-runs the v1.3.0 release. The previous attempt merged, but its `check` job failed, so `tag`, `publish-artifacts` and `publish-release` were all skipped: there is no `v1.3.0` tag, no published image, and the GitHub release is still a draft — while `main` already carries the release commit, the `## [1.3.0]` changelog entry and an emptied `.changes/unreleased`.

Nothing in the merged v1.3.0 content was at fault. The release `check` job runs `make verify test`, and that gate arrived after v1.2.0, so this is the first release to run it. It found two long-standing failures, neither reachable from pull request CI:

- `demo/run.sh` and `demo/cleanup.sh` have been missing the licence boilerplate since the Helm chart rework. `hack/verify-boilerplate.sh` is not part of the pull request checks at all.
- The readiness `http.Server` has no `ReadHeaderTimeout` (gosec G112). The lint job runs with `only-new-issues`, so a pre-existing finding on an unmodified line never fails a pull request.

Both are fixed here rather than suppressed. `make verify` now exits 0 and `go test ./pkg/probe/...` passes.

No changelog fragment is added: the release workflow's `verify` job fails if any file remains in `.changes/unreleased`, and these are release-plumbing fixes rather than user-facing changes.

Merging this tags `v1.3.0` at the merge commit, publishes the image, and flips the draft release to published.