### PR TITLE
ci: format release approvals and guard release-PR diffs

### DIFF
--- a/.github/scripts/approve-release-pr.sh
+++ b/.github/scripts/approve-release-pr.sh
@@ -1,37 +1,56 @@
 #!/usr/bin/env bash
 # Approve a release PR with a status-card review body. Both approval paths in
 # claude-review.yaml call this, so every path enforces the same guards:
-#   - skip when a current approval already stands (idempotent across triggers)
+#   - refuse PRs that are not the release automation's own same-repo
+#     release/next branch
 #   - refuse when the diff carries anything beyond generated release files
+#   - skip when a current approval already stands (idempotent across triggers)
 set -euo pipefail
 
 pr="${1:?usage: approve-release-pr.sh <pr-number>}"
 
-# latestReviews holds each reviewer's current review, so a standing approval
-# means nothing to do; a push dismisses it (DISMISSED) and the next trigger
-# re-approves.
-approved=$(gh pr view "${pr}" -R "${GITHUB_REPOSITORY}" --json latestReviews \
-  --jq '[.latestReviews[] | select(.state == "APPROVED")] | length')
-if [ "${approved}" -gt 0 ]; then
-  echo "::notice::PR #${pr} already has a current approval"
-  exit 0
+# A failed gh call aborts via set -e, so every guard below runs on data that
+# was actually fetched — never on an empty string from a swallowed error.
+meta=$(gh pr view "${pr}" -R "${GITHUB_REPOSITORY}" \
+  --json title,headRefName,headRefOid,isCrossRepository,latestReviews)
+title=$(jq -r '.title' <<<"${meta}")
+head_ref=$(jq -r '.headRefName' <<<"${meta}")
+head_sha=$(jq -r '.headRefOid[0:7]' <<<"${meta}")
+cross=$(jq -r '.isCrossRepository' <<<"${meta}")
+
+# Only the release automation's own branch qualifies, whatever labels a PR
+# carries and whichever workflow path called us.
+if [ "${cross}" != "false" ] || [ "${head_ref}" != "release/next" ]; then
+  echo "::error::PR #${pr} head is ${head_ref} (cross-repo: ${cross}), not this repo's release/next — refusing to auto-approve"
+  exit 1
 fi
 
 # Release PRs may only carry content Prepare Release generated; anything else
 # means release/next was pushed to outside the release tooling and needs a
-# human review instead of an auto-approval.
-unexpected=$(gh pr diff "${pr}" -R "${GITHUB_REPOSITORY}" --name-only \
-  | grep -Ev '^(CHANGELOG\.md$|\.changes/)' || true)
+# human review instead of an auto-approval. Runs before the already-approved
+# short-circuit so a tampered push is flagged on every trigger, independent of
+# the ruleset's dismiss-stale-reviews setting.
+diff_files=$(gh pr diff "${pr}" -R "${GITHUB_REPOSITORY}" --name-only)
+if [ -z "${diff_files}" ]; then
+  echo "::error::could not resolve any changed files for release PR #${pr} — refusing to auto-approve"
+  exit 1
+fi
+unexpected=$(grep -Ev '^(CHANGELOG\.md$|\.changes/)' <<<"${diff_files}" || true)
 if [ -n "${unexpected}" ]; then
   echo "::error::release PR #${pr} touches files outside CHANGELOG.md/.changes/ — refusing to auto-approve"
   printf '%s\n' "${unexpected}"
   exit 1
 fi
 
-meta=$(gh pr view "${pr}" -R "${GITHUB_REPOSITORY}" --json title,headRefName,headRefOid)
-title=$(jq -r '.title' <<<"${meta}")
-head_ref=$(jq -r '.headRefName' <<<"${meta}")
-head_sha=$(jq -r '.headRefOid[0:7]' <<<"${meta}")
+# latestReviews holds each reviewer's current review, so a standing approval
+# means nothing to do; a push dismisses it (DISMISSED, dismiss-stale is on in
+# the main ruleset) and the next trigger re-approves.
+approved=$(jq '[.latestReviews[] | select(.state == "APPROVED")] | length' <<<"${meta}")
+if [ "${approved}" -gt 0 ]; then
+  echo "::notice::PR #${pr} already has a current approval"
+  exit 0
+fi
+
 version="${title#chore: release }"
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 

--- a/.github/scripts/approve-release-pr.sh
+++ b/.github/scripts/approve-release-pr.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Approve a release PR with a status-card review body. Both approval paths in
+# claude-review.yaml call this, so every path enforces the same guards:
+#   - skip when a current approval already stands (idempotent across triggers)
+#   - refuse when the diff carries anything beyond generated release files
+set -euo pipefail
+
+pr="${1:?usage: approve-release-pr.sh <pr-number>}"
+
+# latestReviews holds each reviewer's current review, so a standing approval
+# means nothing to do; a push dismisses it (DISMISSED) and the next trigger
+# re-approves.
+approved=$(gh pr view "${pr}" -R "${GITHUB_REPOSITORY}" --json latestReviews \
+  --jq '[.latestReviews[] | select(.state == "APPROVED")] | length')
+if [ "${approved}" -gt 0 ]; then
+  echo "::notice::PR #${pr} already has a current approval"
+  exit 0
+fi
+
+# Release PRs may only carry content Prepare Release generated; anything else
+# means release/next was pushed to outside the release tooling and needs a
+# human review instead of an auto-approval.
+unexpected=$(gh pr diff "${pr}" -R "${GITHUB_REPOSITORY}" --name-only \
+  | grep -Ev '^(CHANGELOG\.md$|\.changes/)' || true)
+if [ -n "${unexpected}" ]; then
+  echo "::error::release PR #${pr} touches files outside CHANGELOG.md/.changes/ — refusing to auto-approve"
+  printf '%s\n' "${unexpected}"
+  exit 1
+fi
+
+meta=$(gh pr view "${pr}" -R "${GITHUB_REPOSITORY}" --json title,headRefName,headRefOid)
+title=$(jq -r '.title' <<<"${meta}")
+head_ref=$(jq -r '.headRefName' <<<"${meta}")
+head_sha=$(jq -r '.headRefOid[0:7]' <<<"${meta}")
+version="${title#chore: release }"
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+body=$(mktemp)
+cat >"${body}" <<EOF
+## ✅ Release PR — auto-approved
+
+|             |   |
+| ----------- | - |
+| **Verdict** | Approved without review (release gate) |
+| **Release** | \`${version}\` |
+| **Why**     | Diff verified to carry only generated \`CHANGELOG.md\` + \`.changes/\` fragment changes |
+| **Head**    | \`${head_ref}\` @ \`${head_sha}\` — a force-push dismisses this approval and the next trigger re-approves |
+| **Trigger** | [${GITHUB_WORKFLOW} run](${run_url}) |
+
+<sub>🤖 Policy: PRs labeled <code>autorelease:*</code> from <code>release/next</code> are approved automatically — <code>.github/workflows/claude-review.yaml</code></sub>
+EOF
+gh pr review "${pr}" -R "${GITHUB_REPOSITORY}" --approve --body-file "${body}"

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -2,7 +2,8 @@ name: Claude Review
 
 # On-demand PR review and approval. Two paths:
 #   - Release PRs (any label starting with "autorelease") are approved without
-#     review; they carry only generated changelog/fragment changes.
+#     review after verifying the diff carries only generated changelog and
+#     fragment changes (.github/scripts/approve-release-pr.sh).
 #   - Commenting "@claude review" on any other PR runs a Claude code review
 #     and approves only when the review finds no blocking issues.
 on:
@@ -31,6 +32,8 @@ jobs:
        contains(join(github.event.pull_request.labels.*.name, ','), 'autorelease'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read # checkout of the shared approve script
     # Serialize overlapping triggers (pull_request + workflow_run fire within
     # seconds of each other) so the already-approved check below can see the
     # earlier run's review.
@@ -38,6 +41,13 @@ jobs:
       group: release-approve
       cancel-in-progress: false
     steps:
+      # Pin the script to main rather than the pull_request merge ref: the
+      # approval guards must not be rewritable from release/next itself.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: main
+          sparse-checkout: .github/scripts
+          fetch-depth: 1
       - name: Approve release PR
         env:
           # github-actions[bot] authors the release PR and cannot approve its
@@ -55,14 +65,7 @@ jobs:
               --jq '[.[] | select([.labels[].name | startswith("autorelease")] | any)][0].number // ""')
             [ -n "${pr}" ] || { echo "::notice::no open autorelease PR to approve"; exit 0; }
           fi
-          # latestReviews holds each reviewer's current review, so a standing
-          # approval means nothing to do; a push dismisses it (DISMISSED) and
-          # the next trigger re-approves.
-          approved=$(gh pr view "${pr}" -R "${GITHUB_REPOSITORY}" --json latestReviews \
-            --jq '[.latestReviews[] | select(.state == "APPROVED")] | length')
-          [ "${approved}" -eq 0 ] || { echo "::notice::PR #${pr} already has a current approval"; exit 0; }
-          gh pr review "${pr}" -R "${GITHUB_REPOSITORY}" --approve \
-            --body "Auto-approved release PR (autorelease label)."
+          .github/scripts/approve-release-pr.sh "${pr}"
 
   claude-review:
     name: "review:claude"
@@ -80,18 +83,18 @@ jobs:
       actions: read # let Claude read CI results on the PR
       id-token: write
     steps:
+      # issue_comment events check out the default branch, so both paths get
+      # trusted repo content: the approve script for release PRs, the source
+      # tree for Claude reviews.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with: { fetch-depth: 1 }
+
       - name: Approve release PR without review
         if: contains(join(github.event.issue.labels.*.name, ','), 'autorelease')
         env:
           GH_TOKEN: ${{ secrets.RELEASE_APPROVE_PAT }}
           PR: ${{ github.event.issue.number }}
-        run: |
-          gh pr review "${PR}" -R "${GITHUB_REPOSITORY}" --approve \
-            --body "Auto-approved release PR (autorelease label)."
-
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: ${{ !contains(join(github.event.issue.labels.*.name, ','), 'autorelease') }}
-        with: { fetch-depth: 1 }
+        run: .github/scripts/approve-release-pr.sh "${PR}"
 
       # The issue_comment payload lacks head-repo data, so resolve whether the
       # PR comes from a fork; fork PRs get a review but never an auto-approval
@@ -152,4 +155,26 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ github.event.issue.number }}
           SUMMARY: ${{ fromJSON(steps.review.outputs.structured_output).summary }}
-        run: gh pr review "${PR}" -R "${GITHUB_REPOSITORY}" --approve --body "${SUMMARY}"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          IFS=$'\t' read -r head_ref head_sha < <(gh pr view "${PR}" -R "${GITHUB_REPOSITORY}" \
+            --json headRefName,headRefOid --jq '[.headRefName, .headRefOid[0:7]] | @tsv')
+          {
+            cat <<EOF
+          ## ✅ Approved — Claude review clean
+
+          |             |   |
+          | ----------- | - |
+          | **Verdict** | Approved — review found no blocking issues |
+          | **Head**    | \`${head_ref}\` @ \`${head_sha}\` |
+          | **Review**  | [Claude review run](${RUN_URL}) — inline findings, if any, are non-blocking |
+
+          EOF
+            printf '%s\n' "${SUMMARY}" | sed 's/^/> /'
+            cat <<'EOF'
+
+          <sub>🤖 Approval submitted automatically because the review verdict was approve=true and the PR is not from a fork — <code>.github/workflows/claude-review.yaml</code></sub>
+          EOF
+          } > approve-body.md
+          gh pr review "${PR}" -R "${GITHUB_REPOSITORY}" --approve --body-file approve-body.md

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -158,8 +158,11 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          IFS=$'\t' read -r head_ref head_sha < <(gh pr view "${PR}" -R "${GITHUB_REPOSITORY}" \
-            --json headRefName,headRefOid --jq '[.headRefName, .headRefOid[0:7]] | @tsv')
+          # Plain assignments so a failed gh call aborts via set -e instead of
+          # leaving blank fields in the card.
+          meta=$(gh pr view "${PR}" -R "${GITHUB_REPOSITORY}" --json headRefName,headRefOid)
+          head_ref=$(jq -r '.headRefName' <<<"${meta}")
+          head_sha=$(jq -r '.headRefOid[0:7]' <<<"${meta}")
           {
             cat <<EOF
           ## ✅ Approved — Claude review clean


### PR DESCRIPTION
## What changed

Both auto-approval paths in `claude-review.yaml` posted bare one-line review bodies. This PR gives approvals a structured status card and tightens what the release gate will approve.

- **New `.github/scripts/approve-release-pr.sh`** — shared by the `release-approve` job and the `@claude review` shortcut, deduplicating the previously copy-pasted approve logic. It keeps the idempotent already-approved check and adds a **diff guard**: the release PR's diff must contain only `CHANGELOG.md` and `.changes/**`; anything else fails the job instead of approving, so a stray or tampered push to `release/next` can no longer be waved through.
- **Status-card approval bodies** — release approvals now show verdict, release version, verified-diff note, head `branch @ sha`, and a link to the triggering run; clean-review approvals show the same card with Claude's review summary quoted inline.
- The `release-approve` job sparse-checkouts the script pinned to `main`, so the approval guards are not rewritable from the PR's own merge ref.

## Why

Approval comments were unformatted and carried no provenance; the release gate trusted the `autorelease` label alone without verifying the diff was actually generated content.

## Testing

- `actionlint` and `shellcheck` clean.
- Both card bodies rendered locally with sample data (tables, blockquoted summary, footers verified).
