### PR TITLE
ci: dedupe release-PR approvals and drop dead workflow logic

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,10 +13,10 @@ permissions:
   contents: read
 
 concurrency:
-  # Cancel superseded pull request runs; never cancel a run on main or a
-  # scheduled run, whose results are recorded against the default branch.
+  # Serialize main builds; never cancel one mid-publish, so a pushed :edge
+  # image is always fully signed and carries its SBOM.
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: false
 
 jobs:
   image:

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -6,8 +6,11 @@ name: Claude Review
 #   - Commenting "@claude review" on any other PR runs a Claude code review
 #     and approves only when the review finds no blocking issues.
 on:
-  # Prepare Release opens the release PR with GITHUB_TOKEN, whose events never
-  # trigger workflows, so hook the end of that run instead of the PR itself.
+  # Prepare Release opens the release PR with GITHUB_TOKEN. In practice the
+  # resulting pull_request events DO reach workflows (observed on PR #125),
+  # but hooking the end of that run as well costs one no-op job and keeps the
+  # approval working if GitHub ever suppresses those events again. The
+  # approve step is idempotent, so overlapping triggers add no extra reviews.
   workflow_run:
     workflows: ["Prepare Release"]
     types: [completed]
@@ -28,6 +31,12 @@ jobs:
        contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Serialize overlapping triggers (pull_request + workflow_run fire within
+    # seconds of each other) so the already-approved check below can see the
+    # earlier run's review.
+    concurrency:
+      group: release-approve
+      cancel-in-progress: false
     steps:
       - name: Approve release PR
         env:
@@ -46,6 +55,12 @@ jobs:
               --jq '[.[] | select([.labels[].name | startswith("autorelease")] | any)][0].number // ""')
             [ -n "${pr}" ] || { echo "::notice::no open autorelease PR to approve"; exit 0; }
           fi
+          # latestReviews holds each reviewer's current review, so a standing
+          # approval means nothing to do; a push dismisses it (DISMISSED) and
+          # the next trigger re-approves.
+          approved=$(gh pr view "${pr}" -R "${GITHUB_REPOSITORY}" --json latestReviews \
+            --jq '[.latestReviews[] | select(.state == "APPROVED")] | length')
+          [ "${approved}" -eq 0 ] || { echo "::notice::PR #${pr} already has a current approval"; exit 0; }
           gh pr review "${pr}" -R "${GITHUB_REPOSITORY}" --approve \
             --body "Auto-approved release PR (autorelease label)."
 

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -1,10 +1,13 @@
 name: release-image
 
 # Builds and publishes the versioned image and Helm chart for a release tag.
-# Tags/releases published by the release workflow are created with GITHUB_TOKEN,
-# which never triggers other workflows — so release.yaml calls this via
-# workflow_call. The tag-push trigger covers manually pushed tags, and
-# workflow_dispatch backfills artifacts for an existing tag.
+# release.yaml runs this via workflow_call after pushing the tag. The tag-push
+# trigger covers manually pushed tags, and workflow_dispatch backfills
+# artifacts for an existing tag. A tag pushed by github-actions[bot] is
+# release.yaml's own push, already covered by its workflow_call — the job
+# guard below skips it so a release cannot publish twice. (GitHub used to
+# suppress workflow triggers from GITHUB_TOKEN events entirely, but the
+# release PR on 2026-09-01 showed such events do fire now.)
 on:
   push:
     tags:
@@ -27,6 +30,8 @@ permissions:
 
 jobs:
   image:
+    # Skip release.yaml's own tag push (chart needs this job, so it skips too).
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
   schedule:
     # Weekly, Monday 06:00 UTC, so new advisories are caught even without


### PR DESCRIPTION
Follow-ups from watching the first automated release-PR approval:

- **Double approval fixed**: GitHub delivered both the `pull_request` event for the bot-created release PR and the `workflow_run` hook (the `GITHUB_TOKEN` event suppression this design assumed no longer applies). Both triggers stay for robustness, but the job is now serialized via a concurrency group and skips when `latestReviews` already shows a standing approval — a push still dismisses the approval and the next trigger re-approves.
- **Double release publish prevented**: with suppression gone, the tag `release.yaml` pushes would also fire `release-image.yaml`'s tag trigger on top of the `workflow_call` it already makes. Bot tag pushes are now skipped there; manually pushed tags and `workflow_dispatch` backfills behave as before.
- **Dead logic removed**: `build.yaml` carried an always-false `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` (it only triggers on push to main); `security.yaml` triggered on a `master` branch that doesn't exist.