### PR TITLE
ci: give every workflow job a colon-namespaced display name

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   image:
+    name: "build:image"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   analyze:
-    name: analyze (go)
+    name: "scan:codeql"
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/e2e-oidc-gha.yaml
+++ b/.github/workflows/e2e-oidc-gha.yaml
@@ -28,6 +28,7 @@ env:
 
 jobs:
   gha-multi-issuer:
+    name: "test:e2e-oidc"
     # OIDC tokens (id-token: write) are not issued to pull requests from forks,
     # so skip fork PRs; runs on push to main, workflow_dispatch, and same-repo PRs.
     if: >-

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -34,7 +34,7 @@ jobs:
     # the UI (e.g. "e2e (impersonation, headers, probe)") instead of a bare
     # letter. Keep `cases` in sync with the Ginkgo shard-<x> labels on the
     # matching framework.CasesDescribe containers.
-    name: e2e (${{ matrix.cases }})
+    name: "test:e2e (${{ matrix.cases }})"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -96,6 +96,7 @@ jobs:
   # that single required check stable while the work happens in the matrix above.
   # It is green only when every shard succeeded.
   e2e-kind:
+    name: "test:e2e"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [e2e-shard]

--- a/.github/workflows/fuzz.yaml
+++ b/.github/workflows/fuzz.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   fuzz:
-    name: fuzz (${{ matrix.target }})
+    name: "test:fuzz (${{ matrix.target }})"
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -23,6 +23,7 @@ concurrency:
 
 jobs:
   lint-and-template:
+    name: "test:chart"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/oidc.yaml
+++ b/.github/workflows/oidc.yaml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 jobs:
   mint:
+    name: "ops:oidc-mint"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/.github/workflows/pr-release-metadata.yml
+++ b/.github/workflows/pr-release-metadata.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   release-label:
+    name: "meta:release-label"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -10,6 +10,7 @@ concurrency:
 
 jobs:
   prepare:
+    name: "release:prepare"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   verify:
+    name: "release:verify"
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true &&
@@ -53,6 +54,7 @@ jobs:
           echo "tag=${tag}" >> "${GITHUB_OUTPUT}"; echo "sha=${sha}" >> "${GITHUB_OUTPUT}"
 
   check:
+    name: "release:check"
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -67,6 +69,7 @@ jobs:
       - run: sh scripts/release-contract-check.sh
 
   e2e:
+    name: "release:e2e"
     needs: verify
     permissions:
       contents: read
@@ -75,6 +78,7 @@ jobs:
       target_ref: ${{ needs.verify.outputs.sha }}
 
   tag:
+    name: "release:tag"
     needs: [verify, check, e2e]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -93,12 +97,14 @@ jobs:
           fi
 
   publish-artifacts:
+    name: "release:artifact"
     needs: [verify, tag]
     permissions: { contents: read, packages: write, id-token: write }
     uses: ./.github/workflows/release-image.yaml
     with: { tag: "${{ needs.verify.outputs.tag }}" }
 
   publish-release:
+    name: "release:publish"
     needs: [verify, publish-artifacts]
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,7 +17,7 @@ permissions: read-all
 
 jobs:
   analysis:
-    name: Scorecard analysis
+    name: "scan:posture"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   govulncheck:
-    name: govulncheck
+    name: "scan:vuln"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   test:
+    name: "test:unit"
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -58,6 +59,7 @@ jobs:
         run: make verify-e2e-shards
 
   lint:
+    name: "lint:go"
     # golangci-lint carries pre-existing findings across the repo that are being
     # retired incrementally, so gate on issues introduced by the PR. This makes
     # the linter enforce cleanliness going forward without blocking on legacy


### PR DESCRIPTION
## Unblocks main

The required status checks on `main` were switched to the new names ahead of this PR, so `main` currently advertises six contexts (`test:unit`, `lint:go`, `scan:vuln`, `scan:codeql`, `test:e2e`, `test:e2e-oidc`) that its own workflows do not produce. **Every PR is blocked until this merges.**

This PR is self-satisfying: `pull_request` workflows run from the PR's own files, so its checks report under exactly the six required names. Verified programmatically before pushing — all six are produced by a `pull_request`-triggered job.

## Why

Third and last repo in the naming standardization, after steampipe-plugin-youtrack (#45) and pod-certificate-signer (#123). One required-check template now covers all three.

## Mapping — job IDs unchanged, `name:` only

| Workflow | Job id | New display name |
|---|---|---|
| `test.yaml` | `test` / `lint` | `test:unit` / `lint:go` |
| `security.yaml` | `govulncheck` | `scan:vuln` |
| `codeql.yml` | `analyze` | `scan:codeql` *(was `analyze (go)`)* |
| `scorecard.yml` | `analysis` | `scan:posture` |
| `e2e.yaml` | `e2e-shard` | `test:e2e (${{ matrix.cases }})` |
| `e2e.yaml` | `e2e-kind` | **`test:e2e`** ← the required aggregator |
| `e2e-oidc-gha.yaml` | `gha-multi-issuer` | `test:e2e-oidc` |
| `fuzz.yaml` | `fuzz` | `test:fuzz (${{ matrix.target }})` |
| `helm.yaml` | `lint-and-template` | `test:chart` |
| `build.yaml` | `image` | `build:image` |
| `oidc.yaml` | `mint` | `ops:oidc-mint` |
| `pr-release-metadata.yml` | `release-label` | `meta:release-label` |
| `prepare-release.yml` | `prepare` | `release:prepare` |
| `release.yaml` | `verify`/`check`/`e2e`/`tag`/`publish-artifacts`/`publish-release` | `release:verify`/`:check`/`:e2e`/`:tag`/`:artifact`/`:publish` |

`release-image.yaml`'s `image`/`chart` keep their short names so the composites read `release:artifact / image`.

## Composition rules

- **Matrix** → `name (value)`: shards report as `test:e2e (impersonation, headers, probe)` etc. The `e2e-kind` aggregator takes the bare `test:e2e`, keeping one stable required check over a 3-way matrix.
- **Reusable caller** → `caller / callee`: release gates read `release:e2e / test:e2e` and `release:artifact / image`. These only run on merge, so they never gate a PR.

## Verification

- YAML parses for all 13 workflows; `actionlint` — 0 findings.
- `sh scripts/release-contract-check.sh` — ok.
- Programmatic check that all six required contexts are produced by a `pull_request`-triggered job — all six OK.

## After merging

`enforce_admins` is currently `false` on `main` (it was disabled to work around the block). It should be set back to `true`:

```sh
gh api -X POST repos/RafPe/kube-oidc-proxy/branches/main/protection/enforce_admins
```

Any other open PR will need a rebase onto this commit before its checks report under the new names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)