### PR TITLE
fix(proxy): trustworthy client IPs in audit events; configurable token-review timeout

### DIFF
--- a/.changes/unreleased/20260828-audit-source-ips-trusted-proxy.yaml
+++ b/.changes/unreleased/20260828-audit-source-ips-trusted-proxy.yaml
@@ -1,0 +1,2 @@
+kind: Security
+body: Audit event sourceIPs now follow the trusted-proxy contract — forwarded headers from untrusted peers are stripped before auditing and before the request is forwarded upstream, so clients can no longer spoof the audit trail via X-Forwarded-For. Operators with a load balancer in front of the proxy must set --trusted-proxies to resolve the real client IP.

--- a/.changes/unreleased/20260828-token-passthrough-request-timeout.yaml
+++ b/.changes/unreleased/20260828-token-passthrough-request-timeout.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: New --token-passthrough-request-timeout flag bounds each TokenReview call the proxy makes when validating a passthrough token (default 10s, previously hardcoded).

--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -30,8 +30,9 @@ type KubeOIDCProxyOptions struct {
 }
 
 type TokenPassthroughOptions struct {
-	Audiences []string
-	Enabled   bool
+	Audiences      []string
+	RequestTimeout time.Duration
+	Enabled        bool
 }
 
 type ExtraHeaderOptions struct {
@@ -106,6 +107,11 @@ func (t *TokenPassthroughOptions) AddFlags(fs *pflag.FlagSet) {
 		"for at least one of the audiences in this list. If no audiences are "+
 		"provided, the audience will default to the audience of the Kubernetes "+
 		"apiserver. Only used when --token-passthrough is also enabled.")
+
+	fs.DurationVar(&t.RequestTimeout, "token-passthrough-request-timeout", 10*time.Second, ""+
+		"Timeout for each TokenReview request the proxy sends to the target API server "+
+		"when validating a passthrough token. Only used when --token-passthrough is "+
+		"also enabled.")
 
 	fs.BoolVar(&t.Enabled, "token-passthrough", t.Enabled, ""+
 		"(Alpha) Requests with Bearer tokens that fail OIDC validation are tried against "+

--- a/cmd/app/options/app.go
+++ b/cmd/app/options/app.go
@@ -80,7 +80,9 @@ func (k *KubeOIDCProxyOptions) AddFlags(fs *pflag.FlagSet) *KubeOIDCProxyOptions
 			"networks. When empty (the default) no proxy is trusted and the direct peer "+
 			"address is always used, so clients cannot spoof their IP via forwarded "+
 			"headers. Set this only to the addresses of proxies you operate in front of "+
-			"kube-oidc-proxy.")
+			"kube-oidc-proxy. Forwarded headers are sanitized to this contract before "+
+			"auditing and before the request is forwarded, so audit sourceIPs and the "+
+			"upstream API server only see validated values.")
 
 	fs.StringSliceVar(&k.AllowedReservedGroups, "allow-reserved-groups", k.AllowedReservedGroups,
 		"Comma-separated list of Kubernetes-reserved ('system:'-prefixed) groups that "+

--- a/cmd/app/options/options.go
+++ b/cmd/app/options/options.go
@@ -108,6 +108,10 @@ func (o *Options) Validate(cmd *cobra.Command) error {
 		errs = append(errs, errors.New("cannot add extra user headers when impersonation disabled"))
 	}
 
+	if o.App.TokenPassthrough.Enabled && o.App.TokenPassthrough.RequestTimeout <= 0 {
+		errs = append(errs, errors.New("--token-passthrough-request-timeout must be greater than zero"))
+	}
+
 	if o.App.SubjectAccessReviewTimeout <= 0 {
 		errs = append(errs, fmt.Errorf("--subject-access-review-timeout must be greater than 0, got %s", o.App.SubjectAccessReviewTimeout))
 	}

--- a/cmd/app/run.go
+++ b/cmd/app/run.go
@@ -130,7 +130,7 @@ func buildRunCommand(stopCh <-chan struct{}, opts *options.Options) *cobra.Comma
 			// Initialise token reviewer if enabled
 			var tokenReviewer *tokenreview.TokenReview
 			if opts.App.TokenPassthrough.Enabled {
-				tokenReviewer, err = tokenreview.New(restConfig, opts.App.TokenPassthrough.Audiences)
+				tokenReviewer, err = tokenreview.New(restConfig, opts.App.TokenPassthrough.Audiences, opts.App.TokenPassthrough.RequestTimeout)
 				if err != nil {
 					return err
 				}

--- a/pkg/proxy/context/context.go
+++ b/pkg/proxy/context/context.go
@@ -12,7 +12,9 @@
 // address is taken as the client. When no trusted proxies are configured (the
 // default), forwarded headers are never trusted and the direct peer is used, so
 // an untrusted client cannot spoof its resolved IP. Configure trusted networks
-// with SetTrustedProxies.
+// with SetTrustedProxies. SanitizeForwardHeaders applies this contract to the
+// headers themselves, so audit sourceIPs and the upstream API server see only
+// validated forwarding information.
 //
 // Only X-Forwarded-For is parsed; the RFC 7239 Forwarded header is not honoured.
 // On a malformed forwarded hop, or when the entire chain is itself trusted, the
@@ -45,6 +47,10 @@ const (
 
 	// bearerTokenKey is the context key for the client address.
 	clientAddressKey
+
+	// originalForwardedForKey is the context key preserving the raw inbound
+	// X-Forwarded-For chain before sanitization, for forensic logging.
+	originalForwardedForKey
 )
 
 // trustedProxies holds the networks whose forwarded headers are honoured when
@@ -58,6 +64,50 @@ var trustedProxies []*net.IPNet
 // requests are served.
 func SetTrustedProxies(nets []*net.IPNet) {
 	trustedProxies = nets
+}
+
+// SanitizeForwardHeaders enforces the trusted-proxy contract on the inbound
+// forwarding headers before anything downstream reads them: the audit filters
+// (which fill the event's sourceIPs from these headers via utilnet.SourceIPs),
+// the access log, and the upstream API server the request is forwarded to.
+//
+// X-Real-Ip is always removed — the proxy never honours it. X-Forwarded-For is
+// removed when the resolver would ignore it (untrusted peer, fully trusted
+// chain, or malformed hop) and collapsed to the single resolved client IP when
+// the peer is a trusted proxy. The raw inbound chain is preserved on the
+// request context and available via OriginalForwardedFor so forensic logging
+// keeps seeing what the client actually sent.
+func SanitizeForwardHeaders(req *http.Request) *http.Request {
+	xff := forwardedFor(req.Header)
+	if xff == "" && req.Header.Get("X-Real-Ip") == "" {
+		return req
+	}
+
+	if xff != "" {
+		req = req.WithContext(request.WithValue(req.Context(), originalForwardedForKey, xff))
+	}
+	req.Header.Del("X-Real-Ip")
+	if xff == "" {
+		return req
+	}
+
+	resolved := ResolveClientIP(req.RemoteAddr, xff, trustedProxies)
+	if resolved == peerHost(req.RemoteAddr) {
+		// The resolver fell back to the direct peer: nothing in the
+		// forwarded chain is trustworthy.
+		req.Header.Del("X-Forwarded-For")
+		return req
+	}
+
+	req.Header.Set("X-Forwarded-For", resolved)
+	return req
+}
+
+// OriginalForwardedFor returns the raw inbound X-Forwarded-For chain as it was
+// before SanitizeForwardHeaders rewrote it, or "" when there was none.
+func OriginalForwardedFor(req *http.Request) string {
+	xff, _ := req.Context().Value(originalForwardedForKey).(string)
+	return xff
 }
 
 type ImpersonationRequest struct {

--- a/pkg/proxy/context/context_test.go
+++ b/pkg/proxy/context/context_test.go
@@ -4,7 +4,11 @@ package context
 import (
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"reflect"
 	"testing"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 )
 
 // mustCIDRs parses CIDR strings into networks, failing the test on error.
@@ -207,5 +211,113 @@ func TestRemoteAddr_CachesResolvedValue(t *testing.T) {
 	_, second := RemoteAddr(req)
 	if second != first {
 		t.Errorf("cached RemoteAddr changed: got %q, want %q", second, first)
+	}
+}
+
+// TestSanitizeForwardHeaders pins the trusted-proxy contract as applied to the
+// inbound forwarding headers. The final assertion runs the apiserver's own
+// utilnet.SourceIPs over the sanitized request — that function is what the
+// audit filter uses to fill sourceIPs, so it is the audit-visible outcome that
+// is pinned, not just the header rewrite.
+func TestSanitizeForwardHeaders(t *testing.T) {
+	mustCIDRs := func(cidrs ...string) []*net.IPNet {
+		var nets []*net.IPNet
+		for _, c := range cidrs {
+			_, n, err := net.ParseCIDR(c)
+			if err != nil {
+				t.Fatalf("parsing test CIDR %q: %s", c, err)
+			}
+			nets = append(nets, n)
+		}
+		return nets
+	}
+
+	tests := map[string]struct {
+		trusted      []*net.IPNet
+		xff          string
+		realIP       string
+		expXFF       string
+		expOriginal  string
+		expSourceIPs []string
+	}{
+		"no trusted proxies: forwarded headers are stripped": {
+			trusted:      nil,
+			xff:          "1.2.3.4",
+			realIP:       "9.9.9.9",
+			expXFF:       "",
+			expOriginal:  "1.2.3.4",
+			expSourceIPs: []string{"10.0.0.5"},
+		},
+		"trusted peer: chain collapses to the resolved client": {
+			trusted:      mustCIDRs("10.0.0.0/8"),
+			xff:          "1.2.3.4, 10.0.0.9",
+			expXFF:       "1.2.3.4",
+			expOriginal:  "1.2.3.4, 10.0.0.9",
+			expSourceIPs: []string{"1.2.3.4", "10.0.0.5"},
+		},
+		"entirely trusted chain: stripped": {
+			trusted:      mustCIDRs("10.0.0.0/8"),
+			xff:          "10.0.0.7, 10.0.0.9",
+			expXFF:       "",
+			expOriginal:  "10.0.0.7, 10.0.0.9",
+			expSourceIPs: []string{"10.0.0.5"},
+		},
+		"malformed hop: stripped": {
+			trusted:      mustCIDRs("10.0.0.0/8"),
+			xff:          "not-an-ip, 10.0.0.9",
+			expXFF:       "",
+			expOriginal:  "not-an-ip, 10.0.0.9",
+			expSourceIPs: []string{"10.0.0.5"},
+		},
+		"x-real-ip alone is removed": {
+			trusted:      mustCIDRs("10.0.0.0/8"),
+			realIP:       "9.9.9.9",
+			expXFF:       "",
+			expOriginal:  "",
+			expSourceIPs: []string{"10.0.0.5"},
+		},
+		"no forwarding headers: untouched": {
+			trusted:      mustCIDRs("10.0.0.0/8"),
+			expXFF:       "",
+			expOriginal:  "",
+			expSourceIPs: []string{"10.0.0.5"},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			oldTrusted := trustedProxies
+			t.Cleanup(func() { trustedProxies = oldTrusted })
+			trustedProxies = test.trusted
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil)
+			req.RemoteAddr = "10.0.0.5:12345"
+			if test.xff != "" {
+				req.Header.Set("X-Forwarded-For", test.xff)
+			}
+			if test.realIP != "" {
+				req.Header.Set("X-Real-Ip", test.realIP)
+			}
+
+			req = SanitizeForwardHeaders(req)
+
+			if got := req.Header.Get("X-Forwarded-For"); got != test.expXFF {
+				t.Errorf("unexpected X-Forwarded-For after sanitizing, exp=%q got=%q", test.expXFF, got)
+			}
+			if got := req.Header.Get("X-Real-Ip"); got != "" {
+				t.Errorf("X-Real-Ip must always be removed, got %q", got)
+			}
+			if got := OriginalForwardedFor(req); got != test.expOriginal {
+				t.Errorf("unexpected preserved original chain, exp=%q got=%q", test.expOriginal, got)
+			}
+
+			var sourceIPs []string
+			for _, ip := range utilnet.SourceIPs(req) {
+				sourceIPs = append(sourceIPs, ip.String())
+			}
+			if !reflect.DeepEqual(sourceIPs, test.expSourceIPs) {
+				t.Errorf("unexpected audit-visible source IPs, exp=%v got=%v", test.expSourceIPs, sourceIPs)
+			}
+		})
 	}
 }

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -31,11 +31,24 @@ func (p *Proxy) withHandlers(handler http.Handler) http.Handler {
 	handler = p.auditor.WithRequest(handler)
 	handler = p.withImpersonateRequest(handler)
 	handler = p.withAuthenticateRequest(handler)
+	handler = p.withSanitizedForwardHeaders(handler)
 
 	// Add the auditor backend as a shutdown hook
 	p.hooks.AddPreShutdownHook("AuditBackend", p.auditor.Shutdown)
 
 	return handler
+}
+
+// withSanitizedForwardHeaders enforces the trusted-proxy contract on the
+// forwarding headers before anything downstream reads them: the audit filters
+// fill sourceIPs from these headers, the access log resolves the client IP
+// from them, and the reverse proxy forwards them to the API server. It is the
+// outermost handler so every path — including the unauthenticated audit
+// chain, which runs inside withAuthenticateRequest — sees sanitized headers.
+func (p *Proxy) withSanitizedForwardHeaders(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		handler.ServeHTTP(rw, context.SanitizeForwardHeaders(req))
+	})
 }
 
 // withAuthenticateRequest adds the proxy authentication handler to a chain.

--- a/pkg/proxy/logging/accesslog.go
+++ b/pkg/proxy/logging/accesslog.go
@@ -27,6 +27,8 @@ import (
 	"unicode"
 
 	"k8s.io/apiserver/pkg/authentication/user"
+
+	proxycontext "github.com/rafpe/kube-oidc-proxy/pkg/proxy/context"
 )
 
 const (
@@ -97,7 +99,14 @@ func requestAttrs(event string, req *http.Request) []slog.Attr {
 		slog.String("src_ip", resolveClientIP(req.RemoteAddr, forwardedFor(req.Header), trustedProxies)),
 		slog.String("path", sanitizePath(req)),
 	}
-	if fwd := sanitize(forwardedFor(req.Header)); fwd != "" {
+	// forwarded_for_untrusted is forensic: it must log the chain the client
+	// actually sent, which SanitizeForwardHeaders preserved on the context
+	// before rewriting the header.
+	rawFwd := proxycontext.OriginalForwardedFor(req)
+	if rawFwd == "" {
+		rawFwd = forwardedFor(req.Header)
+	}
+	if fwd := sanitize(rawFwd); fwd != "" {
 		attrs = append(attrs, slog.String("forwarded_for_untrusted", fwd))
 	}
 	return attrs

--- a/pkg/proxy/tokenreview/tokenreview.go
+++ b/pkg/proxy/tokenreview/tokenreview.go
@@ -20,16 +20,17 @@ import (
 	"github.com/rafpe/kube-oidc-proxy/pkg/util/token"
 )
 
-var (
-	timeout = time.Second * 10
-)
+// defaultTimeout bounds a TokenReview call when no explicit timeout is
+// configured. It also backstops zero-valued construction.
+const defaultTimeout = 10 * time.Second
 
 type TokenReview struct {
 	reviewRequester clientauthv1.TokenReviewInterface
 	audiences       []string
+	timeout         time.Duration
 }
 
-func New(restConfig *rest.Config, audiences []string) (*TokenReview, error) {
+func New(restConfig *rest.Config, audiences []string, timeout time.Duration) (*TokenReview, error) {
 	kubeclient, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
 		return nil, err
@@ -38,7 +39,17 @@ func New(restConfig *rest.Config, audiences []string) (*TokenReview, error) {
 	return &TokenReview{
 		reviewRequester: kubeclient.AuthenticationV1().TokenReviews(),
 		audiences:       audiences,
+		timeout:         timeout,
 	}, nil
+}
+
+// reviewTimeout returns the configured TokenReview budget, defaulting when
+// unset so zero-value construction keeps the historical 10s behaviour.
+func (t *TokenReview) reviewTimeout() time.Duration {
+	if t.timeout > 0 {
+		return t.timeout
+	}
+	return defaultTimeout
 }
 
 func (t *TokenReview) Review(req *http.Request) (bool, error) {
@@ -49,7 +60,7 @@ func (t *TokenReview) Review(req *http.Request) (bool, error) {
 
 	review := t.buildReview(bearer)
 
-	ctx, cancel := context.WithTimeout(req.Context(), timeout)
+	ctx, cancel := context.WithTimeout(req.Context(), t.reviewTimeout())
 	defer cancel()
 
 	resp, err := t.reviewRequester.Create(ctx, review, metav1.CreateOptions{})

--- a/pkg/proxy/tokenreview/tokenreview_test.go
+++ b/pkg/proxy/tokenreview/tokenreview_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
+	"time"
 
 	authv1 "k8s.io/api/authentication/v1"
 
@@ -93,5 +94,28 @@ func runTest(t *testing.T, test testT) {
 	if test.expAuth != authed {
 		t.Errorf("got unexpected authed, exp=%t got=%t",
 			test.expAuth, authed)
+	}
+}
+
+// TestReviewTimeout pins the timeout plumbing: New stores what it is given,
+// and the zero value falls back to the default so struct-literal construction
+// (as the tests above do) keeps the old behaviour.
+func TestReviewTimeout(t *testing.T) {
+	tests := map[string]struct {
+		timeout time.Duration
+		exp     time.Duration
+	}{
+		"configured timeout is used":     {timeout: 3 * time.Second, exp: 3 * time.Second},
+		"zero falls back to default":     {timeout: 0, exp: defaultTimeout},
+		"negative falls back to default": {timeout: -time.Second, exp: defaultTimeout},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			tr := &TokenReview{timeout: test.timeout}
+			if got := tr.reviewTimeout(); got != test.exp {
+				t.Errorf("unexpected review timeout, exp=%s got=%s", test.exp, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Two operator-facing gaps reported upstream, both small and independent; separate commits per concern.

## Trusted client IP in audit events (TremoloSecurity/kube-oidc-proxy#70)

Audit-event `sourceIPs` are filled by the apiserver's `utilnet.SourceIPs`, which believes any client-supplied `X-Forwarded-For`/`X-Real-Ip` unconditionally — so the first entry was fully spoofable, and inconsistent with the access log's `src_ip`, which already resolves through `--trusted-proxies`. The audit filter exposes no override for `sourceIPs`, so the fix intercepts at the only sound point: a new outermost handler sanitizes the forwarding headers per the existing trusted-proxy contract before the audit filters, the access log, or the forwarded request read them.

- Untrusted peer (or malformed/fully-trusted chain): forwarded headers stripped → `sourceIPs` = the direct peer, the one value a client cannot spoof.
- Trusted peer: chain collapses to the resolved client → `sourceIPs` = `[client, peer]`.
- `X-Real-Ip` always removed (never honoured by the proxy).
- The raw inbound chain is preserved on the request context; the access log's forensic `forwarded_for_untrusted` field still records exactly what the client sent.

**Behaviour change:** client-supplied forwarded headers no longer flow through to the upstream API server (they previously poisoned its audit `sourceIPs` too). Operators with a load balancer in front of the proxy must set `--trusted-proxies` for the real client IP to be resolved — which is that flag's documented contract.

## Configurable token-review timeout (TremoloSecurity/kube-oidc-proxy#75)

The TokenReview call made when validating a passthrough token had a hardcoded 10s budget; clients that burst token validation (upstream report: ArgoCD) blow through it with no recourse. `--kube-client-qps`/`--kube-client-burst` already exist; this adds the missing `--token-passthrough-request-timeout` (default `10s`, validated > 0 when passthrough is enabled).

## Tests

- `TestSanitizeForwardHeaders` pins the header rewrite AND the audit-visible outcome by running the apiserver's own `utilnet.SourceIPs` over the sanitized request.
- `TestReviewTimeout` pins the timeout plumbing and zero-value fallback.
