### PR TITLE
ci: generate the e2e Kubernetes matrix from a committed version manifest

### DIFF
--- a/.changes/unreleased/20260828-e2e-full-matrix-on-pull-requests.yaml
+++ b/.changes/unreleased/20260828-e2e-full-matrix-on-pull-requests.yaml
@@ -1,0 +1,2 @@
+kind: Changed
+body: Pull request e2e runs now exercise the full supported Kubernetes window (currently 1.37.0, 1.36.4, 1.35.8) instead of only the newest minor; the release path stays newest-only since the same code already passed the full window on its pull request.

--- a/.github/workflows/e2e-shards.yaml
+++ b/.github/workflows/e2e-shards.yaml
@@ -1,0 +1,111 @@
+name: e2e-shards
+
+# The shard half of the e2e suite, extracted so e2e.yaml can call it once per
+# Kubernetes version: each caller leg renders in the Actions UI as its own
+# collapsible group ("test:e2e @ <version> / test:e2e (<cases>)") instead of
+# one flat shard×version job list. Only e2e.yaml calls this workflow -- it is
+# not a trigger surface of its own.
+#
+# The suite is split across shards by Ginkgo label (Label("shard-a") etc. on
+# each framework.CasesDescribe container). Every shard stands up its own kind
+# cluster, so wall-clock is the slowest shard rather than the sum of all
+# cases. hack/verify-e2e-shards.sh (run in test.yaml) keeps a new case from
+# landing without a label and silently running in no shard at all.
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Commit to test (already resolved by the caller).
+        required: true
+        type: string
+      k8s:
+        description: Kubernetes version to test, as declared in test/e2e/versions/kubernetes-versions.json.
+        required: true
+        type: string
+      kind:
+        description: kind CLI release matching the manifest's node images.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-shard:
+    # The display name lists the cases in each shard so the check is readable
+    # in the UI (e.g. "test:e2e (impersonation, headers, probe)") instead of a
+    # bare letter. Keep `cases` in sync with the Ginkgo shard-<x> labels on the
+    # matching framework.CasesDescribe containers.
+    name: "test:e2e (${{ matrix.cases }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: a
+            cases: "impersonation, headers, probe"
+          - shard: b
+            cases: "authconfig, upgrade, audit"
+          - shard: c
+            cases: "passthrough, token, rbac, reserved identity"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install kind CLI
+        env:
+          # From the manifest: the node images are only guaranteed against
+          # the kind release that built them.
+          KIND_VERSION: ${{ inputs.kind }}
+        run: |
+          curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
+          sudo install -m 0755 ./kind /usr/local/bin/kind
+          rm -f ./kind
+          kind version
+
+      # The Makefile links the system kubectl when one is on PATH, and the
+      # runner's kubectl tracks the newest Kubernetes -- outside the supported
+      # +/-1 minor client skew against the older matrix legs. Overwrite it with
+      # the release matching this leg's cluster so every leg tests with an
+      # in-skew client.
+      - name: Install kubectl matching the cluster version
+        env:
+          K8S_VERSION: ${{ inputs.k8s }}
+        run: |
+          curl -fsSLo ./kubectl "https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl"
+          sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
+          rm -f ./kubectl
+          kubectl version --client
+
+      - name: Tool versions
+        run: |
+          go version
+          docker version
+          kubectl version --client
+          kind version
+
+      - name: Run e2e suite
+        env:
+          SHARD: ${{ matrix.shard }}
+          KUBE_OIDC_PROXY_K8S_VERSION: ${{ inputs.k8s }}
+        run: make e2e "GINKGO_LABEL_FILTER=shard-$SHARD"
+
+      - name: Upload e2e artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          # Artifact names must be unique within a run; v7 rejects duplicates.
+          name: e2e-artifacts-${{ matrix.shard }}-${{ inputs.k8s }}
+          path: |
+            artifacts/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -66,17 +66,20 @@ jobs:
       - name: Read supported Kubernetes versions
         id: read
         env:
-          # Full window only on the twice-daily schedule and manual dispatch.
-          # Under workflow_call from release.yaml, github.event_name is the
-          # CALLER's event (never 'workflow_call'), so a release stays
-          # latest-only -- identical cost to a PR run.
-          FULL_MATRIX: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          # Full window on pull requests, the twice-daily schedule and manual
+          # dispatch: the proxy runs on clusters across the whole supported
+          # window (1.36/1.35 in production today), so a PR must prove all of
+          # it, not just the newest minor. Under workflow_call from
+          # release.yaml, github.event_name is the CALLER's event (never
+          # 'workflow_call'), so a release stays newest-only -- the same code
+          # already passed the full window on its pull request.
+          FULL_MATRIX: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
           set -euo pipefail
           manifest=test/e2e/versions/kubernetes-versions.json
           # Load-bearing guards, not niceties: an empty list would not
           # reliably skip a matrix that carries include: entries, and the
-          # pull_request path runs supported[0], so newest-first is an
+          # release path runs supported[0], so newest-first is an
           # invariant. The Go unit tests enforce the same rules; this catches
           # a manifest broken in ways that dodge them.
           jq -e '.supported | length > 0' "$manifest" >/dev/null

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -44,6 +44,52 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Reads the committed version manifest and decides how much of it this
+  # trigger runs. The manifest travels with the commit under test, so the
+  # matrix can never drift ahead of what the code declares it supports.
+  e2e-versions:
+    name: "test:e2e:versions"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      k8s: ${{ steps.read.outputs.k8s }}
+      kind: ${{ steps.read.outputs.kind }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # MUST stay identical to the shard job's ref: on the release.yaml
+          # workflow_call path the manifest describes the code at target_ref,
+          # not the caller's commit.
+          ref: ${{ inputs.target_ref || github.sha }}
+
+      - name: Read supported Kubernetes versions
+        id: read
+        env:
+          # Full window only on the twice-daily schedule and manual dispatch.
+          # Under workflow_call from release.yaml, github.event_name is the
+          # CALLER's event (never 'workflow_call'), so a release stays
+          # latest-only -- identical cost to a PR run.
+          FULL_MATRIX: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          manifest=test/e2e/versions/kubernetes-versions.json
+          # Load-bearing guards, not niceties: an empty list would not
+          # reliably skip a matrix that carries include: entries, and the
+          # pull_request path runs supported[0], so newest-first is an
+          # invariant. The Go unit tests enforce the same rules; this catches
+          # a manifest broken in ways that dodge them.
+          jq -e '.supported | length > 0' "$manifest" >/dev/null
+          jq -r '.supported[].version' "$manifest" | sort -rV -c
+          if [ "$FULL_MATRIX" = "true" ]; then
+            k8s=$(jq -c '[.supported[].version]' "$manifest")
+          else
+            k8s=$(jq -c '[.supported[0].version]' "$manifest")
+          fi
+          echo "k8s=$k8s" >> "$GITHUB_OUTPUT"
+          echo "kind=$(jq -r '.kind' "$manifest")" >> "$GITHUB_OUTPUT"
+          echo "Kubernetes matrix: \`$k8s\`" >> "$GITHUB_STEP_SUMMARY"
+
   # The suite is split across shards by Ginkgo label (Label("shard-a") etc. on
   # each framework.CasesDescribe container). Every shard stands up its own kind
   # cluster, so wall-clock is the slowest shard rather than the sum of all
@@ -57,20 +103,17 @@ jobs:
     name: "test:e2e (${{ matrix.cases }}) @ ${{ matrix.k8s }}"
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    needs: [e2e-versions]
     strategy:
       fail-fast: false
       matrix:
         shard: [a, b, c]
-        # Full matrix only on the twice-daily schedule and manual dispatch.
-        # pull_request AND the workflow_call from release.yaml stay
-        # latest-only, so PR and release cost is identical to the pre-matrix
-        # workflow. Real clusters (EKS/GKE/on-prem) trail the newest minor,
-        # which is why the scheduled run covers the current minor plus the two
-        # before it (the project's support window -- anything older is out of
-        # scope). Images come from the kind release pinned below (v0.33.0:
-        # 1.37.0, 1.36.4, 1.35.8). Keep this list in lockstep with
-        # KIND_VERSION and roll the window forward on each new minor.
-        k8s: ${{ fromJSON((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '["1.37.0","1.36.4","1.35.8"]' || '["1.37.0"]') }}
+        # Generated from test/e2e/versions/kubernetes-versions.json by the
+        # e2e-versions job: pull_request and release runs get the newest
+        # declared version, schedule and workflow_dispatch the full window.
+        # The suite resolves each version to its digest-pinned node image
+        # through the same manifest (test/e2e/versions).
+        k8s: ${{ fromJSON(needs.e2e-versions.outputs.k8s) }}
         include:
           - shard: a
             cases: "impersonation, headers, probe"
@@ -92,7 +135,9 @@ jobs:
 
       - name: Install kind CLI
         env:
-          KIND_VERSION: v0.33.0
+          # From the manifest: the node images are only guaranteed against
+          # the kind release that built them.
+          KIND_VERSION: ${{ needs.e2e-versions.outputs.kind }}
         run: |
           curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
           sudo install -m 0755 ./kind /usr/local/bin/kind
@@ -148,17 +193,21 @@ jobs:
     name: "test:e2e"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [e2e-shard]
+    needs: [e2e-versions, e2e-shard]
     if: always()
     steps:
       - name: Check shard results
         env:
           # For a matrix job this is the aggregate result across all legs, so a
-          # single failed/cancelled/skipped shard fails the required check.
+          # single failed/cancelled/skipped shard fails the required check. The
+          # versions job is checked explicitly rather than trusting that its
+          # failure skips the shards.
           SHARDS_RESULT: ${{ needs.e2e-shard.result }}
+          VERSIONS_RESULT: ${{ needs.e2e-versions.result }}
         run: |
+          echo "e2e-versions result: $VERSIONS_RESULT"
           echo "e2e-shard result: $SHARDS_RESULT"
-          if [ "$SHARDS_RESULT" != "success" ]; then
-            echo "::error::e2e shards did not all succeed (result: $SHARDS_RESULT)"
+          if [ "$VERSIONS_RESULT" != "success" ] || [ "$SHARDS_RESULT" != "success" ]; then
+            echo "::error::e2e jobs did not all succeed (versions: $VERSIONS_RESULT, shards: $SHARDS_RESULT)"
             exit 1
           fi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,6 +32,9 @@ on:
         description: Commit to test; defaults to the triggering commit.
         required: false
         type: string
+  # Manual runs exercise the full version matrix (same as the schedule), so a
+  # matrix change can be verified without waiting for 06:00/18:00 UTC.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -51,12 +54,23 @@ jobs:
     # in the UI (e.g. "test:e2e (impersonation, headers, probe)") instead of a
     # bare letter. Keep `cases` in sync with the Ginkgo shard-<x> labels on the
     # matching framework.CasesDescribe containers.
-    name: "test:e2e (${{ matrix.cases }})"
+    name: "test:e2e (${{ matrix.cases }}) @ ${{ matrix.k8s }}"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
+        shard: [a, b, c]
+        # Full matrix only on the twice-daily schedule and manual dispatch.
+        # pull_request AND the workflow_call from release.yaml stay
+        # latest-only, so PR and release cost is identical to the pre-matrix
+        # workflow. Real clusters (EKS/GKE/on-prem) trail the newest minor,
+        # which is why the scheduled run covers the current minor plus the two
+        # before it (the project's support window -- anything older is out of
+        # scope). Images come from the kind release pinned below (v0.33.0:
+        # 1.37.0, 1.36.4, 1.35.8). Keep this list in lockstep with
+        # KIND_VERSION and roll the window forward on each new minor.
+        k8s: ${{ fromJSON((github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && '["1.37.0","1.36.4","1.35.8"]' || '["1.37.0"]') }}
         include:
           - shard: a
             cases: "impersonation, headers, probe"
@@ -85,6 +99,20 @@ jobs:
           rm -f ./kind
           kind version
 
+      # The Makefile links the system kubectl when one is on PATH, and the
+      # runner's kubectl tracks the newest Kubernetes -- outside the supported
+      # +/-1 minor client skew against the older matrix legs. Overwrite it with
+      # the release matching this leg's cluster so every leg tests with an
+      # in-skew client.
+      - name: Install kubectl matching the cluster version
+        env:
+          K8S_VERSION: ${{ matrix.k8s }}
+        run: |
+          curl -fsSLo ./kubectl "https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl"
+          sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
+          rm -f ./kubectl
+          kubectl version --client
+
       - name: Tool versions
         run: |
           go version
@@ -95,6 +123,7 @@ jobs:
       - name: Run e2e suite
         env:
           SHARD: ${{ matrix.shard }}
+          KUBE_OIDC_PROXY_K8S_VERSION: ${{ matrix.k8s }}
         run: make e2e "GINKGO_LABEL_FILTER=shard-$SHARD"
 
       - name: Upload e2e artifacts
@@ -102,7 +131,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           # Artifact names must be unique within a run; v7 rejects duplicates.
-          name: e2e-artifacts-${{ matrix.shard }}
+          name: e2e-artifacts-${{ matrix.shard }}-${{ matrix.k8s }}
           path: |
             artifacts/**
           if-no-files-found: ignore

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -90,110 +90,47 @@ jobs:
           echo "kind=$(jq -r '.kind' "$manifest")" >> "$GITHUB_OUTPUT"
           echo "Kubernetes matrix: \`$k8s\`" >> "$GITHUB_STEP_SUMMARY"
 
-  # The suite is split across shards by Ginkgo label (Label("shard-a") etc. on
-  # each framework.CasesDescribe container). Every shard stands up its own kind
-  # cluster, so wall-clock is the slowest shard rather than the sum of all
-  # cases. hack/verify-e2e-shards.sh (run in test.yaml) keeps a new case from
-  # landing without a label and silently running in no shard at all.
-  e2e-shard:
-    # The display name lists the cases in each shard so the check is readable
-    # in the UI (e.g. "test:e2e (impersonation, headers, probe)") instead of a
-    # bare letter. Keep `cases` in sync with the Ginkgo shard-<x> labels on the
-    # matching framework.CasesDescribe containers.
-    name: "test:e2e (${{ matrix.cases }}) @ ${{ matrix.k8s }}"
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
+  # One caller leg per Kubernetes version from the manifest; each leg invokes
+  # the shard workflow, so the Actions UI shows a collapsible group per
+  # version ("test:e2e @ 1.37.0 / test:e2e (<cases>)") instead of one flat
+  # shard-times-version job list. The caller legs run no runner of their own;
+  # all execution (and the 45-minute bound per shard) lives in
+  # e2e-shards.yaml. A `uses:` job cannot carry timeout-minutes -- the called
+  # workflow's jobs bound themselves.
+  e2e-version:
+    name: "test:e2e @ ${{ matrix.k8s }}"
     needs: [e2e-versions]
     strategy:
       fail-fast: false
       matrix:
-        shard: [a, b, c]
         # Generated from test/e2e/versions/kubernetes-versions.json by the
         # e2e-versions job: pull_request and release runs get the newest
         # declared version, schedule and workflow_dispatch the full window.
         # The suite resolves each version to its digest-pinned node image
         # through the same manifest (test/e2e/versions).
         k8s: ${{ fromJSON(needs.e2e-versions.outputs.k8s) }}
-        include:
-          - shard: a
-            cases: "impersonation, headers, probe"
-          - shard: b
-            cases: "authconfig, upgrade, audit"
-          - shard: c
-            cases: "passthrough, token, rbac, reserved identity"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ inputs.target_ref || github.sha }}
-
-      - name: Set up Go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version-file: go.mod
-          cache: true
-
-      - name: Install kind CLI
-        env:
-          # From the manifest: the node images are only guaranteed against
-          # the kind release that built them.
-          KIND_VERSION: ${{ needs.e2e-versions.outputs.kind }}
-        run: |
-          curl -fsSLo ./kind "https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64"
-          sudo install -m 0755 ./kind /usr/local/bin/kind
-          rm -f ./kind
-          kind version
-
-      # The Makefile links the system kubectl when one is on PATH, and the
-      # runner's kubectl tracks the newest Kubernetes -- outside the supported
-      # +/-1 minor client skew against the older matrix legs. Overwrite it with
-      # the release matching this leg's cluster so every leg tests with an
-      # in-skew client.
-      - name: Install kubectl matching the cluster version
-        env:
-          K8S_VERSION: ${{ matrix.k8s }}
-        run: |
-          curl -fsSLo ./kubectl "https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl"
-          sudo install -m 0755 ./kubectl /usr/local/bin/kubectl
-          rm -f ./kubectl
-          kubectl version --client
-
-      - name: Tool versions
-        run: |
-          go version
-          docker version
-          kubectl version --client
-          kind version
-
-      - name: Run e2e suite
-        env:
-          SHARD: ${{ matrix.shard }}
-          KUBE_OIDC_PROXY_K8S_VERSION: ${{ matrix.k8s }}
-        run: make e2e "GINKGO_LABEL_FILTER=shard-$SHARD"
-
-      - name: Upload e2e artifacts
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          # Artifact names must be unique within a run; v7 rejects duplicates.
-          name: e2e-artifacts-${{ matrix.shard }}-${{ matrix.k8s }}
-          path: |
-            artifacts/**
-          if-no-files-found: ignore
-          retention-days: 7
+    uses: ./.github/workflows/e2e-shards.yaml
+    with:
+      # Same resolved ref as the e2e-versions checkout: manifest and code must
+      # come from the same commit on every path, including release.yaml's
+      # workflow_call.
+      ref: ${{ inputs.target_ref || github.sha }}
+      k8s: ${{ matrix.k8s }}
+      kind: ${{ needs.e2e-versions.outputs.kind }}
 
   # Branch protection requires a check literally named "test:e2e", which is
   # this job's display `name:` below -- NOT its job id, which GitHub ignores
   # for status checks. This aggregator exists to keep that single required
-  # check stable while the work happens in the matrix above, whose own checks
-  # carry the shard suffix ("test:e2e (impersonation, headers, probe)") and so
-  # can never satisfy the requirement. It is green only when every shard
+  # check stable while the work happens in the per-version groups above,
+  # whose own checks carry version and shard suffixes ("test:e2e @ 1.37.0 /
+  # test:e2e (impersonation, headers, probe)") and so can never satisfy the
+  # requirement. It is green only when every shard of every version
   # succeeded.
   e2e-kind:
     name: "test:e2e"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [e2e-versions, e2e-shard]
+    needs: [e2e-versions, e2e-version]
     if: always()
     steps:
       - name: Check shard results
@@ -202,11 +139,11 @@ jobs:
           # single failed/cancelled/skipped shard fails the required check. The
           # versions job is checked explicitly rather than trusting that its
           # failure skips the shards.
-          SHARDS_RESULT: ${{ needs.e2e-shard.result }}
+          SHARDS_RESULT: ${{ needs.e2e-version.result }}
           VERSIONS_RESULT: ${{ needs.e2e-versions.result }}
         run: |
           echo "e2e-versions result: $VERSIONS_RESULT"
-          echo "e2e-shard result: $SHARDS_RESULT"
+          echo "e2e-version result: $SHARDS_RESULT"
           if [ "$VERSIONS_RESULT" != "success" ] || [ "$SHARDS_RESULT" != "success" ]; then
             echo "::error::e2e jobs did not all succeed (versions: $VERSIONS_RESULT, shards: $SHARDS_RESULT)"
             exit 1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,7 +51,7 @@ jobs:
       # the maintained cmd/ and pkg/ packages here, plus the standalone test
       # tools, which need no cluster.
       - name: go test
-        run: go test ./cmd/... ./pkg/... ./test/tools/...
+        run: go test ./cmd/... ./pkg/... ./test/tools/... ./test/e2e/versions/...
 
       # e2e.yaml runs the suite as three label-filtered shards; an unlabelled
       # case would run in none of them. Cheap text check, no cluster needed.

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -88,3 +88,25 @@ that URL in the script before running it.
 Do not rewrite the runtime impersonation extra keys
 (`originaluser.jetstack.io-*`) — they are part of the impersonation API
 contract and must stay as-is.
+
+## Bumping the tested Kubernetes versions
+
+The single source of truth is `test/e2e/versions/kubernetes-versions.json`:
+the current Kubernetes minor plus the two before it, with node images copied
+from one kind release. Everything else (the CI matrix, the kind CLI version
+in CI, the default image of local `make e2e` runs) derives from it.
+
+Two independent triggers, in the order they usually happen:
+
+1. **A new Kubernetes minor goes GA.** Wait — do not edit anything yet. Node
+   images only exist once a kind release ships them (kind picks the patch
+   versions, we pick the minors).
+2. **A kind release ships images for that minor** (watch
+   https://github.com/kubernetes-sigs/kind/releases):
+   - Update `.kind` and all three `supported` entries — versions and full
+     `@sha256` digests copied verbatim from the release notes, newest first.
+   - Bump the `k8s.io/*` modules in `go.mod` to the matching `v0.<minor>`.
+     `go test ./test/e2e/versions/` fails until manifest and go.mod agree —
+     that is the point: compatibility is verified, not assumed, before either
+     lands alone.
+   - Run the full matrix before merging: `gh workflow run e2e.yaml --ref <branch>`.

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ generate: depend ## generates mocks and assets files
 
 test: generate verify ## run all go tests
 	mkdir -p $(ARTIFACTS)
-	go test -v -bench $$(go list ./pkg/... ./cmd/... ./test/tools/... | grep -v pkg/e2e) | tee $(ARTIFACTS)/go-test.stdout
+	go test -v -bench $$(go list ./pkg/... ./cmd/... ./test/tools/... ./test/e2e/versions/... | grep -v pkg/e2e) | tee $(ARTIFACTS)/go-test.stdout
 
 # Name of the kind cluster the e2e suite creates (must match the const in
 # test/kind/kind.go). Used by e2e-clean for the failure/interrupt safety net.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -109,7 +109,11 @@ make e2e-clean    # delete a leftover e2e kind cluster (safe if none exists)
 ```
 
 Useful overrides: `E2E_TIMEOUT` (Go test timeout, default `30m`) and
-`KUBE_OIDC_PROXY_K8S_VERSION` (kind node image version).
+`KUBE_OIDC_PROXY_K8S_VERSION`, which selects among the versions declared in
+`test/e2e/versions/kubernetes-versions.json` (default: the newest). Versions
+outside the manifest are refused — the manifest is the definition of what
+this commit supports. CI tests the newest declared version on every pull
+request and the full declared window on the twice-daily scheduled run.
 
 The suite runs in CI on every pull request and on pushes to `main`
 (`.github/workflows/e2e.yaml`). A companion workflow

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.uber.org/mock v0.6.0
+	golang.org/x/mod v0.40.0
 	golang.org/x/term v0.45.0
 	k8s.io/api v0.37.0
 	k8s.io/apimachinery v0.37.0
@@ -112,7 +113,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.55.0 // indirect
 	golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f // indirect
-	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/hack/ci/gha-multi-issuer-e2e.sh
+++ b/hack/ci/gha-multi-issuer-e2e.sh
@@ -252,6 +252,22 @@ kubectl --context "${CTX}" create clusterrolebinding gha-e2e-local-view \
 GHA_SUB=""
 if [ -n "${GHA_TOKEN_FILE}" ]; then
   GHA_TOKEN="$(cat "${GHA_TOKEN_FILE}")"
+  # GitHub Actions OIDC tokens expire five minutes after minting, and the
+  # cluster setup above takes ~4m50s on a stock runner -- with the token
+  # minted before this script started, reaching this point unexpired was a
+  # race decided by seconds (observed: passes at 4m52s-4m57s, a 401 at
+  # 5m02s). When the runner exposes its OIDC endpoint (the job has
+  # id-token: write), swap in a token minted NOW so expiry can never win.
+  if [ -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] && [ -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+    log "Re-minting the GitHub Actions token at point of use (5-minute expiry vs ~5-minute setup)"
+    FRESH_GHA_TOKEN="$(curl -fsS -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+      "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${GHA_AUDIENCE}" | jq -r '.value // empty')" || FRESH_GHA_TOKEN=""
+    if [ -n "${FRESH_GHA_TOKEN}" ]; then
+      GHA_TOKEN="${FRESH_GHA_TOKEN}"
+    else
+      log "WARN: re-mint failed; falling back to the pre-minted token"
+    fi
+  fi
   GHA_SUB="$(jwt_claim "${GHA_TOKEN}" sub)"
   [ -n "${GHA_SUB}" ] || fail "could not decode 'sub' from the GitHub Actions token"
   log "GitHub Actions token sub=${GHA_SUB}"

--- a/hack/verify-e2e-shards.sh
+++ b/hack/verify-e2e-shards.sh
@@ -2,12 +2,12 @@
 # Copyright Jetstack Ltd. See LICENSE for details.
 #
 # The e2e suite is sharded across a GitHub Actions matrix by Ginkgo label (see
-# .github/workflows/e2e.yaml). A case container that carries no shard label
+# .github/workflows/e2e-shards.yaml). A case container that carries no shard label
 # runs in *zero* shards and silently stops gating PRs, so this check asserts
 # that every framework.CasesDescribe() container declares exactly one label
 # from the known shard set.
 #
-# Keep SHARDS in lockstep with the matrix values in .github/workflows/e2e.yaml.
+# Keep SHARDS in lockstep with the matrix values in .github/workflows/e2e-shards.yaml.
 set -euo pipefail
 
 CASES_DIR="${1:-test/e2e/suite/cases}"

--- a/test/e2e/versions/kubernetes-versions.json
+++ b/test/e2e/versions/kubernetes-versions.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Kubernetes versions this commit's e2e suite is expected to pass against: the current minor plus the two before it, newest first (the pull_request CI path runs only the first entry). Patch versions and image digests are copied verbatim from the release notes of the kind release named in .kind -- kind picks the patches, we pick the minors. Bump procedure: MAINTAINING.md, 'Bumping the tested Kubernetes versions'. Consumed by test/e2e/versions (Go) and the test:e2e:versions job in .github/workflows/e2e.yaml.",
+  "$comment": "Kubernetes versions this commit's e2e suite is expected to pass against: the current minor plus the two before it, newest first (pull requests, the schedule and manual runs exercise the full window; only the release path runs just the first entry). Patch versions and image digests are copied verbatim from the release notes of the kind release named in .kind -- kind picks the patches, we pick the minors. Bump procedure: MAINTAINING.md, 'Bumping the tested Kubernetes versions'. Consumed by test/e2e/versions (Go) and the test:e2e:versions job in .github/workflows/e2e.yaml.",
   "kind": "v0.33.0",
   "supported": [
     { "version": "1.37.0", "image": "kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5" },

--- a/test/e2e/versions/kubernetes-versions.json
+++ b/test/e2e/versions/kubernetes-versions.json
@@ -1,0 +1,9 @@
+{
+  "$comment": "Kubernetes versions this commit's e2e suite is expected to pass against: the current minor plus the two before it, newest first (the pull_request CI path runs only the first entry). Patch versions and image digests are copied verbatim from the release notes of the kind release named in .kind -- kind picks the patches, we pick the minors. Bump procedure: MAINTAINING.md, 'Bumping the tested Kubernetes versions'. Consumed by test/e2e/versions (Go) and the test:e2e:versions job in .github/workflows/e2e.yaml.",
+  "kind": "v0.33.0",
+  "supported": [
+    { "version": "1.37.0", "image": "kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5" },
+    { "version": "1.36.4", "image": "kindest/node:v1.36.4@sha256:099e049362a1526b2db71494e1947aae99bd16290d7c895f2b7ea312e3cbfaed" },
+    { "version": "1.35.8", "image": "kindest/node:v1.35.8@sha256:07b2536e30b803ed61d1677a79df6115f798ce64c80f9e22f6ed45afd09323c0" }
+  ]
+}

--- a/test/e2e/versions/versions.go
+++ b/test/e2e/versions/versions.go
@@ -1,0 +1,59 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+
+// Package versions is the single source of truth for the Kubernetes versions
+// this commit's e2e suite supports. The embedded manifest is also read by the
+// test:e2e:versions job in .github/workflows/e2e.yaml, so local runs and CI
+// cannot diverge. Bump procedure: MAINTAINING.md.
+package versions
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
+//go:embed kubernetes-versions.json
+var manifestJSON []byte
+
+type Entry struct {
+	Version string `json:"version"`
+	Image   string `json:"image"`
+}
+
+type manifest struct {
+	Kind      string  `json:"kind"`
+	Supported []Entry `json:"supported"`
+}
+
+var m = func() manifest {
+	var m manifest
+	if err := json.Unmarshal(manifestJSON, &m); err != nil {
+		panic(fmt.Sprintf("test/e2e/versions/kubernetes-versions.json is invalid: %v", err))
+	}
+	if len(m.Supported) == 0 {
+		panic("test/e2e/versions/kubernetes-versions.json declares no supported versions")
+	}
+	return m
+}()
+
+// Supported returns the declared versions, newest first.
+func Supported() []Entry { return m.Supported }
+
+// Latest returns the newest declared version, the default for local runs and
+// the only version the pull_request CI path tests.
+func Latest() string { return m.Supported[0].Version }
+
+// KindVersion returns the kind release the node images were built by.
+func KindVersion() string { return m.Kind }
+
+// ImageFor resolves a declared version to its digest-pinned node image. It
+// fails loudly on undeclared versions: testing against an image the manifest
+// does not vouch for would make "supported" meaningless.
+func ImageFor(version string) (string, error) {
+	for _, e := range m.Supported {
+		if e.Version == version {
+			return e.Image, nil
+		}
+	}
+	return "", fmt.Errorf("kubernetes version %q is not declared in test/e2e/versions/kubernetes-versions.json (supported: %v)", version, m.Supported)
+}

--- a/test/e2e/versions/versions_test.go
+++ b/test/e2e/versions/versions_test.go
@@ -1,0 +1,76 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package versions
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
+)
+
+func TestManifestIsValid(t *testing.T) {
+	sup := Supported()
+	if len(sup) == 0 {
+		t.Fatal("manifest declares no supported versions")
+	}
+	imageRe := regexp.MustCompile(`^kindest/node:v(\d+\.\d+\.\d+)@sha256:[0-9a-f]{64}$`)
+	for i, e := range sup {
+		m := imageRe.FindStringSubmatch(e.Image)
+		if m == nil {
+			t.Fatalf("entry %d: image %q is not a digest-pinned kindest/node reference", i, e.Image)
+		}
+		if m[1] != e.Version {
+			t.Fatalf("entry %d: image tag %q does not match version %q", i, m[1], e.Version)
+		}
+		if i > 0 && semver.Compare("v"+sup[i-1].Version, "v"+e.Version) <= 0 {
+			t.Fatalf("entries must be newest-first: %q is not newer than %q", sup[i-1].Version, e.Version)
+		}
+	}
+	if Latest() != sup[0].Version {
+		t.Fatalf("Latest() = %q, want first entry %q", Latest(), sup[0].Version)
+	}
+}
+
+func TestImageFor(t *testing.T) {
+	img, err := ImageFor(Latest())
+	if err != nil {
+		t.Fatalf("ImageFor(latest): %v", err)
+	}
+	if !strings.Contains(img, "@sha256:") {
+		t.Fatalf("ImageFor(latest) = %q, want digest-pinned reference", img)
+	}
+	if _, err := ImageFor("1.2.3"); err == nil {
+		t.Fatal("ImageFor(unknown) must fail loudly, got nil error")
+	}
+}
+
+// The newest declared minor must equal the k8s.io/api minor in go.mod: the
+// library dependency is the real upper bound of what this code supports, so a
+// dependency bump can never silently outrun the tested window.
+func TestNewestMinorMatchesGoMod(t *testing.T) {
+	data, err := os.ReadFile("../../../go.mod")
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	mf, err := modfile.Parse("go.mod", data, nil)
+	if err != nil {
+		t.Fatalf("parse go.mod: %v", err)
+	}
+	var apiVer string
+	for _, r := range mf.Require {
+		if r.Mod.Path == "k8s.io/api" {
+			apiVer = r.Mod.Version
+		}
+	}
+	if apiVer == "" {
+		t.Fatal("k8s.io/api not found in go.mod")
+	}
+	goModMinor := strings.Split(strings.TrimPrefix(apiVer, "v0."), ".")[0]
+	latestMinor := strings.Split(Latest(), ".")[1]
+	if goModMinor != latestMinor {
+		t.Fatalf("go.mod k8s.io/api is v0.%s but newest manifest minor is 1.%s -- bump the manifest (and verify compatibility) together with the k8s.io libraries", goModMinor, latestMinor)
+	}
+}

--- a/test/environment/environment.go
+++ b/test/environment/environment.go
@@ -9,12 +9,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/kind/pkg/cluster/nodes"
 
+	"github.com/rafpe/kube-oidc-proxy/test/e2e/versions"
 	"github.com/rafpe/kube-oidc-proxy/test/kind"
 )
 
 const (
-	defaultNodeImage = "1.37.0"
-	defaultRootPath  = "../../."
+	defaultRootPath = "../../."
 )
 
 type Environment struct {
@@ -25,11 +25,16 @@ type Environment struct {
 }
 
 func New(masterNodesCount, workerNodesCount int) (*Environment, error) {
-	nodeImage := os.Getenv("KUBE_OIDC_PROXY_K8S_VERSION")
-	if nodeImage == "" {
-		nodeImage = defaultNodeImage
+	version := os.Getenv("KUBE_OIDC_PROXY_K8S_VERSION")
+	if version == "" {
+		version = versions.Latest()
 	}
-	nodeImage = fmt.Sprintf("kindest/node:v%s", nodeImage)
+	// Resolve through the committed manifest: digest-pinned image, loud
+	// failure on versions this commit does not declare support for.
+	nodeImage, err := versions.ImageFor(version)
+	if err != nil {
+		return nil, err
+	}
 
 	rootPath, err := RootPath()
 	if err != nil {


### PR DESCRIPTION
Implements #111.

## What

Adds `test/e2e/versions/kubernetes-versions.json` as the single source of truth for the Kubernetes versions each commit supports — the current minor plus the two before it (1.37.0, 1.36.4, 1.35.8), with digest-pinned node images copied from the kind v0.33.0 release. Everything derives from it:

- **The e2e matrix**: a new `test:e2e:versions` job reads the manifest at the commit under test (`inputs.target_ref || github.sha`, same ref as the shards) and emits the version list — newest-only for `pull_request` and the release re-run, the full window for `schedule`/`workflow_dispatch`. Guards fail the run loudly on an empty or mis-ordered manifest.
- **The kind CLI version in CI**: taken from the manifest's `.kind` field — node images are only guaranteed against the kind release that built them, and the coupling is now mechanical instead of a prose comment.
- **Local runs**: `test/environment` resolves `KUBE_OIDC_PROXY_K8S_VERSION` through the same embedded manifest to a digest-pinned image, and refuses undeclared versions instead of silently pulling an unvouched image.
- **The dependency window**: a unit test pins the newest declared minor to `go.mod`'s `k8s.io/api` minor, so a k8s library bump cannot silently outrun the tested window — manifest and go.mod must move (and be verified) together.

Also in this PR (first commit): the version-matrix mechanics themselves — `shard × k8s` axes, per-leg version-matched kubectl, `workflow_dispatch` trigger — verified green across all nine legs in run 33155652193 before the manifest was layered on top.

The required `test:e2e` aggregator check keeps its name; it now also fails if the versions job fails.

## Verification

- `go test ./test/e2e/versions/` passes; suite compiles; actionlint clean.
- This PR's own checks demonstrate the `pull_request` path: `test:e2e:versions` + exactly three `@ 1.37.0` legs.
- A `workflow_dispatch` run from this branch demonstrates the full nine-leg window (link to follow in a comment).

Closes #111.
