### PR TITLE
ci: run the e2e suite twice daily instead of on every merge to main

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,9 +6,26 @@ name: e2e
 # installed only for the failure/interrupt cleanup net (`make e2e-clean`).
 on:
   pull_request:
-  push:
-    branches:
-      - main
+  # Deliberately NOT `push: {branches: [main]}`. A pull_request run already
+  # tests the merge commit, and release.yaml re-runs this suite at the
+  # resolved release SHA before tagging -- so a post-merge run was a third
+  # execution of the same code. For a release it ran on the release/next
+  # pull request, again on the merge to main, and again inside Release.
+  # Across the last 200 workflow runs those post-merge runs caught nothing:
+  # 10 runs, 0 failures. The twice-daily schedule below keeps drift
+  # detection, since nothing else exercises main on a cadence -- and unlike
+  # the per-merge run its cost is fixed rather than scaling with merges.
+  # The three shards together ARE the whole suite (shard-a/b/c partition
+  # it; an empty GINKGO_LABEL_FILTER selects everything), so this schedule
+  # runs full e2e coverage, not a subset.
+  #
+  # e2e-oidc-gha.yaml keeps its push trigger on purpose: it mints a real
+  # GitHub Actions OIDC token, whose sub/ref/workflow_ref claims genuinely
+  # differ between push and pull_request, and it has diverged in practice
+  # (run 32383082551 failed on main having passed on the pull request).
+  schedule:
+    - cron: "0 6 * * *" # 06:00 UTC
+    - cron: "0 18 * * *" # 18:00 UTC
   workflow_call:
     inputs:
       target_ref:
@@ -30,9 +47,9 @@ jobs:
   # cases. hack/verify-e2e-shards.sh (run in test.yaml) keeps a new case from
   # landing without a label and silently running in no shard at all.
   e2e-shard:
-    # The display name lists the cases in each shard so the check is readable in
-    # the UI (e.g. "e2e (impersonation, headers, probe)") instead of a bare
-    # letter. Keep `cases` in sync with the Ginkgo shard-<x> labels on the
+    # The display name lists the cases in each shard so the check is readable
+    # in the UI (e.g. "test:e2e (impersonation, headers, probe)") instead of a
+    # bare letter. Keep `cases` in sync with the Ginkgo shard-<x> labels on the
     # matching framework.CasesDescribe containers.
     name: "test:e2e (${{ matrix.cases }})"
     runs-on: ubuntu-latest
@@ -91,10 +108,13 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Branch protection requires a check literally named "e2e-kind". The job id
-  # is the check name (no `name:` key here on purpose), so this aggregator keeps
-  # that single required check stable while the work happens in the matrix above.
-  # It is green only when every shard succeeded.
+  # Branch protection requires a check literally named "test:e2e", which is
+  # this job's display `name:` below -- NOT its job id, which GitHub ignores
+  # for status checks. This aggregator exists to keep that single required
+  # check stable while the work happens in the matrix above, whose own checks
+  # carry the shard suffix ("test:e2e (impersonation, headers, probe)") and so
+  # can never satisfy the requirement. It is green only when every shard
+  # succeeded.
   e2e-kind:
     name: "test:e2e"
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

For a release, this suite ran **three times over the same code**:

1. on the `release/next` pull request
2. again on the push to `main` when it merged
3. again inside `release.yaml`, which re-runs it at the resolved release SHA before tagging

Steps 2 and 3 are the same commit. The suite carries `timeout-minutes: 45` and runs as a 3-way kind matrix, so this is the most expensive duplication in the repo.

## The data

Across the last 200 workflow runs:

| Workflow | PR runs | push-to-main runs | failures on main |
|---|---|---|---|
| `e2e` | 17 (1 real catch) | 10 | **0 — never caught anything** |
| `e2e-oidc-gha` | 17 | 11 | **1** |

A `pull_request` run already tests the merge commit, so post-merge only adds value when `main` advanced between PR CI and the merge. In this repo, over that window, it never did.

## What changed

`push: {branches: [main]}` → a schedule at **06:00 and 18:00 UTC**.

Replacing rather than dropping: nothing else exercises `main` on a cadence, and drift against a moving kind/Kubernetes surface is exactly what a periodic run catches. A twelve-hour interval keeps a regression attributable to a small window of merges, while the cost stops scaling with merge volume.

**This is full coverage, not a subset.** `shard-a/b/c` partition the suite and an empty `GINKGO_LABEL_FILTER` selects everything, so the three shards together are the whole suite. Unlike `pod-certificate-signer`, this repo has no reduced-vs-nightly split — there is no extra tier to enable.

## What deliberately did NOT change

**`e2e-oidc-gha.yaml` keeps its push trigger.** It mints a real GitHub Actions OIDC token, whose `sub`/`ref`/`workflow_ref` claims genuinely differ between `push` and `pull_request` — so the two events test materially different tokens. It has diverged in practice: run [32383082551](https://github.com/RafPe/kube-oidc-proxy/actions/runs/32383082551) failed on `main` having passed on the PR head. That one earns its post-merge slot.

## Drive-by: two comments the rename falsified

The aggregator's comment still claimed branch protection required a check named `e2e-kind` and that the job carried no `name:` key "on purpose" — both untrue since the required check became `test:e2e`. The shard comment still showed a pre-rename example name. Corrected both; no behavior change.

## Safety

- `pull_request` trigger unchanged, so the required **`test:e2e`** check still reports on every PR — no required-context wedge risk.
- Only job condition in the file is `if: always()` on the aggregator; no job assumes a particular event.
- Checkout uses `ref: ${{ inputs.target_ref || github.sha }}`, so a scheduled run correctly tests main's tip.
- `actionlint` — 0 findings; `sh scripts/release-contract-check.sh` — ok.

### Note on the chosen times

`0 6` and `0 18` are on the hour, which GitHub documents as its highest-load scheduling window — queued runs there are the most likely to start late. Harmless for a drift-detection run, but if punctuality ever matters, shifting a few minutes off the hour (e.g. `7 6` / `7 18`) avoids it. `0 6 * * *` also coincides with `security.yaml`'s `0 6 * * 1` every Monday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)