### PR TITLE
feat(proxy): support UID impersonation end to end

### DIFF
--- a/.changes/unreleased/20260828-impersonate-uid.yaml
+++ b/.changes/unreleased/20260828-impersonate-uid.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: UID impersonation works end to end — an authorized Impersonate-Uid header is forwarded to the API server, the impersonation check reviews uids in the authentication.k8s.io group, and the chart grants the proxy impersonate on uids and on the originaluser.jetstack.io-uid extra. Deployments that map a uid claim now emit Impersonate-Uid and need the new RBAC.

--- a/chart/kube-oidc-proxy/Chart.yaml
+++ b/chart/kube-oidc-proxy/Chart.yaml
@@ -9,7 +9,7 @@ type: application
 # The chart and image share a single version. On a tagged release the
 # automation overrides both `version` and `appVersion` from the git tag
 # (vX.Y.Z); the values here are the development baseline.
-version: 1.1.0
+version: 1.2.0
 appVersion: "1.1.0"
 home: https://github.com/rafpe/kube-oidc-proxy
 sources:

--- a/chart/kube-oidc-proxy/templates/clusterrole.yaml
+++ b/chart/kube-oidc-proxy/templates/clusterrole.yaml
@@ -19,10 +19,14 @@ rules:
   - "userextras/scopes"
   - "userextras/remote-client-ip"
   - "tokenreviews"
+  # UID impersonation lives in authentication.k8s.io, unlike users/groups
+  # which are core
+  - "uids"
   # to support end user impersonation
   - "userextras/authentication.kubernetes.io/credential-id"
   - "userextras/originaluser.jetstack.io-user"
   - "userextras/originaluser.jetstack.io-groups"
+  - "userextras/originaluser.jetstack.io-uid"
   - "userextras/originaluser.jetstack.io-extra"
   verbs:
   - "create"

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -256,6 +256,7 @@ func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
 		conf := &context.ImpersonationRequest{
 			ImpersonationConfig: &transport.ImpersonationConfig{
 				UserName: user.GetName(),
+				UID:      user.GetUID(),
 				Groups:   groups,
 				Extra:    extra,
 			},

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -601,7 +601,6 @@ func TestHandlers(t *testing.T) {
 			expBody: "",
 		},
 
-		/* Commenting due to https://github.com/TremoloSecurity/kube-oidc-proxy/issues/7
 		"an authed request with authorized impersonation uid should succeed": {
 			req: &http.Request{
 				Header: http.Header{
@@ -631,7 +630,7 @@ func TestHandlers(t *testing.T) {
 				"Impersonate-Extra-Originaluser.jetstack.io-Groups": {"group1"},
 			},
 			expBody: "",
-		},*/
+		},
 
 		"an authed request with unauthorized impersonation user should error unauthorized": {
 			req: &http.Request{

--- a/pkg/proxy/subjectaccessreview/fake/subjectaccessreview.go
+++ b/pkg/proxy/subjectaccessreview/fake/subjectaccessreview.go
@@ -44,7 +44,12 @@ func (f *FakeReviewer) Create(ctx context.Context, req *azv1.SubjectAccessReview
 		return req, nil
 	}
 
-	if req.Spec.ResourceAttributes.Resource == "uids" && req.Spec.ResourceAttributes.Name == "1-2-3-4" {
+	// UID impersonation is authorized in the authentication.k8s.io group,
+	// unlike users/groups which are core. Refusing a group-less review here
+	// pins the group the production SAR must send.
+	if req.Spec.ResourceAttributes.Group == "authentication.k8s.io" &&
+		req.Spec.ResourceAttributes.Resource == "uids" &&
+		req.Spec.ResourceAttributes.Name == "1-2-3-4" {
 		req.Status = azv1.SubjectAccessReviewStatus{
 			Allowed: true,
 		}

--- a/pkg/proxy/subjectaccessreview/subjectaccessreview.go
+++ b/pkg/proxy/subjectaccessreview/subjectaccessreview.go
@@ -246,6 +246,13 @@ func (s *SubjectAccessReview) checkRbacImpersonationAuthorization(ctx context.Co
 		group = "authentication.k8s.io"
 	}
 
+	// UID impersonation lives in authentication.k8s.io, unlike
+	// users/groups/serviceaccounts which are core. Without the group the
+	// review checks a core-group "uids" resource no RBAC rule grants.
+	if resource == "uids" {
+		group = "authentication.k8s.io"
+	}
+
 	clusterSubjectAccessReview := v1.SubjectAccessReview{
 		Spec: v1.SubjectAccessReviewSpec{
 			User:   requester.GetName(),

--- a/test/e2e/framework/helper/deploy.go
+++ b/test/e2e/framework/helper/deploy.go
@@ -180,7 +180,7 @@ func (h *Helper) DeployProxyWithExtras(ns *corev1.Namespace, issuerURL *url.URL,
 			},
 			{
 				APIGroups: []string{"authentication.k8s.io"},
-				Resources: []string{"userextras/scopes", "tokenreviews", "userextras/originaluser.jetstack.io-user", "userextras/originaluser.jetstack.io-groups", "userextras/originaluser.jetstack.io-extra", "userextras/oktoimpersonateextra"},
+				Resources: []string{"userextras/scopes", "tokenreviews", "uids", "userextras/originaluser.jetstack.io-user", "userextras/originaluser.jetstack.io-groups", "userextras/originaluser.jetstack.io-uid", "userextras/originaluser.jetstack.io-extra", "userextras/oktoimpersonateextra"},
 				Verbs:     []string{"impersonate", "create"},
 			},
 			{


### PR DESCRIPTION
## Problem

The proxy half-supported UID impersonation: `subjectaccessreview.go` authorized an inbound `Impersonate-Uid` header against the `uids` resource and set the UID on the target user — but the outbound `transport.ImpersonationConfig` never carried it, so client-go never emitted the header. An operator who granted `uids` RBAC got a successful authorization check and a request that reached the API server with the UID silently stripped.

This finishes upstream issue TremoloSecurity/kube-oidc-proxy#7, which deferred UID support pending client-go v0.22.5 (we are on v0.36.0; the `Impersonate-Uid` transport support has existed for years). The test case covering exactly this, disabled in-tree with a pointer to that issue, is re-enabled unchanged.

## Changes

- `pkg/proxy/handlers.go`: populate `ImpersonationConfig.UID` from the resolved user (the impersonation target when `Impersonate-Uid` was sent, else the authenticated user).
- `pkg/proxy/subjectaccessreview`: the inbound authorization check reviewed `uids` in the **core** API group; kube-apiserver defines UID impersonation as `uids` in `authentication.k8s.io`, so a caller holding the correct RBAC was denied by the proxy. The review now carries the group, and the fake reviewer refuses a group-less `uids` review so tests pin it.
- Chart + e2e deployer RBAC: grant `impersonate` on `uids` (authentication.k8s.io) and on `userextras/originaluser.jetstack.io-uid` — the latter closes a pre-existing gap: the proxy has been emitting that extra whenever the original user carries a UID, and no RBAC ever granted it. Chart version 1.1.0 → 1.2.0.

## Behaviour change

Deployments whose authentication config maps a `uid` claim will now emit `Impersonate-Uid` on every request. The chart grants the required RBAC; anyone running hand-rolled RBAC must add `impersonate` on `uids` in `authentication.k8s.io` or those requests will be rejected by the API server.

## Tests

- Re-enabled `an authed request with authorized impersonation uid should succeed` (red before the fix: UID header empty).
- Existing negative case (`unauthorized impersonation uid`) unchanged and green.