### PR TITLE
chart: grant impersonation of every declared userextras key

### DIFF
--- a/.changes/unreleased/20260905-chart-userextras-rbac.yaml
+++ b/.changes/unreleased/20260905-chart-userextras-rbac.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: The Helm chart's ClusterRole now grants `impersonate` on `userextras/<key>` for every `claimMappings.extra[].key` declared in `authenticationConfig.content`, plus any keys listed in the new `rbac.userExtras` value. Previously an issuer that mapped extra claims had every request rejected with 403, because the API server authorizes each `Impersonate-Extra-<key>` header separately and the chart only granted a fixed set of keys. The chart's development baseline `appVersion` is 1.7.0.

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -8,11 +8,13 @@ on:
       - 'chart/kube-oidc-proxy/**'
       - '.github/workflows/helm.yaml'
       - 'hack/verify-chart-logging.sh'
+      - 'hack/verify-chart-rbac.sh'
   pull_request:
     paths:
       - 'chart/kube-oidc-proxy/**'
       - '.github/workflows/helm.yaml'
       - 'hack/verify-chart-logging.sh'
+      - 'hack/verify-chart-rbac.sh'
 
 permissions:
   contents: read
@@ -50,6 +52,9 @@ jobs:
 
       - name: logging values render as proxy flags
         run: bash hack/verify-chart-logging.sh
+
+      - name: ClusterRole grants every declared userextras key
+        run: bash hack/verify-chart-rbac.sh
 
       - name: default image tag follows appVersion
         # The release pipeline sets appVersion from the git tag; the chart must

--- a/chart/kube-oidc-proxy/Chart.yaml
+++ b/chart/kube-oidc-proxy/Chart.yaml
@@ -11,7 +11,7 @@ type: application
 # (vX.Y.Z); the values here are the development baseline. The Deployment
 # image tag defaults to `appVersion`, so the override also selects the image.
 version: 1.7.0
-appVersion: "1.6.0"
+appVersion: "1.7.0"
 home: https://github.com/rafpe/kube-oidc-proxy
 sources:
   - https://github.com/rafpe/kube-oidc-proxy
@@ -33,4 +33,4 @@ annotations:
       url: https://github.com/RafPe/kube-oidc-proxy/blob/main/SECURITY.md
   artifacthub.io/images: |
     - name: kube-oidc-proxy
-      image: ghcr.io/rafpe/kube-oidc-proxy:1.6.0
+      image: ghcr.io/rafpe/kube-oidc-proxy:1.7.0

--- a/chart/kube-oidc-proxy/README.md
+++ b/chart/kube-oidc-proxy/README.md
@@ -116,6 +116,7 @@ Ignored when `authenticationConfig.content` is set.
 | `oidc.tlsClient.certKey` | string | `"tls.crt"` | Certificate key in `oidc.tlsClient.existingSecret`. |
 | `oidc.tlsClient.keyKey` | string | `"tls.key"` | Private-key key in `oidc.tlsClient.existingSecret`. |
 | `readinessRequireAllIssuers` | bool | `false` | Require every issuer to initialize before the pod is ready. Default: ready once at least one initializes. |
+| `rbac.userExtras` | list | `[]` | Extra user-info keys the proxy's ServiceAccount may impersonate (`userextras/<key>`), in addition to every `claimMappings.extra[].key` found in `authenticationConfig.content`, which the chart grants automatically. Only needed for keys that reach the proxy another way. |
 
 ### Token passthrough & impersonation
 
@@ -306,6 +307,14 @@ dropped, no privilege escalation, and the `RuntimeDefault` seccomp profile. The
 proxy is a privileged component — its ServiceAccount can impersonate identities
 against the API server — so keep those defaults and restrict who can edit the
 Deployment and its RBAC. See [`../../docs/operations.md`](../../docs/operations.md#security).
+
+The API server authorizes each `Impersonate-Extra-<key>` header separately, as
+`impersonate` on `userextras/<key>`, and a key the ServiceAccount is not
+granted fails the whole request with 403. The chart's ClusterRole therefore
+grants every `claimMappings.extra[].key` declared in
+`authenticationConfig.content`, read from that YAML at render time so the grant
+cannot drift from the mapping. Keys that reach the proxy some other way go in
+`rbac.userExtras`.
 
 If you enable a feature that writes to the local filesystem (e.g. an
 `audit-log-path` to a file), add an `emptyDir` via `extraVolumes` /

--- a/chart/kube-oidc-proxy/README.md
+++ b/chart/kube-oidc-proxy/README.md
@@ -116,7 +116,7 @@ Ignored when `authenticationConfig.content` is set.
 | `oidc.tlsClient.certKey` | string | `"tls.crt"` | Certificate key in `oidc.tlsClient.existingSecret`. |
 | `oidc.tlsClient.keyKey` | string | `"tls.key"` | Private-key key in `oidc.tlsClient.existingSecret`. |
 | `readinessRequireAllIssuers` | bool | `false` | Require every issuer to initialize before the pod is ready. Default: ready once at least one initializes. |
-| `rbac.userExtras` | list | `[]` | Extra user-info keys the proxy's ServiceAccount may impersonate (`userextras/<key>`), in addition to every `claimMappings.extra[].key` found in `authenticationConfig.content`, which the chart grants automatically. Only needed for keys that reach the proxy another way. |
+| `rbac.userExtras` | list | `[]` | Extra user-info keys the proxy's ServiceAccount may impersonate (`userextras/<key>`), in addition to every `claimMappings.extra[].key` in `authenticationConfig.content` and every key in `extraImpersonationHeaders.headers`, which the chart grants automatically. Only needed for keys clients send themselves as `Impersonate-Extra-*`. Lowercased. |
 
 ### Token passthrough & impersonation
 
@@ -312,9 +312,10 @@ The API server authorizes each `Impersonate-Extra-<key>` header separately, as
 `impersonate` on `userextras/<key>`, and a key the ServiceAccount is not
 granted fails the whole request with 403. The chart's ClusterRole therefore
 grants every `claimMappings.extra[].key` declared in
-`authenticationConfig.content`, read from that YAML at render time so the grant
-cannot drift from the mapping. Keys that reach the proxy some other way go in
-`rbac.userExtras`.
+`authenticationConfig.content` and every key in
+`extraImpersonationHeaders.headers`, read from those values at render time so
+the grant cannot drift from the configuration. Keys that clients send
+themselves as `Impersonate-Extra-*` headers go in `rbac.userExtras`.
 
 If you enable a feature that writes to the local filesystem (e.g. an
 `audit-log-path` to a file), add an `emptyDir` via `extraVolumes` /

--- a/chart/kube-oidc-proxy/ci/multi-issuer-values.yaml
+++ b/chart/kube-oidc-proxy/ci/multi-issuer-values.yaml
@@ -2,7 +2,9 @@
 # authenticationConfig.content is set, so the chart must emit
 # --authentication-config and omit issuer-specific --oidc-* flags.
 # requiredClaims is set on purpose to prove it is ignored, while tlsClient is
-# set to prove shared OIDC transport credentials remain available.
+# set to prove shared OIDC transport credentials remain available. The GitHub
+# issuer declares claimMappings.extra keys and rbac.userExtras adds one more,
+# so the rendered ClusterRole must grant impersonate on all of them.
 readinessRequireAllIssuers: true
 oidc:
   requiredClaims:
@@ -30,3 +32,11 @@ authenticationConfig:
           username:
             claim: sub
             prefix: "github:"
+          extra:
+            - key: github.com/actor
+              valueExpression: claims.actor
+            - key: github.com/run-id
+              valueExpression: claims.run_id
+rbac:
+  userExtras:
+    - example.com/team

--- a/chart/kube-oidc-proxy/templates/_helpers.tpl
+++ b/chart/kube-oidc-proxy/templates/_helpers.tpl
@@ -43,3 +43,36 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Extra user-info keys the proxy must be allowed to impersonate.
+
+The API server authorizes every Impersonate-Extra-<key> header separately, as
+`impersonate` on `userextras/<key>` in authentication.k8s.io. A key the
+ServiceAccount is not granted fails the whole request with 403, so the
+ClusterRole has to name every key the proxy can emit. Two sources feed it:
+
+  1. `claimMappings.extra[].key` of every issuer in authenticationConfig.content,
+     read straight from that YAML so the grant cannot drift from the mapping;
+  2. `rbac.userExtras`, for keys that reach the proxy some other way.
+
+Returns a sorted, de-duplicated JSON array (helpers can only return strings).
+*/}}
+{{- define "kube-oidc-proxy.userExtraKeys" -}}
+{{- $keys := list -}}
+{{- with .Values.authenticationConfig.content -}}
+{{- $cfg := fromYaml . -}}
+{{- if hasKey $cfg "Error" -}}
+{{- fail (printf "authenticationConfig.content is not valid YAML: %s" (index $cfg "Error")) -}}
+{{- end -}}
+{{- range $issuer := (default (list) $cfg.jwt) -}}
+{{- range $extra := (default (list) (dig "claimMappings" "extra" (list) $issuer)) -}}
+{{- with $extra.key -}}{{- $keys = append $keys . -}}{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- range (default (list) .Values.rbac.userExtras) -}}
+{{- $keys = append $keys (toString .) -}}
+{{- end -}}
+{{- $keys | uniq | sortAlpha | toJson -}}
+{{- end -}}

--- a/chart/kube-oidc-proxy/templates/_helpers.tpl
+++ b/chart/kube-oidc-proxy/templates/_helpers.tpl
@@ -50,11 +50,18 @@ Extra user-info keys the proxy must be allowed to impersonate.
 The API server authorizes every Impersonate-Extra-<key> header separately, as
 `impersonate` on `userextras/<key>` in authentication.k8s.io. A key the
 ServiceAccount is not granted fails the whole request with 403, so the
-ClusterRole has to name every key the proxy can emit. Two sources feed it:
+ClusterRole has to name every key the proxy can emit. Three sources feed it:
 
   1. `claimMappings.extra[].key` of every issuer in authenticationConfig.content,
      read straight from that YAML so the grant cannot drift from the mapping;
-  2. `rbac.userExtras`, for keys that reach the proxy some other way.
+  2. the keys of `extraImpersonationHeaders.headers` (`k1=v1,k2=v2`), which the
+     proxy adds to every impersonated request;
+  3. `rbac.userExtras`, for keys that reach the proxy some other way, such as
+     Impersonate-Extra-* headers clients send themselves.
+
+Keys are lowercased: the API server lowercases extra keys taken from headers
+before authorizing them, and Kubernetes already rejects non-lowercase keys in
+claimMappings.extra, so a mixed-case grant would never match a request.
 
 Returns a sorted, de-duplicated JSON array (helpers can only return strings).
 */}}
@@ -79,10 +86,19 @@ is nil rather than its default.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- with .Values.extraImpersonationHeaders -}}
+{{- with .headers -}}
+{{- range (splitList "," (toString .)) -}}
+{{- with (trim (first (splitList "=" .))) -}}{{- $keys = append $keys . -}}{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- with .Values.rbac -}}
 {{- range (default (list) .userExtras) -}}
 {{- $keys = append $keys (toString .) -}}
 {{- end -}}
 {{- end -}}
-{{- $keys | uniq | sortAlpha | toJson -}}
+{{- $lowered := list -}}
+{{- range $keys -}}{{- $lowered = append $lowered (lower .) -}}{{- end -}}
+{{- $lowered | uniq | sortAlpha | toJson -}}
 {{- end -}}

--- a/chart/kube-oidc-proxy/templates/_helpers.tpl
+++ b/chart/kube-oidc-proxy/templates/_helpers.tpl
@@ -60,7 +60,14 @@ Returns a sorted, de-duplicated JSON array (helpers can only return strings).
 */}}
 {{- define "kube-oidc-proxy.userExtraKeys" -}}
 {{- $keys := list -}}
-{{- with .Values.authenticationConfig.content -}}
+{{/*
+Every lookup is wrapped in `with`: `helm upgrade --reuse-values` renders with
+the values stored by the previous release and does not merge this chart's
+defaults, so a key introduced after that release (rbac, and any future one)
+is nil rather than its default.
+*/}}
+{{- with .Values.authenticationConfig -}}
+{{- with .content -}}
 {{- $cfg := fromYaml . -}}
 {{- if hasKey $cfg "Error" -}}
 {{- fail (printf "authenticationConfig.content is not valid YAML: %s" (index $cfg "Error")) -}}
@@ -71,8 +78,11 @@ Returns a sorted, de-duplicated JSON array (helpers can only return strings).
 {{- end -}}
 {{- end -}}
 {{- end -}}
-{{- range (default (list) .Values.rbac.userExtras) -}}
+{{- end -}}
+{{- with .Values.rbac -}}
+{{- range (default (list) .userExtras) -}}
 {{- $keys = append $keys (toString .) -}}
+{{- end -}}
 {{- end -}}
 {{- $keys | uniq | sortAlpha | toJson -}}
 {{- end -}}

--- a/chart/kube-oidc-proxy/templates/clusterrole.yaml
+++ b/chart/kube-oidc-proxy/templates/clusterrole.yaml
@@ -31,3 +31,17 @@ rules:
   verbs:
   - "create"
   - "impersonate"
+{{- $extraKeys := include "kube-oidc-proxy.userExtraKeys" . | fromJsonArray }}
+{{- if $extraKeys }}
+# Extra user-info keys the proxy forwards as Impersonate-Extra-* headers:
+# every claimMappings.extra key in authenticationConfig.content plus
+# rbac.userExtras. Each must be granted or the API server rejects the request.
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  {{- range $extraKeys }}
+  - {{ printf "userextras/%s" . | quote }}
+  {{- end }}
+  verbs:
+  - "impersonate"
+{{- end }}

--- a/chart/kube-oidc-proxy/values.yaml
+++ b/chart/kube-oidc-proxy/values.yaml
@@ -148,9 +148,13 @@ rbac:
   # header as `impersonate` on `userextras/<key>`, and a key that is not
   # granted fails the whole request with 403.
   #
-  # Every `claimMappings.extra[].key` in authenticationConfig.content is
-  # granted automatically, so this list is only for keys that reach the proxy
-  # another way (e.g. a token-passthrough identity carrying its own extras).
+  # Every `claimMappings.extra[].key` in authenticationConfig.content and every
+  # key in extraImpersonationHeaders.headers is granted automatically, so this
+  # list is only for keys that reach the proxy another way: typically
+  # Impersonate-Extra-<key> headers that clients send themselves (the
+  # `as-user-extra` field of a kubeconfig user entry), which the proxy
+  # authorizes against the caller's own RBAC and then forwards.
+  # Keys are lowercased, matching how the API server authorizes them.
   # Example:
   #   userExtras:
   #     - example.com/team

--- a/chart/kube-oidc-proxy/values.yaml
+++ b/chart/kube-oidc-proxy/values.yaml
@@ -141,6 +141,21 @@ authenticationConfig:
 # in single-issuer mode.
 readinessRequireAllIssuers: false
 
+# RBAC granted to the proxy's ServiceAccount.
+rbac:
+  # Extra user-info keys the proxy may impersonate, beyond the ones the chart
+  # always grants. The API server authorizes each Impersonate-Extra-<key>
+  # header as `impersonate` on `userextras/<key>`, and a key that is not
+  # granted fails the whole request with 403.
+  #
+  # Every `claimMappings.extra[].key` in authenticationConfig.content is
+  # granted automatically, so this list is only for keys that reach the proxy
+  # another way (e.g. a token-passthrough identity carrying its own extras).
+  # Example:
+  #   userExtras:
+  #     - example.com/team
+  userExtras: []
+
 # Token passthrough: forward the original bearer token to the API server for
 # requests whose token is not an OIDC token the proxy can verify.
 # https://github.com/rafpe/kube-oidc-proxy/blob/main/docs/configuration.md#token-passthrough

--- a/docs/multi-issuer.md
+++ b/docs/multi-issuer.md
@@ -356,9 +356,10 @@ readinessRequireAllIssuers: false
 If an issuer declares `claimMappings.extra`, the proxy forwards each key as an
 `Impersonate-Extra-<key>` header and the API server authorizes every one of
 them separately, as `impersonate` on `userextras/<key>`. The chart reads the
-keys out of `authenticationConfig.content` and grants them in its ClusterRole,
-so nothing extra is needed there; `rbac.userExtras` covers keys that reach the
-proxy another way. Installing without the chart, grant them yourself, or every
+keys out of `authenticationConfig.content` (and out of
+`extraImpersonationHeaders.headers`) and grants them in its ClusterRole, so
+nothing extra is needed there; `rbac.userExtras` covers keys that clients send
+themselves. Installing without the chart, grant them yourself, or every
 request carrying an extra fails with 403:
 
 ```yaml

--- a/docs/multi-issuer.md
+++ b/docs/multi-issuer.md
@@ -353,6 +353,20 @@ authenticationConfig:
 readinessRequireAllIssuers: false
 ```
 
+If an issuer declares `claimMappings.extra`, the proxy forwards each key as an
+`Impersonate-Extra-<key>` header and the API server authorizes every one of
+them separately, as `impersonate` on `userextras/<key>`. The chart reads the
+keys out of `authenticationConfig.content` and grants them in its ClusterRole,
+so nothing extra is needed there; `rbac.userExtras` covers keys that reach the
+proxy another way. Installing without the chart, grant them yourself, or every
+request carrying an extra fails with 403:
+
+```yaml
+- apiGroups: ["authentication.k8s.io"]
+  resources: ["userextras/github.com/actor", "userextras/github.com/run-id"]
+  verbs: ["impersonate"]
+```
+
 ## Notes
 
 - Signing algorithms: with `--authentication-config`, all valid JOSE signing

--- a/hack/verify-chart-rbac.sh
+++ b/hack/verify-chart-rbac.sh
@@ -29,6 +29,17 @@ out=$(render -f "$CHART/ci/multi-issuer-values.yaml" --set 'rbac.userExtras={git
 n=$(grep -c -- '"userextras/github.com/actor"' <<<"$out" || true)
 [ "$n" = "1" ] || { echo "duplicate key granted ${n} times, expected 1" >&2; exit 1; }
 
+# `helm upgrade --reuse-values` renders with the previous release's stored
+# values and does not merge this chart's defaults, so a release installed
+# before `rbac` existed renders with .Values.rbac nil. Nulling the key
+# reproduces that; the render must succeed and still grant the config's keys.
+out=$(render -f "$CHART/ci/multi-issuer-values.yaml" --set 'rbac=null') \
+  || { echo "render failed with rbac unset (--reuse-values from an older release)" >&2; exit 1; }
+grep -q -- '"userextras/github.com/actor"' <<<"$out" \
+  || { echo "config-declared key not granted when rbac is unset" >&2; exit 1; }
+! grep -q -- 'example.com/team' <<<"$out" \
+  || { echo "rbac.userExtras key granted although rbac is unset" >&2; exit 1; }
+
 # Malformed authenticationConfig.content must fail the render, not silently
 # grant nothing.
 if helm template kop "$CHART" --set 'authenticationConfig.content=jwt: [' >/dev/null 2>&1; then

--- a/hack/verify-chart-rbac.sh
+++ b/hack/verify-chart-rbac.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright Jetstack Ltd. See LICENSE for details.
+set -euo pipefail
+# The API server authorizes each Impersonate-Extra-<key> header as `impersonate`
+# on `userextras/<key>`. The ClusterRole must therefore grant every extra key the
+# proxy can emit: the claimMappings.extra keys declared in
+# authenticationConfig.content plus rbac.userExtras. A key missing from the grant
+# fails every request that carries it with 403.
+CHART=chart/kube-oidc-proxy
+render() { helm template kop "$CHART" "$@" --show-only templates/clusterrole.yaml; }
+
+# Single-issuer mode declares no extras: no userextras beyond the fixed grant.
+out=$(render --set oidc.issuerUrl=https://x --set oidc.clientId=y)
+! grep -q -- 'userextras/github.com' <<<"$out" || { echo "userextras rendered without any extra keys" >&2; exit 1; }
+
+# The multi-issuer fixture declares two extra keys on the GitHub issuer and one
+# more via rbac.userExtras; all three must be granted, exactly once each.
+out=$(render -f "$CHART/ci/multi-issuer-values.yaml")
+for key in github.com/actor github.com/run-id example.com/team; do
+  n=$(grep -c -- "\"userextras/${key}\"" <<<"$out" || true)
+  [ "$n" = "1" ] || { echo "userextras/${key}: rendered ${n} times, expected 1" >&2; exit 1; }
+done
+# The grant carries the impersonate verb and nothing broader.
+grep -A20 'userextras/example.com/team' <<<"$out" | grep -q -- '- "impersonate"' \
+  || { echo "extra userextras rule lacks the impersonate verb" >&2; exit 1; }
+
+# A key declared both in the config and in rbac.userExtras is granted once.
+out=$(render -f "$CHART/ci/multi-issuer-values.yaml" --set 'rbac.userExtras={github.com/actor}')
+n=$(grep -c -- '"userextras/github.com/actor"' <<<"$out" || true)
+[ "$n" = "1" ] || { echo "duplicate key granted ${n} times, expected 1" >&2; exit 1; }
+
+# Malformed authenticationConfig.content must fail the render, not silently
+# grant nothing.
+if helm template kop "$CHART" --set 'authenticationConfig.content=jwt: [' >/dev/null 2>&1; then
+  echo "invalid authenticationConfig.content rendered instead of failing" >&2; exit 1
+fi
+
+echo "chart rbac userextras: ok"

--- a/hack/verify-chart-rbac.sh
+++ b/hack/verify-chart-rbac.sh
@@ -29,6 +29,26 @@ out=$(render -f "$CHART/ci/multi-issuer-values.yaml" --set 'rbac.userExtras={git
 n=$(grep -c -- '"userextras/github.com/actor"' <<<"$out" || true)
 [ "$n" = "1" ] || { echo "duplicate key granted ${n} times, expected 1" >&2; exit 1; }
 
+# The API server lowercases extra keys taken from headers before authorizing
+# them, so a mixed-case rbac.userExtras entry must be granted in lowercase, and
+# two spellings of one key must collapse to a single grant.
+out=$(render --set oidc.issuerUrl=https://x --set oidc.clientId=y \
+  --set 'rbac.userExtras={Example.com/Team,example.com/team}')
+n=$(grep -c -- '"userextras/example.com/team"' <<<"$out" || true)
+[ "$n" = "1" ] || { echo "mixed-case key: lowercase grant rendered ${n} times, expected 1" >&2; exit 1; }
+! grep -q -- 'Example.com/Team' <<<"$out" || { echo "mixed-case key granted verbatim" >&2; exit 1; }
+
+# extraImpersonationHeaders.headers adds Impersonate-Extra-<key> to every
+# impersonated request, so its keys must be granted too; values and repeated
+# keys must not leak into the grant.
+out=$(render --set oidc.issuerUrl=https://x --set oidc.clientId=y \
+  --set 'extraImpersonationHeaders.headers=example.com/env=prod\,example.com/env=eu\,Example.com/Tier=a=b')
+for key in example.com/env example.com/tier; do
+  n=$(grep -c -- "\"userextras/${key}\"" <<<"$out" || true)
+  [ "$n" = "1" ] || { echo "extra header key ${key}: rendered ${n} times, expected 1" >&2; exit 1; }
+done
+! grep -q -- 'prod\|userextras/eu\|a=b' <<<"$out" || { echo "extra header value leaked into the grant" >&2; exit 1; }
+
 # `helm upgrade --reuse-values` renders with the previous release's stored
 # values and does not merge this chart's defaults, so a release installed
 # before `rbac` existed renders with .Values.rbac nil. Nulling the key


### PR DESCRIPTION
## Problem

The API server authorizes each `Impersonate-Extra-<key>` header on its own, as `impersonate` on `userextras/<key>` in `authentication.k8s.io`. The chart's ClusterRole grants a fixed list of keys (`scopes`, `remote-client-ip`, the `originaluser.jetstack.io-*` set and `credential-id`). As soon as an issuer in `authenticationConfig.content` declares `claimMappings.extra`, the proxy forwards those keys and the API server rejects every request from that issuer with 403, from the proxy's own ServiceAccount:

```
User "system:serviceaccount:<ns>:kube-oidc-proxy" cannot impersonate resource "userextras/github.com/actor" in API group "authentication.k8s.io"
```

Nothing in the chart made this visible; the mapping rendered fine and the proxy logged `AuSuccess` before the upstream 403.

## Change

- `templates/_helpers.tpl`: a `kube-oidc-proxy.userExtraKeys` helper parses `authenticationConfig.content` and collects every `jwt[].claimMappings.extra[].key`, unions it with the new `rbac.userExtras` list, de-duplicates and sorts. Malformed content fails the render rather than silently granting nothing.
- `templates/clusterrole.yaml`: when the set is non-empty, an additional rule grants `impersonate` on `userextras/<key>` for each.
- `values.yaml`: `rbac.userExtras: []` for keys that reach the proxy some other way, with the automatic derivation documented.
- `ci/multi-issuer-values.yaml`: the GitHub issuer declares two extra keys and `rbac.userExtras` adds one more.
- `hack/verify-chart-rbac.sh`, wired into the chart workflow: single-issuer renders no such rule; the fixture grants all three keys exactly once with the `impersonate` verb; a key declared in both places is granted once; invalid content fails the render.
- Chart README and `docs/multi-issuer.md`: explain the per-key authorization and what non-Helm installs must grant themselves.

## Verification

```
$ bash hack/verify-chart-rbac.sh
chart rbac userextras: ok
$ bash hack/verify-chart-logging.sh
chart logging values: ok
$ helm lint chart/kube-oidc-proxy -f chart/kube-oidc-proxy/ci/{single,multi}-issuer-values.yaml   # 0 failed
```

Rendered from the fixture:

```yaml
- apiGroups:
  - "authentication.k8s.io"
  resources:
  - "userextras/example.com/team"
  - "userextras/github.com/actor"
  - "userextras/github.com/run-id"
  verbs:
  - "impersonate"
```

No change for charts without `claimMappings.extra`: the helper returns an empty set and the ClusterRole is byte-identical to before.
