### PR TITLE
chore: move e2e and tooling pins to Kubernetes 1.37

### DIFF
--- a/.changes/unreleased/20260828-e2e-kubernetes-1-37.yaml
+++ b/.changes/unreleased/20260828-e2e-kubernetes-1-37.yaml
@@ -1,0 +1,2 @@
+kind: Changed
+body: Test and CI tooling now targets Kubernetes 1.37 — the e2e suite boots kindest/node v1.37.0 by default, the kind CLI in the e2e workflows moves to v0.33.0 (kubeadm v1beta4 support, required since 1.37 dropped v1beta3), and the Makefile kubectl download fallback moves to v1.37.0.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -38,7 +38,7 @@ body:
     id: k8s
     attributes:
       label: Kubernetes version & provider
-      placeholder: "EKS 1.30 / kind 0.23 / ..."
+      placeholder: "EKS 1.33 / kind 0.33 / ..."
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/e2e-oidc-gha.yaml
+++ b/.github/workflows/e2e-oidc-gha.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install kind CLI
         env:
-          KIND_VERSION: v0.31.0
+          KIND_VERSION: v0.33.0
         run: |
           curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           sudo install -m 0755 ./kind /usr/local/bin/kind

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Install kind CLI
         env:
-          KIND_VERSION: v0.31.0
+          KIND_VERSION: v0.33.0
         run: |
           curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           sudo install -m 0755 ./kind /usr/local/bin/kind

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ help:  ## display this help
 GOLANGCILINT_VERSION := v2.12.2
 # kubectl version used only as a download fallback when no system kubectl is on
 # PATH (the e2e suite prefers the host's kubectl, see the $(BINDIR)/kubectl rule).
-KUBECTL_VERSION ?= v1.31.4
+KUBECTL_VERSION ?= v1.37.0
 KUBECTL_OS   := $(shell go env GOOS)
 KUBECTL_ARCH := $(shell go env GOARCH)
 

--- a/test/environment/environment.go
+++ b/test/environment/environment.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultNodeImage = "1.35.1"
+	defaultNodeImage = "1.37.0"
 	defaultRootPath  = "../../."
 )
 


### PR DESCRIPTION
## What

Catches the test/CI tooling up to Kubernetes 1.37 — the `k8s.io/*` modules were already bumped to v0.37.0 in #109, but the e2e stack was still running 1.35.

- **Default kind node image** `1.35.1` → `1.37.0` (`test/environment/environment.go`) — this is the knob that decides which Kubernetes the e2e suite actually boots; still overridable via `KUBE_OIDC_PROXY_K8S_VERSION`.
- **kind CLI** in `e2e.yaml` and `e2e-oidc-gha.yaml`: `v0.31.0` → `v0.33.0`, in lockstep with the `sigs.k8s.io/kind` library in go.mod. Kubernetes 1.37 dropped the kubeadm v1beta3 config format and kind only generates v1beta4 from v0.32.0, so a v0.31 CLI cannot create 1.37 clusters (in CI it is only the `e2e-clean` safety net, but local devs follow the same recipe).
- **kubectl download fallback** in the Makefile: `v1.31.4` → `v1.37.0` (v1.31 is outside the ±1 minor skew policy against a 1.37 apiserver).
- Refreshed the stale environment placeholder in the bug-report template.

## Verification

- `go build ./...` and the full unit suite pass against v0.37.0.
- The three e2e shards on this PR are the real gate — they now stand up `kindest/node:v1.37.0` clusters.