### PR TITLE
docs: add a dedicated caching and API-server protection guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ See [docs/architecture.md](./docs/architecture.md) for the full C4 model (system
 | **Multi-issuer authentication** (headline feature) | [docs/multi-issuer.md](./docs/multi-issuer.md) |
 | Install, TLS, kubeconfig, auth modes | [docs/getting-started.md](./docs/getting-started.md) |
 | All flags, impersonation, task recipes | [docs/configuration.md](./docs/configuration.md) |
+| Caching and API-server protection: TokenReview/SAR caches, header cap | [docs/caching.md](./docs/caching.md) |
 | How it works: request flow, union authenticator, readiness | [docs/architecture.md](./docs/architecture.md) |
 | Security, troubleshooting, request logs, local testing | [docs/operations.md](./docs/operations.md) |
 | All chart values | [chart/kube-oidc-proxy/README.md](./chart/kube-oidc-proxy/README.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,24 +55,17 @@ Every request passes through the same pipeline:
 1. **Authenticate.** The bearer token is validated. If it fails OIDC validation
    and token passthrough is enabled, the proxy falls back to a `TokenReview`
    against the API server (see [token passthrough](./configuration.md#token-passthrough)).
-   TokenReview results are cached in a bounded in-memory cache (successful and
-   unauthenticated verdicts have separate TTLs, both 10s by default; errors are
-   never cached), so repeated requests with the same token don't trigger a
-   review each time. Concurrent first requests for the same token each run
-   their own review on their caller's context.
+   Review results are served from a bounded in-memory cache — see
+   [Caching and API-server protection](./caching.md#tokenreview-result-cache).
 2. **Resolve the impersonation target.** If the inbound request also carries
    `Impersonate-*` headers (`kubectl --as`), the proxy runs a
    `SubjectAccessReview` to confirm the authenticated user may assume that
-   identity before honouring it. Because the review fan-out scales with the
-   number of header values, the values are counted first and capped
-   (`--max-impersonation-header-values`, default 64); over-cap requests are
-   rejected with HTTP 431 before any `SubjectAccessReview` is sent. Decisions
-   are served from a bounded in-memory cache before a live
-   `SubjectAccessReview` is issued: allowed and denied decisions are cached
-   under separate TTLs (`--subject-access-review-cache-allow-ttl` /
-   `--subject-access-review-cache-deny-ttl`, both `10s` by default, `0`
-   disables that class), while API-server errors are never cached. See
-   [the impersonation model](./configuration.md#impersonation-model).
+   identity before honouring it (see
+   [the impersonation model](./configuration.md#impersonation-model)). The
+   header value count is capped up front (over-cap requests are rejected with
+   HTTP 431 before any review is sent), and decisions are served from a
+   bounded in-memory cache — see
+   [Caching and API-server protection](./caching.md#subjectaccessreview-decision-cache).
 3. **Impersonate.** The proxy rewrites the request to authenticate as its own
    ServiceAccount, attaches the impersonation headers for the resolved identity,
    and records the original caller in `originaluser.jetstack.io-*` extra headers
@@ -154,4 +147,5 @@ maps to a handler in `pkg/proxy`.
 - [Multi-issuer authentication](./multi-issuer.md)
 - [Getting started](./getting-started.md)
 - [Configuration reference](./configuration.md)
+- [Caching and API-server protection](./caching.md)
 - [Operations: security](./operations.md#security)

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -1,0 +1,166 @@
+# Caching and API-server protection
+
+Two request paths in the proxy turn client input into round trips to the
+Kubernetes API server: validating a passthrough token costs a `TokenReview`,
+and authorizing inbound impersonation (`kubectl --as`) costs one
+`SubjectAccessReview` per impersonation header value. Left unbounded, both
+scale with client behaviour — a request storm of invalid tokens, or a single
+request stuffed with impersonation headers, becomes API-server load.
+
+Three mechanisms bound that load:
+
+| Mechanism | Flags | Defaults |
+| --- | --- | --- |
+| [TokenReview result cache](#tokenreview-result-cache) | `--token-passthrough-cache-success-ttl`, `--token-passthrough-cache-failure-ttl` | `10s` / `10s` |
+| [SubjectAccessReview decision cache](#subjectaccessreview-decision-cache) | `--subject-access-review-cache-allow-ttl`, `--subject-access-review-cache-deny-ttl` | `10s` / `10s` |
+| [Impersonation header value cap](#impersonation-header-value-cap) | `--max-impersonation-header-values` | `64` |
+
+The caches follow the precedent set by `k8s.io/apiserver` for delegated
+authentication and authorization: 10-second TTLs, definitive results only —
+**errors are never cached** — and `0` disables. Both caches are bounded LRU
+caches of at most **8192 entries**, so client-influenced input can never grow
+the proxy's memory without bound.
+
+## TokenReview result cache
+
+Applies only with [`--token-passthrough`](./configuration.md#token-passthrough).
+When a bearer token fails OIDC validation, the proxy falls back to a
+`TokenReview` against the API server. Without a cache, every request carrying
+the same failing token — for example during an OIDC issuer outage — becomes its
+own API-server round trip. With it, repeated requests are answered from memory:
+
+```mermaid
+flowchart LR
+    C[Client] --> O{OIDC auth}
+    O -- ok --> F[Impersonate + forward]
+    O -- fail --> T{TokenReview<br>cache}
+    T -- hit --> D[Allow / 401]
+    T -- miss --> R[TokenReview<br>to API server] --> D
+```
+
+- **Split TTLs.** Successful reviews are cached for
+  `--token-passthrough-cache-success-ttl`, unauthenticated results for
+  `--token-passthrough-cache-failure-ttl`. Either can be `0` to disable that
+  class; with both at `0` the reviewer runs exactly as if the cache did not
+  exist.
+- **Errors are never cached.** An unreachable API server or a timed-out review
+  fails only the request that saw it and is retried on the next one — the path
+  stays fail-closed.
+- **Tokens are never stored as keys.** Cache keys are an HMAC-SHA256, keyed
+  with a per-instance random key, over the token and configured audiences — so
+  keys cannot be precomputed and a memory dump does not yield tokens.
+- **Concurrent misses each run their own review — deliberately.** A miss runs
+  on the caller's own context, so the full configured
+  `--token-passthrough-request-timeout` applies and cancelling the request
+  cancels its review. The cost is a few duplicate reviews when many requests
+  present the same not-yet-cached token at the same instant; the first to
+  finish populates the cache and everything after is a hit. The cache only
+  ever subtracts load.
+
+> [!WARNING]
+> A cached success outlives token revocation: a token revoked at the API
+> server keeps passing through the proxy for up to the success TTL. Keep it
+> low (the `10s` default matches the kube-apiserver's own
+> delegated-authentication cache) or set it to `0` if revocation must be
+> per-request.
+
+## SubjectAccessReview decision cache
+
+When an inbound request carries `Impersonate-*` headers, the proxy verifies via
+`SubjectAccessReview` that the authenticated user may assume each requested
+value (see [inbound impersonation](./configuration.md#inbound-impersonation-kubectl---as)).
+RBAC grants change rarely, so without a cache most of these calls ask the API
+server the same question again and again:
+
+```mermaid
+flowchart LR
+    A[Request with<br>Impersonate-* headers] --> B{Decision<br>cache}
+    B -- hit --> C[Reuse allow / deny]
+    B -- miss --> D[SubjectAccessReview<br>to API server]
+    D -- allow --> E[Cache for allow TTL]
+    D -- deny --> F[Cache for deny TTL]
+    D -- error --> G[Never cached]
+```
+
+- **Split TTLs, tuned per failure mode.** A cached **allow** means revoking an
+  RBAC impersonation grant takes up to
+  `--subject-access-review-cache-allow-ttl` to be enforced. A cached **deny**
+  means a newly granted permission takes up to
+  `--subject-access-review-cache-deny-ttl` to be honoured. Set either to `0`
+  to re-check that class on every request; both at `0` disables the cache
+  entirely.
+- **The key is the whole question.** Each entry is keyed on the exact
+  serialized `SubjectAccessReviewSpec` sent to the API server — requester
+  username, groups, extras **and UID**, plus every resource attribute — so two
+  distinct principals or questions can never share a decision.
+- **Oversized questions are never cached.** Specs over 10 000 bytes (e.g.
+  absurdly long header values) are authorized live and skipped by the cache, so
+  a client cannot fill it with huge keys.
+- **Concurrent identical misses share one review** (singleflight). If the
+  shared call dies because another request was cancelled, waiters fall back to
+  their own live check.
+- **A hit behaves exactly like a live review.** Cached denials produce the
+  identical error type, so `errors.Is` classification, `403` semantics, and
+  fail-closed handling are unchanged.
+
+## Impersonation header value cap
+
+Each impersonation header value — the `Impersonate-User` value plus every
+`Impersonate-Group`, `Impersonate-Uid`, and `Impersonate-Extra-*` value — costs
+one `SubjectAccessReview`, and the count is entirely client-controlled. Values
+are not deduplicated, and a single request can carry tens of thousands of them
+before hitting HTTP header size limits — so a cap, not a cache, is the right
+tool. The kube-apiserver tolerates unbounded counts because its per-value check
+is in-process; here every value is a network call.
+
+The proxy counts values **before** sending anything and rejects over-cap
+requests with **HTTP 431 Request Header Fields Too Large**:
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant P as kube-oidc-proxy
+    participant A as kube-apiserver
+
+    C->>P: Request with N impersonation values
+    alt N > cap (default 64)
+        P-->>C: 431 Request Header Fields Too Large
+        Note over P,A: zero SubjectAccessReviews sent
+    else N <= cap
+        loop one per value (cache miss only)
+            P->>A: SubjectAccessReview
+            A-->>P: Allowed / Denied
+        end
+        P->>A: Forward request (impersonated)
+    end
+```
+
+- Values are counted exactly the way the impersonation handler consumes them
+  (case-insensitive `Impersonate-` prefix, every value of every key), so case
+  variants or duplicate header keys cannot bypass the cap.
+- At or under the cap, behaviour is byte-for-byte identical to having no cap:
+  which identities are authorized, `403` handling, and auditing are unchanged.
+- The cap must be greater than `0`. Raise it
+  (`maxImpersonationHeaderValues` in the chart) only if identities legitimately
+  carry more values; see [troubleshooting](./operations.md#troubleshooting) for
+  the 431 symptom.
+
+## Tuning
+
+| You want | Set |
+| --- | --- |
+| Token revocation enforced per-request on the passthrough path | `--token-passthrough-cache-success-ttl=0` |
+| A just-issued token accepted immediately after a failed attempt | `--token-passthrough-cache-failure-ttl=0` |
+| RBAC impersonation revocation enforced per-request | `--subject-access-review-cache-allow-ttl=0` |
+| New impersonation grants honoured immediately | `--subject-access-review-cache-deny-ttl=0` |
+| Less API-server load from hot identities | Raise the TTLs — and accept the matching revocation/grant lag |
+| Identities with more than 64 impersonation values | Raise `--max-impersonation-header-values` |
+
+## See also
+
+- [Configuration reference](./configuration.md) — the full flag tables.
+- [Architecture](./architecture.md#the-auth--impersonate-handler-chain) — where
+  these steps sit in the handler chain.
+- [Operations: security](./operations.md#security) and
+  [troubleshooting](./operations.md#troubleshooting) — symptoms of cache lag
+  and the 431 rejection.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,16 +59,16 @@ not require a pod restart.
 | `--token-passthrough` | `false` | (Alpha) Bearer tokens that fail OIDC validation are tried via TokenReview and, if valid, forwarded as-is with no impersonation. |
 | `--token-passthrough-audiences` | — | (Alpha) Allowed audiences for passthrough tokens. |
 | `--token-passthrough-request-timeout` | `10s` | Timeout for each TokenReview request sent to the target API server when validating a passthrough token. |
-| `--token-passthrough-cache-success-ttl` | `10s` | How long a successful TokenReview result is cached and reused without a new API server request. A cached success outlives token revocation for up to this duration, so keep it low (the default matches the kube-apiserver's own delegated-authentication cache). `0` disables caching successes. |
-| `--token-passthrough-cache-failure-ttl` | `10s` | How long an unauthenticated TokenReview result is cached, shielding the API server from repeated reviews of the same invalid token (e.g. request storms during an OIDC issuer outage). Review errors are never cached. `0` disables caching failures. |
+| `--token-passthrough-cache-success-ttl` | `10s` | How long a successful TokenReview result is reused without a new API-server request. A cached success outlives token revocation for up to this duration, so keep it low. `0` disables caching successes. See [caching](./caching.md#tokenreview-result-cache). |
+| `--token-passthrough-cache-failure-ttl` | `10s` | How long an unauthenticated TokenReview result is cached, shielding the API server from repeated reviews of the same invalid token. Review errors are never cached. `0` disables caching failures. |
 | `--disable-impersonation` | `false` | (Alpha) Forward authenticated requests as-is, without impersonation. |
 | `--extra-user-header-client-ip` | `false` | (Alpha) Add `Impersonate-Extra-Remote-Client-IP` with the request's resolved client IP. |
 | `--extra-user-headers` | — | (Alpha) Extra `key=value` user headers to add to the impersonated request. |
 | `--trusted-proxies` | — | Comma-separated trusted proxy CIDRs (IPv4/IPv6). `X-Forwarded-For` is honoured for client-IP resolution only when the immediate peer is within one of these networks. Empty (default) trusts no proxy. See [Trusted proxies and client IP](#trusted-proxies-and-client-ip). |
 | `--subject-access-review-timeout` | `5s` | Timeout for authorizing inbound impersonation via `SubjectAccessReview` — a single shared budget across all SAR calls for one request (not per-call). Must be greater than 0. |
-| `--subject-access-review-cache-allow-ttl` | `10s` | How long an **allowed** impersonation SAR decision is served from a bounded in-memory cache before being re-checked. The tradeoff is revocation lag: revoking a requester's RBAC impersonation grant can take up to this long to be enforced while an allow is cached. Default matches the delegating-authorization default in `k8s.io/apiserver`. `0` disables caching of allows (per-request revocation). Only definitive decisions are cached — API-server errors never are. |
+| `--subject-access-review-cache-allow-ttl` | `10s` | How long an **allowed** impersonation SAR decision is served from a bounded in-memory cache before being re-checked. Revoking an RBAC impersonation grant can take up to this long to be enforced. `0` disables caching of allows. See [caching](./caching.md#subjectaccessreview-decision-cache). |
 | `--subject-access-review-cache-deny-ttl` | `10s` | How long a **denied** impersonation SAR decision is served from the cache. A newly granted RBAC impersonation permission can take up to this long to be honoured. `0` disables caching of denies. |
-| `--max-impersonation-header-values` | `64` | Maximum total number of impersonation header values accepted per request (the `Impersonate-User` value plus every `Impersonate-Group`, `Impersonate-Uid` and `Impersonate-Extra-*` value). Each value costs one `SubjectAccessReview` round trip, so this caps the per-request API-server load a client can drive; over-cap requests are rejected with HTTP 431 before any review is sent. Must be greater than 0. |
+| `--max-impersonation-header-values` | `64` | Maximum total number of impersonation header values accepted per request. Each value costs one `SubjectAccessReview` round trip; over-cap requests are rejected with HTTP 431 before any review is sent. Must be greater than 0. See [caching](./caching.md#impersonation-header-value-cap). |
 | `--allow-reserved-groups` | _(empty)_ | Comma-separated `system:`-prefixed groups a token may carry. See [Reserved `system:` identities](#reserved-system-identities). |
 
 ### Serving / TLS & misc
@@ -100,34 +100,16 @@ the proxy first checks — via `SubjectAccessReview` against the API server — 
 the authenticated user may assume that identity, then forwards the impersonated
 identity instead of the caller's own.
 
-### SubjectAccessReview caching
+### SubjectAccessReview caching and the header value cap
 
 Impersonation authorization decisions are served from a bounded in-memory cache
-per the `--subject-access-review-cache-allow-ttl` and
-`--subject-access-review-cache-deny-ttl` flags, so a client that repeatedly
-impersonates the same identities does not send a `SubjectAccessReview` to the
-API server on every request. The cache holds at most 8192 entries and evicts the
-least recently used one when full, so client-influenced impersonation values
-cannot grow the proxy's memory without bound.
-
-Allowed and denied decisions have **separate** TTLs so the two failure modes can
-be tuned independently:
-
-- A cached **allow** outlives an RBAC change: revoking a requester's
-  impersonation grant is not enforced until the cached allow expires (up to
-  `--subject-access-review-cache-allow-ttl`). Lower it, or set it to `0`, where
-  per-request revocation matters more than API-server load.
-- A cached **deny** delays a newly granted permission from taking effect for up
-  to `--subject-access-review-cache-deny-ttl`. Set it to `0` to have grants
-  honoured immediately.
-
-Only definitive allow/deny decisions are cached — a `SubjectAccessReview` that
-errors is never cached, so a transient API-server failure cannot latch into a
-denial. The cache key is the full authorization question, including the
-requester's username, groups, extras **and UID**, so two distinct principals can
-never share a cached decision. Both TTLs default to `10s`, matching the
-delegating-authorization cache in `k8s.io/apiserver`; setting both to `0`
-disables SAR caching entirely.
+(`--subject-access-review-cache-allow-ttl` /
+`--subject-access-review-cache-deny-ttl`, both `10s` by default), and the
+number of impersonation header values accepted per request is capped
+(`--max-impersonation-header-values`, default `64`; over-cap requests are
+rejected with HTTP 431 before any review is sent). The flows, cache semantics,
+and tuning tradeoffs — revocation and grant lag in particular — are documented
+in [Caching and API-server protection](./caching.md).
 
 ### Reserved `system:` identities
 
@@ -226,20 +208,10 @@ instead, supply them — at least one must be present in the token:
 ### TokenReview caching
 
 Review results are cached per the `--token-passthrough-cache-success-ttl` and
-`--token-passthrough-cache-failure-ttl` flags. The cache holds at most 8192
-entries and evicts the least recently used one when full, so a flood of unique
-invalid tokens cannot grow the proxy's memory without bound.
-
-Concurrent requests that miss the cache for the same token each run their own
-TokenReview — misses are deliberately not collapsed into a single in-flight
-review. This matches the behaviour before caching existed (the cache only ever
-subtracts API server load) and is what preserves the full configured
-`--token-passthrough-request-timeout` (including values above 30s) and
-per-request cancellation on every review. The trade-off is a few duplicate
-reviews when many requests present the same not-yet-cached token at the same
-instant: each of those in-flight requests completes its own review, the first
-to finish populates the cache, and every request arriving after that is served
-from it.
+`--token-passthrough-cache-failure-ttl` flags (both `10s` by default; errors
+are never cached). Note that a cached success outlives token revocation for up
+to the success TTL. The flow, key derivation, and tuning tradeoffs are
+documented in [Caching and API-server protection](./caching.md#tokenreview-result-cache).
 
 ## No impersonation
 
@@ -341,6 +313,7 @@ to configure it. For the proxy's own per-request stdout log, see
 
 - [Multi-issuer authentication](./multi-issuer.md)
 - [Getting started](./getting-started.md)
+- [Caching and API-server protection](./caching.md)
 - [Architecture](./architecture.md)
 - [Operations](./operations.md)
 - [Chart values reference](../chart/kube-oidc-proxy/README.md)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -23,10 +23,13 @@ Security, troubleshooting, and testing the proxy locally.
   non-OIDC tokens after a TokenReview; only enable it (and constrain
   `--token-passthrough-audiences`) when you understand the tokens involved.
   TokenReview results are cached, so a **revoked token keeps working for up to
-  `--token-passthrough-cache-success-ttl`** (default 10s, matching the
-  kube-apiserver's own delegated-authentication cache), and a newly valid token
-  can keep being rejected for up to `--token-passthrough-cache-failure-ttl`
-  (default 10s). Set either to `0` to disable that side of the cache.
+  `--token-passthrough-cache-success-ttl`** (default 10s). Set it to `0` to
+  disable — see [Caching and API-server protection](./caching.md#tokenreview-result-cache).
+- **Know the caching tradeoffs.** TokenReview results and impersonation
+  `SubjectAccessReview` decisions are both cached with 10s TTLs by default, so
+  token revocation and RBAC grant/revoke changes lag by up to one TTL. The
+  tradeoffs and the per-request-revocation settings are documented in
+  [Caching and API-server protection](./caching.md).
 - **Configure trusted proxies before trusting forwarded IPs.** By default the
   proxy ignores `X-Forwarded-For` and uses the direct peer as the client IP, so
   clients cannot forge the logged or impersonated client IP. Set
@@ -42,11 +45,11 @@ Security, troubleshooting, and testing the proxy locally.
 | `401 Unauthorized` from the proxy | The token failed OIDC validation — wrong `issuerUrl`/`clientId` (audience), expired token, unmet `requiredClaims`, or a signing algorithm not in `--oidc-signing-algs`. Look for an `AuFail` line in the proxy logs. |
 | `403 Forbidden` after a successful login | Authentication worked but RBAC denied the impersonated identity. Grant the mapped username/groups the appropriate roles. Watch for username **prefixes** (e.g. `google:alice@example.com`). |
 | `kubectl --as` fails through the proxy | The authenticated user isn't authorized to impersonate that identity (`SubjectAccessReview` denied), or the proxy's ServiceAccount lacks impersonation RBAC for a named `Impersonate-Extra-` key. |
-| `431 Request Header Fields Too Large` on `kubectl --as` | The request carried more impersonation header values (user + every group, uid and extra value) than the proxy accepts per request — each value counts toward the per-request `SubjectAccessReview` fan-out, so the count is capped (default 64) and over-cap requests are rejected before any review is sent. Raise `--max-impersonation-header-values` (`maxImpersonationHeaderValues` in the chart) if the identity legitimately needs more. |
-| RBAC impersonation grant/revoke takes up to 10s to take effect through the proxy | Expected: impersonation `SubjectAccessReview` decisions are cached. A revoked grant keeps working for up to `--subject-access-review-cache-allow-ttl` (default `10s`) while the cached allow expires; a new grant keeps failing for up to `--subject-access-review-cache-deny-ttl` (default `10s`) while the cached deny expires. Set either TTL to `0` to disable caching for that decision class and re-check every request. |
+| `431 Request Header Fields Too Large` on `kubectl --as` | The request carried more impersonation header values (user + every group, uid and extra value) than the proxy accepts per request (default 64). Raise `--max-impersonation-header-values` (`maxImpersonationHeaderValues` in the chart) if the identity legitimately needs more — see [the header value cap](./caching.md#impersonation-header-value-cap). |
+| RBAC impersonation grant/revoke takes up to 10s to take effect through the proxy | Expected: impersonation `SubjectAccessReview` decisions are cached. A revoked grant keeps working for up to `--subject-access-review-cache-allow-ttl`; a new grant keeps failing for up to `--subject-access-review-cache-deny-ttl` (both default `10s`). Set either TTL to `0` to re-check that class on every request — see [the SAR decision cache](./caching.md#subjectaccessreview-decision-cache). |
 | TLS errors connecting to the proxy | The client's kubeconfig `certificate-authority` must trust the proxy's **serving** certificate (self-signed by the chart, your own Secret, or cert-manager). |
 | Confirm which issuers loaded | `kubectl -n kube-oidc-proxy logs deploy/kube-oidc-proxy \| grep "configured OIDC issuers"`. |
-| A revoked passthrough token still works / a newly valid one is rejected | The TokenReview result cache. A revoked token passes for up to `--token-passthrough-cache-success-ttl` (default 10s) after revocation; a token that just became valid can be rejected for up to `--token-passthrough-cache-failure-ttl` (default 10s). Set either flag to `0` to disable that cache. |
+| A revoked passthrough token still works / a newly valid one is rejected | The TokenReview result cache. A revoked token passes for up to `--token-passthrough-cache-success-ttl`; a token that just became valid can be rejected for up to `--token-passthrough-cache-failure-ttl` (both default 10s). Set either flag to `0` to disable that side — see [the TokenReview cache](./caching.md#tokenreview-result-cache). |
 
 ### Reading the request log
 


### PR DESCRIPTION
## What

Adds [`docs/caching.md`](../blob/docs/caching-doc/docs/caching.md) — one place that explains the three mechanisms bounding the API-server load the proxy can generate, with a flow diagram for each:

- **TokenReview result cache** (token passthrough): split success/failure TTLs, HMAC-keyed entries, errors never cached, and why concurrent misses deliberately each run their own review.
- **SubjectAccessReview decision cache**: split allow/deny TTLs, full-spec cache key (username, groups, extras, UID), 8192-entry LRU bound, oversized-spec bypass, singleflight dedup, and identical error semantics on a hit.
- **Impersonation header value cap**: why a cap rather than a cache (each value is a client-controlled network call), 431 rejection before any review is sent, and bypass-resistant counting.

Ends with a tuning table mapping operator goals (per-request revocation, immediate grants, less load, >64 values) to the exact flag settings.

## Consistency changes

The same material was previously spread across three pages in different depths. Those now carry short summaries that link to the new guide instead of repeating it:

- `docs/configuration.md`: the *SubjectAccessReview caching* and *TokenReview caching* sections shrink to a paragraph each; the four cache/cap flag rows are tightened and link to their sections.
- `docs/architecture.md`: handler-chain steps 1–2 keep one sentence on caching and link out.
- `docs/operations.md`: security bullets and the three cache/cap troubleshooting rows link to the relevant sections.
- `README.md`: new row in the documentation table.

All flag names, defaults, cache sizes (8192 entries, 10 000-byte spec limit), and singleflight behaviour were verified against `pkg/proxy/tokenreview`, `pkg/proxy/subjectaccessreview`, and `cmd/app/options`.

Docs-only — no code changes.