### PR TITLE
fix(chart): default image tag to appVersion so releases deploy their own image

### DIFF
--- a/.changes/unreleased/20260904-chart-image-tag-follows-appversion.yaml
+++ b/.changes/unreleased/20260904-chart-image-tag-follows-appversion.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Helm chart now deploys the image matching its appVersion by default. Charts 1.2.0 through 1.6.0 shipped with a hardcoded `image.tag` of 1.1.0, so installs without an explicit `image.tag` override ran the 1.1.0 binary; the release pipeline now refuses to publish a chart whose default image tag differs from the release version.

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -51,9 +51,11 @@ jobs:
         # deploy that image unless image.tag is explicitly overridden.
         run: |
           app_version="$(yq -r .appVersion "$CHART/Chart.yaml")"
-          rendered="$(helm template ci-single "$CHART" -f "$CHART/ci/single-issuer-values.yaml" \
-            | awk '/^ +image: "ghcr.io\//{gsub(/"/,"",$2); print $2; exit}')"
+          render_image() {
+            helm template ci-single "$CHART" -f "$CHART/ci/single-issuer-values.yaml" "$@" \
+              --show-only templates/deployment.yaml | yq -r '.spec.template.spec.containers[0].image'
+          }
+          rendered="$(render_image)"
           [ "$rendered" = "ghcr.io/rafpe/kube-oidc-proxy:${app_version}" ] || { echo "::error::rendered ${rendered}, expected appVersion ${app_version}"; exit 1; }
-          rendered="$(helm template ci-single "$CHART" -f "$CHART/ci/single-issuer-values.yaml" --set image.tag=9.9.9 \
-            | awk '/^ +image: "ghcr.io\//{gsub(/"/,"",$2); print $2; exit}')"
+          rendered="$(render_image --set image.tag=9.9.9)"
           [ "$rendered" = "ghcr.io/rafpe/kube-oidc-proxy:9.9.9" ] || { echo "::error::image.tag override not honoured: ${rendered}"; exit 1; }

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -45,3 +45,15 @@ jobs:
 
       - name: helm template (multi-issuer fixture)
         run: helm template ci-multi "$CHART" -f "$CHART/ci/multi-issuer-values.yaml" > /dev/null
+
+      - name: default image tag follows appVersion
+        # The release pipeline sets appVersion from the git tag; the chart must
+        # deploy that image unless image.tag is explicitly overridden.
+        run: |
+          app_version="$(yq -r .appVersion "$CHART/Chart.yaml")"
+          rendered="$(helm template ci-single "$CHART" -f "$CHART/ci/single-issuer-values.yaml" \
+            | awk '/^ +image: "ghcr.io\//{gsub(/"/,"",$2); print $2; exit}')"
+          [ "$rendered" = "ghcr.io/rafpe/kube-oidc-proxy:${app_version}" ] || { echo "::error::rendered ${rendered}, expected appVersion ${app_version}"; exit 1; }
+          rendered="$(helm template ci-single "$CHART" -f "$CHART/ci/single-issuer-values.yaml" --set image.tag=9.9.9 \
+            | awk '/^ +image: "ghcr.io\//{gsub(/"/,"",$2); print $2; exit}')"
+          [ "$rendered" = "ghcr.io/rafpe/kube-oidc-proxy:9.9.9" ] || { echo "::error::image.tag override not honoured: ${rendered}"; exit 1; }

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -157,7 +157,7 @@ jobs:
           # Guard against publishing a chart whose default values deploy an
           # image other than this release (the rendered tag must match).
           RENDERED="$(helm template guard "$PKG" -f "${CHART_DIR}/ci/single-issuer-values.yaml" \
-            | awk '/^ +image: "ghcr.io\//{gsub(/"/,"",$2); print $2; exit}')"
+            --show-only templates/deployment.yaml | yq -r '.spec.template.spec.containers[0].image')"
           EXPECTED="ghcr.io/${OWNER}/kube-oidc-proxy:${VERSION}"
           [ "$RENDERED" = "$EXPECTED" ] || { echo "::error::packaged chart renders image ${RENDERED}, expected ${EXPECTED}"; exit 1; }
 

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -154,6 +154,13 @@ jobs:
           helm package "$CHART_DIR" --version "$VERSION" --app-version "$VERSION"
           PKG="kube-oidc-proxy-${VERSION}.tgz"
 
+          # Guard against publishing a chart whose default values deploy an
+          # image other than this release (the rendered tag must match).
+          RENDERED="$(helm template guard "$PKG" -f "${CHART_DIR}/ci/single-issuer-values.yaml" \
+            | awk '/^ +image: "ghcr.io\//{gsub(/"/,"",$2); print $2; exit}')"
+          EXPECTED="ghcr.io/${OWNER}/kube-oidc-proxy:${VERSION}"
+          [ "$RENDERED" = "$EXPECTED" ] || { echo "::error::packaged chart renders image ${RENDERED}, expected ${EXPECTED}"; exit 1; }
+
           OUT="$(helm push "$PKG" "$OCI" 2>&1)"
           echo "$OUT"
           DIGEST="$(echo "$OUT" | awk '/Digest:/{print $2}')"

--- a/chart/kube-oidc-proxy/Chart.yaml
+++ b/chart/kube-oidc-proxy/Chart.yaml
@@ -8,9 +8,10 @@ description: >-
 type: application
 # The chart and image share a single version. On a tagged release the
 # automation overrides both `version` and `appVersion` from the git tag
-# (vX.Y.Z); the values here are the development baseline.
-version: 1.3.0
-appVersion: "1.1.0"
+# (vX.Y.Z); the values here are the development baseline. The Deployment
+# image tag defaults to `appVersion`, so the override also selects the image.
+version: 1.6.0
+appVersion: "1.6.0"
 home: https://github.com/rafpe/kube-oidc-proxy
 sources:
   - https://github.com/rafpe/kube-oidc-proxy
@@ -32,4 +33,4 @@ annotations:
       url: https://github.com/RafPe/kube-oidc-proxy/blob/main/SECURITY.md
   artifacthub.io/images: |
     - name: kube-oidc-proxy
-      image: ghcr.io/rafpe/kube-oidc-proxy:1.1.0
+      image: ghcr.io/rafpe/kube-oidc-proxy:1.6.0

--- a/chart/kube-oidc-proxy/README.md
+++ b/chart/kube-oidc-proxy/README.md
@@ -62,7 +62,7 @@ Every value in [`values.yaml`](./values.yaml).
 | --- | --- | --- | --- |
 | `replicaCount` | int | `1` | Number of proxy replicas. |
 | `image.repository` | string | `ghcr.io/rafpe/kube-oidc-proxy` | Container image repository. |
-| `image.tag` | string | `"1.1.0"` | Image tag (pin an explicit version; never `latest`). |
+| `image.tag` | string | `""` | Image tag. Empty uses the chart `appVersion`, which matches the chart version on every release. Set to pin a different explicit version; never `latest`. |
 | `image.pullPolicy` | string | `IfNotPresent` | Image pull policy. |
 | `imagePullSecrets` | list | `[]` | Secrets for pulling from a private registry. |
 | `nameOverride` | string | `""` | Override the chart-name portion of resource names. |

--- a/chart/kube-oidc-proxy/templates/deployment.yaml
+++ b/chart/kube-oidc-proxy/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext:

--- a/chart/kube-oidc-proxy/values.yaml
+++ b/chart/kube-oidc-proxy/values.yaml
@@ -8,9 +8,11 @@ replicaCount: 1
 image:
   # Container image repository. Published by this fork's release pipeline.
   repository: ghcr.io/rafpe/kube-oidc-proxy
-  # Image tag. Always pin to an explicit version (never "latest") so rollouts
-  # are reproducible.
-  tag: "1.1.0"
+  # Image tag. Leave empty to use the chart's appVersion, which the release
+  # pipeline sets to the same version as the chart, so every chart release
+  # installs the image built from the same commit. Set it only to pin a
+  # different explicit version; never use "latest".
+  tag: ""
   # Image pull policy. IfNotPresent avoids re-pulling a pinned tag on every start.
   pullPolicy: IfNotPresent
 

--- a/scripts/release-contract-check.sh
+++ b/scripts/release-contract-check.sh
@@ -21,6 +21,7 @@ grep -q '^  group: release' .github/workflows/release.yaml || fail "Release must
 grep -q 'uses: ./.github/workflows/e2e.yaml' .github/workflows/release.yaml || fail "Release must run reusable E2E"
 grep -q 'target_ref: \${{ needs.verify.outputs.sha }}' .github/workflows/release.yaml || fail "Release E2E must test the resolved release commit"
 grep -q 'git tag -a' .github/workflows/release.yaml || fail "Release must create an annotated tag after verification"
+grep -q 'packaged chart renders image' .github/workflows/release-image.yaml || fail "Chart publish must assert the packaged chart deploys the release image"
 grep -q 'exactly one' .github/workflows/pr-release-metadata.yml || fail "PR metadata must enforce exactly one release label"
 grep -q '.changes/unreleased' .github/workflows/pr-release-metadata.yml || fail "PR metadata must enforce changelog fragments"
 grep -q 'Ordinary pull requests never publish' docs/releases.md || fail "release docs must describe the publication gate"


### PR DESCRIPTION
## Problem

The published Helm chart does not install the release it claims to. Verified against the chart in GHCR:

| Field in `oci://ghcr.io/rafpe/charts/kube-oidc-proxy:1.6.0` | Value |
| --- | --- |
| `version` | 1.6.0 |
| `appVersion` | 1.6.0 |
| Artifact Hub image annotation | `ghcr.io/rafpe/kube-oidc-proxy:1.6.0` |
| `values.yaml` `image.tag` | `"1.1.0"` |
| Rendered Deployment image | `ghcr.io/rafpe/kube-oidc-proxy:1.1.0` |

`release-image.yaml` passes `--version` and `--app-version` to `helm package` and rewrites the Artifact Hub annotation, but never touches `values.yaml`, and the Deployment template used `.Values.image.tag` verbatim. Every chart from 1.2.0 through 1.6.0 installs the 1.1.0 binary unless the user overrides `image.tag`.

## Fix

- `templates/deployment.yaml`: image tag falls back to `.Chart.AppVersion`.
- `values.yaml`: `image.tag` defaults to `""`; an explicit pin still wins.
- `Chart.yaml`: development baseline bumped to 1.6.0 so a local-checkout install also gets the current image.
- `release-image.yaml`: after packaging, template the `.tgz` and refuse to push if the rendered image tag is not the release version.
- `helm.yaml`: on every PR, assert the default render follows `appVersion` and that `--set image.tag=` still overrides it.
- `scripts/release-contract-check.sh`: require the publish-time guard to stay in place.

## Verification

```
$ helm package chart/kube-oidc-proxy --version 1.7.0 --app-version 1.7.0
$ helm template guard kube-oidc-proxy-1.7.0.tgz -f chart/kube-oidc-proxy/ci/single-issuer-values.yaml | grep 'image: "ghcr'
        image: "ghcr.io/rafpe/kube-oidc-proxy:1.7.0"
$ helm template t chart/kube-oidc-proxy -f chart/kube-oidc-proxy/ci/single-issuer-values.yaml --set image.tag=9.9.9 | grep 'image: "ghcr'
        image: "ghcr.io/rafpe/kube-oidc-proxy:9.9.9"
$ sh scripts/release-contract-check.sh
release-contract-check: ok
```

`helm lint` passes with both CI fixtures.

## Impact

Anyone who installed chart 1.2.0 to 1.6.0 without overriding `image.tag` is running 1.1.0 today. Upgrading to the next chart release rolls them forward to the matching image.
