### PR TITLE
chore: release v1.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,6 @@ generate: depend ## generates mocks and assets files
 test: generate verify ## run all go tests
 	mkdir -p $(ARTIFACTS)
 	go test -v -bench $$(go list ./pkg/... ./cmd/... ./test/tools/... | grep -v pkg/e2e) | tee $(ARTIFACTS)/go-test.stdout
-	cat $(ARTIFACTS)/go-test.stdout | go run github.com/jstemmer/go-junit-report > $(ARTIFACTS)/junit-go-test.xml
 
 # Name of the kind cluster the e2e suite creates (must match the const in
 # test/kind/kind.go). Used by e2e-clean for the failure/interrupt safety net.


### PR DESCRIPTION
Third attempt at the v1.3.0 release. The previous two merged but failed the `check` job, so `tag`, `publish-artifacts` and `publish-release` were skipped each time: there is still no `v1.3.0` tag, no published image, and the GitHub release is still a draft, while `main` carries the release commit and the `## [1.3.0]` changelog entry.

None of the three failures came from the released content. The `check` job runs `make verify test`, a gate added after v1.2.0, so v1.3.0 is the first release to run it — and it has surfaced three long-standing breakages in the release path, one per attempt:

1. `demo/run.sh` and `demo/cleanup.sh` missing the licence boilerplate (fixed in the previous attempt).
2. gosec G112 on the readiness `http.Server` (fixed in the previous attempt).
3. This one: `make test` pipes into `github.com/jstemmer/go-junit-report`, which is no longer a module dependency, so the target fails *after* every test passes.

None are reachable from pull request CI: boilerplate is not run there, lint uses `only-new-issues`, and the test job runs `go test` directly rather than through `make`.

Verified differently this time. Rather than checking the individual step that failed, both commands the `check` job runs were executed locally against a tree identical to this one:

- `make verify test` — exit 0
- `sh scripts/release-contract-check.sh` — ok

The Makefile was also audited for other `go run` invocations of non-dependencies; this was the only one, and `release-contract-check.sh` shells out to nothing but `grep`.

Merging this tags `v1.3.0` at the merge commit, publishes the image, and flips the draft release to published.