### PR TITLE
chart: let the ServiceAccount create SubjectAccessReviews

### DIFF
--- a/.changes/unreleased/20260905-chart-subjectaccessreview-rbac.yaml
+++ b/.changes/unreleased/20260905-chart-subjectaccessreview-rbac.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: The Helm chart's ClusterRole now lets the proxy's ServiceAccount create `SubjectAccessReview`s. The proxy authorizes every inbound `Impersonate-*` header value with one before forwarding, so on a chart install every `kubectl --as` request failed with HTTP 500 and `reason=internal_error` (`authz.sar.failed` carried `cannot create resource "subjectaccessreviews"`). The end-to-end suite grants this in its own fixture, which is why it never surfaced there. Plain token requests were unaffected.

--- a/chart/kube-oidc-proxy/templates/clusterrole.yaml
+++ b/chart/kube-oidc-proxy/templates/clusterrole.yaml
@@ -31,6 +31,16 @@ rules:
   verbs:
   - "create"
   - "impersonate"
+# Inbound impersonation (kubectl --as): the proxy authorizes every
+# Impersonate-* header value with a SubjectAccessReview before forwarding.
+# Without this grant the review itself is refused and every impersonating
+# request fails with 500.
+- apiGroups:
+  - "authorization.k8s.io"
+  resources:
+  - "subjectaccessreviews"
+  verbs:
+  - "create"
 {{- $extraKeys := include "kube-oidc-proxy.userExtraKeys" . | fromJsonArray }}
 {{- if $extraKeys }}
 # Extra user-info keys the proxy forwards as Impersonate-Extra-* headers:

--- a/hack/verify-chart-rbac.sh
+++ b/hack/verify-chart-rbac.sh
@@ -13,6 +13,14 @@ render() { helm template kop "$CHART" "$@" --show-only templates/clusterrole.yam
 out=$(render --set oidc.issuerUrl=https://x --set oidc.clientId=y)
 ! grep -q -- 'userextras/github.com' <<<"$out" || { echo "userextras rendered without any extra keys" >&2; exit 1; }
 
+# Inbound impersonation is authorized with a SubjectAccessReview the proxy
+# creates itself; the ServiceAccount must be allowed to create them in every
+# mode, or kubectl --as fails with 500 before any authorization happens.
+grep -A4 -- '"authorization.k8s.io"' <<<"$out" | grep -q -- '"subjectaccessreviews"' \
+  || { echo "ClusterRole does not grant subjectaccessreviews in authorization.k8s.io" >&2; exit 1; }
+grep -A6 -- '"subjectaccessreviews"' <<<"$out" | grep -q -- '- "create"' \
+  || { echo "subjectaccessreviews grant lacks the create verb" >&2; exit 1; }
+
 # The multi-issuer fixture declares two extra keys on the GitHub issuer and one
 # more via rbac.userExtras; all three must be granted, exactly once each.
 out=$(render -f "$CHART/ci/multi-issuer-values.yaml")


### PR DESCRIPTION
## Problem

The proxy authorizes every inbound `Impersonate-*` header value (`kubectl --as`, `--as-group`, `--as-uid`) by creating a `SubjectAccessReview` before it forwards the request. The chart's ClusterRole grants the ServiceAccount `impersonate` on users, groups, uids and extras, and `create` on `tokenreviews`, but nothing in `authorization.k8s.io`. On any chart install the review itself is therefore refused:

```
authz.sar.failed  reason=authorization_dependency_error
  create SubjectAccessReview: subjectaccessreviews.authorization.k8s.io is forbidden:
  User "system:serviceaccount:<ns>:kube-oidc-proxy" cannot create resource "subjectaccessreviews"
  in API group "authorization.k8s.io" at the cluster scope
```

and every impersonating request ends as `AuFail reason=internal_error` with HTTP 500, before any authorization decision is made. Plain token requests never trigger a review and were unaffected.

The end-to-end suite deploys the proxy with its own RBAC fixture (`test/e2e/framework/helper/deploy.go`), which does grant `subjectaccessreviews`, so the impersonation tests pass while the shipped chart cannot do what they test.

## Change

- `templates/clusterrole.yaml`: a rule granting `create` on `subjectaccessreviews` in `authorization.k8s.io`, with a comment saying why it exists.
- `hack/verify-chart-rbac.sh`: asserts the grant and its verb are present in the default render, so it cannot be dropped again.
- Changelog fragment.

## Verification

```
$ bash hack/verify-chart-rbac.sh
chart rbac userextras: ok
$ bash hack/verify-chart-logging.sh
chart logging values: ok
$ helm lint chart/kube-oidc-proxy -f chart/kube-oidc-proxy/ci/{single,multi}-issuer-values.yaml   # 0 failed
```

The failure was reproduced on a cluster running the released chart: `kubectl --as=<user> get pods` through the proxy returns 500 with the log above on every request, including kubectl's discovery calls. With the grant in place the expected outcome is that the same command reaches the authorization decision: 403 `impersonation_denied` when the caller has no impersonation binding, the target's own RBAC result when it has one.
