### PR TITLE
fix(audit): emit audit events for unauthenticated (401) requests

### DIFF
--- a/.changes/unreleased/20260828-audit-unauthenticated-401.yaml
+++ b/.changes/unreleased/20260828-audit-unauthenticated-401.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Unauthenticated (401) requests now produce audit events — the unauthorized audit chain initialises the audit context, so failed authentication attempts are recorded with a ResponseStarted event instead of leaving no trace in the audit log.

--- a/pkg/proxy/audit/audit.go
+++ b/pkg/proxy/audit/audit.go
@@ -104,8 +104,12 @@ func (a *Audit) WithRequest(handler http.Handler) http.Handler {
 
 // WithUnauthorized will wrap the given handler to inject the request
 // information into the context which is then used by the wrapped audit
-// handler.
+// handler. WithAuditInit mirrors WithRequest above: without it there is no
+// AuditContext on the request, the failed-authentication filter finds
+// auditing disabled, and a 401 leaves no audit event at all
+// (TremoloSecurity/kube-oidc-proxy#92).
 func (a *Audit) WithUnauthorized(handler http.Handler) http.Handler {
 	handler = genericapifilters.WithFailedAuthenticationAudit(handler, a.serverConfig.AuditBackend, a.serverConfig.AuditPolicyRuleEvaluator)
+	handler = genericapifilters.WithAuditInit(handler)
 	return genericapifilters.WithRequestInfo(handler, a.serverConfig.RequestInfoResolver)
 }

--- a/pkg/proxy/audit/handler_test.go
+++ b/pkg/proxy/audit/handler_test.go
@@ -193,3 +193,54 @@ func TestNewForbiddenHandlerWithoutAuditor(t *testing.T) {
 		t.Errorf("unexpected response body, exp=forbidden got=%q", got)
 	}
 }
+
+// TestNewUnauthenticatedHandlerAuditsFailedAuthentication is the regression
+// guard for the missing WithAuditInit in the WithUnauthorized chain
+// (TremoloSecurity/kube-oidc-proxy#92). Without an initialised audit context
+// the failed-authentication filter finds auditing disabled and a rejected
+// request leaves no trace in the audit log at all — the exact case an audit
+// log exists for.
+//
+// Assertions are confined to what this chain decides: that exactly one event
+// is written, at ResponseStarted (the stage the failed-auth filter's decorated
+// response writer records on WriteHeader), carrying the 401 and the
+// authentication-failure message, with no authenticated identity. Verb and
+// objectRef are the RequestInfo resolver's decision and are covered elsewhere.
+func TestNewUnauthenticatedHandlerAuditsFailedAuthentication(t *testing.T) {
+	a, logPath := newForbiddenTestAudit(t)
+
+	handler := NewUnauthenticatedHandler(a, func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusUnauthorized)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/namespaces/kube-system/pods", nil)
+	req.Header.Set("Authorization", "bearer some-invalid-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status %d, got %d", http.StatusUnauthorized, rec.Code)
+	}
+
+	events := readForbiddenAuditEvents(t, a, logPath)
+	if len(events) != 1 {
+		t.Fatalf("expected exactly one audit event for a failed authentication, got %d: %+v", len(events), events)
+	}
+
+	event := events[0]
+	if event.Stage != "ResponseStarted" {
+		t.Errorf("expected stage ResponseStarted, got %q", event.Stage)
+	}
+	if event.User.Username != "" {
+		t.Errorf("failed authentication must not record an identity, got %q", event.User.Username)
+	}
+	if event.ResponseStatus == nil {
+		t.Fatalf("expected a responseStatus on the event, got none")
+	}
+	if event.ResponseStatus.Code != http.StatusUnauthorized {
+		t.Errorf("expected responseStatus code 401, got %d", event.ResponseStatus.Code)
+	}
+	if !strings.Contains(event.ResponseStatus.Message, "Authentication failed, attempted: bearer") {
+		t.Errorf("expected the authentication-failure message naming the attempted method, got %q", event.ResponseStatus.Message)
+	}
+}

--- a/test/e2e/suite/cases/audit/audit.go
+++ b/test/e2e/suite/cases/audit/audit.go
@@ -574,17 +574,26 @@ func testAuditLogs(f *framework.Framework, podLabelSelector, containerName, logP
 			},
 		},
 
-		// From what I could tell, this could never had succeeded - even pre-fork
-		// auditv1.Event{
-		// 	Level:      auditv1.LevelRequestResponse,
-		// 	Stage:      auditv1.StageResponseStarted,
-		// 	RequestURI: "/api/v1/namespaces/kube-system/pods",
-		// 	Verb:       "get",
-		// 	ResponseStatus: &metav1.Status{
-		// 		Code:    401,
-		// 		Message: "Authentication failed, attempted: bearer",
-		// 	},
-		// },
+		// The unauthenticated request. The failed-authentication filter
+		// records a single ResponseStarted event: no identity (the request
+		// was rejected before a user reached the context), the 401, and the
+		// attempted authentication method. The verb and objectRef are
+		// resolved because the audit chain classifies core group requests as
+		// resource requests. Restored by the WithAuditInit fix
+		// (TremoloSecurity/kube-oidc-proxy#92) — the previous expectation
+		// here was commented out because, without an initialised audit
+		// context, it could never have passed.
+		{
+			Level:      auditv1.LevelRequestResponse,
+			Stage:      auditv1.StageResponseStarted,
+			RequestURI: "/api/v1/namespaces/kube-system/pods",
+			Verb:       "list",
+			ObjectRef:  expObjectRef,
+			ResponseStatus: &metav1.Status{
+				Code:    401,
+				Message: "Authentication failed, attempted: bearer",
+			},
+		},
 	}
 
 	By("Testing for expected audit logs")


### PR DESCRIPTION
## Problem

`Audit.WithUnauthorized` wrapped the 401 handler in `WithFailedAuthenticationAudit` + `WithRequestInfo` but never `WithAuditInit`. Without an initialised `AuditContext`, `evaluatePolicyAndCreateAuditEvent` returns early, `ac.Enabled()` is false, and the handler runs with auditing disabled — a failed authentication attempt left **no audit event at all**. Failed logins are precisely what an audit log exists to record.

Reported upstream as TremoloSecurity/kube-oidc-proxy#92 (still open there).

## Fix

Insert `genericapifilters.WithAuditInit` into the `WithUnauthorized` chain, mirroring the `WithRequest` chain directly above it. One line of production code.

## Tests

- New unit test `TestNewUnauthenticatedHandlerAuditsFailedAuthentication` asserts exactly one `ResponseStarted` event with the 401, the `Authentication failed, attempted: bearer` message, and no identity (red before the fix: zero events).
- Revived the e2e expectation that was commented out pre-fork with the note "this could never had succeeded — even pre-fork". It could never have passed because of this bug; it now asserts the 401 event through both the log-file and webhook audit backends.

## Notes

- The event's user field is empty by design: the request is rejected before an identity reaches the context. That matches kube-apiserver's own failed-auth audit behaviour.