### PR TITLE
test: deploy the proxy with the chart's RBAC and guard the chart against the code

### DIFF
--- a/.github/workflows/e2e-shards.yaml
+++ b/.github/workflows/e2e-shards.yaml
@@ -86,12 +86,18 @@ jobs:
           rm -f ./kubectl
           kubectl version --client
 
+      # The suite deploys the proxy with the ClusterRole rendered from the
+      # chart, so it needs helm on PATH.
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
       - name: Tool versions
         run: |
           go version
           docker version
           kubectl version --client
           kind version
+          helm version
 
       - name: Run e2e suite
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,14 +53,19 @@ jobs:
       - name: Verify event reference
         run: make verify_eventdoc && git diff --exit-code docs/logging.md
 
-      # e2e packages need Docker + kind and run in e2e.yaml; run unit tests for
-      # the maintained cmd/ and pkg/ packages here, plus the standalone test
-      # tools, which need no cluster.
+      # The e2e framework's unit tests render the chart's ClusterRole and check
+      # it grants every permission the proxy code needs.
+      - name: Set up Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+
+      # The e2e suite needs Docker + kind and runs in e2e.yaml; run unit tests
+      # for the maintained cmd/ and pkg/ packages here, plus the standalone test
+      # tools and the e2e framework's own tests, which need no cluster.
       #
       # -tags logcheck compiles the required-attribute assertions into Emit, so
       # a record missing a mandatory field fails a test instead of shipping.
       - name: go test
-        run: go test -tags logcheck ./cmd/... ./pkg/... ./test/tools/... ./test/e2e/versions/...
+        run: go test -tags logcheck ./cmd/... ./pkg/... ./test/tools/... ./test/e2e/framework/... ./test/e2e/versions/...
 
       # e2e.yaml runs the suite as three label-filtered shards; an unlabelled
       # case would run in none of them. Cheap text check, no cluster needed.

--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,16 @@ ifneq ($(strip $(GINKGO_LABEL_FILTER)),)
 E2E_GOTEST_ARGS := -args --ginkgo.label-filter='$(GINKGO_LABEL_FILTER)'
 endif
 
-# Prerequisites (local runs): go, docker (daemon running), kind, and kubectl on
-# PATH. The suite builds and side-loads the proxy + test-tool images itself and
-# creates/destroys its own kind cluster, so no pre-existing cluster is needed.
+# Prerequisites (local runs): go, docker (daemon running), kind, kubectl and
+# helm on PATH. The suite builds and side-loads the proxy + test-tool images
+# itself and creates/destroys its own kind cluster, so no pre-existing cluster
+# is needed. helm renders the chart's ClusterRole, which is the RBAC the suite
+# deploys the proxy with.
 e2e: $(BINDIR)/kubectl ## run the e2e suite hermetically (creates + destroys its own kind cluster)
+	@command -v helm >/dev/null 2>&1 || { \
+		echo "e2e: 'helm' not found on PATH; the suite deploys the proxy with the RBAC rendered from chart/kube-oidc-proxy." >&2; \
+		exit 1; \
+	}
 	mkdir -p $(ARTIFACTS)
 	@echo "e2e: removing any stale cluster from a previous run"
 	@$(MAKE) --no-print-directory e2e-clean

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -498,8 +498,12 @@ images, runs the suite, and tears the cluster down on exit (including on failure
 or interrupt). No pre-existing cluster is required.
 
 Prerequisites (all on `PATH`): `go`, `docker` (daemon running), `kind`,
-`kubectl`. Images are built for the host architecture, so the suite runs on both
-`amd64` and `arm64` (e.g. Apple Silicon).
+`kubectl`, `helm`. Images are built for the host architecture, so the suite runs
+on both `amd64` and `arm64` (e.g. Apple Silicon). The suite deploys the proxy
+with the ClusterRole rendered from the Helm chart, not a copy of its own, so a
+permission the proxy needs but the chart does not grant fails the suite; a unit
+test in the framework checks the same thing against the list of extra keys the
+proxy code emits.
 
 ```sh
 make e2e          # build images, spin up kind, run the suite, tear down

--- a/hack/ci/gha-multi-issuer-e2e.sh
+++ b/hack/ci/gha-multi-issuer-e2e.sh
@@ -145,6 +145,23 @@ check_identity() { # <kubeconfig> <expected_user> <label>
   ok "authenticated + impersonated through the proxy as ${expected}"
 }
 
+check_impersonation() { # <kubeconfig> <caller> <label>
+  local kcfg="$1" caller="$2" label="$3" out
+  echo; echo "${BLUE}--- ${label}: kubectl --as through the proxy as \"${caller}\" ---${NC}"
+  # Allowed: the caller may impersonate ci-viewer, and ci-viewer may view.
+  # This needs the proxy's ServiceAccount to create SubjectAccessReviews; a
+  # chart that does not grant that fails here with a 500, not a 403.
+  out="$(kubectl --kubeconfig "${kcfg}" --as=ci-viewer get pods -A 2>&1)" \
+    || fail "${label}: '--as=ci-viewer get pods' failed (impersonation grant + view should allow it):\n${out}"
+  ok "--as=ci-viewer allowed: SubjectAccessReview created and granted"
+  # Refused by the proxy itself, before anything is forwarded: the caller has
+  # no grant for this target, so the review says no and the proxy answers 403.
+  out="$(kubectl --kubeconfig "${kcfg}" --as=nobody get pods -A 2>&1 || true)"
+  echo "${out}" | grep -q "is not allowed to impersonate user" \
+    || fail "${label}: '--as=nobody' was not refused by the proxy's impersonation check:\n${out}"
+  ok "--as=nobody refused by the proxy (403 impersonation_denied, not a 500)"
+}
+
 # --------------------------------------------------------------------------
 log "Preflight"
 for t in kind docker kubectl helm openssl jq curl go; do require_tool "$t"; done
@@ -219,6 +236,13 @@ jwt:
       username:
         claim: sub
         prefix: "gha:"
+      # An extra mapping makes every request carry Impersonate-Extra-<key>,
+      # which the API server authorizes as userextras/<key>. The request only
+      # succeeds if the chart's ClusterRole granted the key it read from this
+      # very configuration.
+      extra:
+        - key: github.com/repository
+          valueExpression: claims.repository
   - issuer:
       url: https://${DEX_NAME}.dex.svc.cluster.local:5556/dex
       audiences:
@@ -232,8 +256,11 @@ ${CA_INDENTED}
       groups:
         claim: groups
         prefix: "oidc-local:"
+      extra:
+        - key: example.com/email
+          valueExpression: claims.email
 EOF
-ok "authentication-config.yaml rendered (GHA issuer has no certificateAuthority)"
+ok "authentication-config.yaml rendered (GHA issuer has no certificateAuthority; both issuers map an extra)"
 
 log "Installing kube-oidc-proxy via Helm (multi-issuer, readinessRequireAllIssuers)"
 helm --kube-context "${CTX}" install "${PROXY_RELEASE}" "${CHART}" \
@@ -249,6 +276,17 @@ ok "proxy Ready -> BOTH issuers initialised (real GitHub Actions JWKS fetched)"
 log "Applying RBAC (view) for the impersonated identities"
 kubectl --context "${CTX}" create clusterrolebinding gha-e2e-local-view \
   --clusterrole=view --user="oidc-local:${DEX_USER}" >/dev/null
+
+# Inbound impersonation (kubectl --as): the proxy authorizes it with a
+# SubjectAccessReview it must be allowed to create, then forwards as the
+# target. A ClusterRole scoped to one target username, bound to each
+# identity under test; the target itself may only view.
+kubectl --context "${CTX}" create clusterrole gha-e2e-impersonate-ci-viewer \
+  --verb=impersonate --resource=users --resource-name=ci-viewer >/dev/null
+kubectl --context "${CTX}" create clusterrolebinding gha-e2e-ci-viewer-view \
+  --clusterrole=view --user=ci-viewer >/dev/null
+kubectl --context "${CTX}" create clusterrolebinding gha-e2e-local-impersonate \
+  --clusterrole=gha-e2e-impersonate-ci-viewer --user="oidc-local:${DEX_USER}" >/dev/null
 GHA_SUB=""
 if [ -n "${GHA_TOKEN_FILE}" ]; then
   GHA_TOKEN="$(cat "${GHA_TOKEN_FILE}")"
@@ -273,6 +311,8 @@ if [ -n "${GHA_TOKEN_FILE}" ]; then
   log "GitHub Actions token sub=${GHA_SUB}"
   kubectl --context "${CTX}" create clusterrolebinding gha-e2e-github-view \
     --clusterrole=view --user="gha:${GHA_SUB}" >/dev/null
+  kubectl --context "${CTX}" create clusterrolebinding gha-e2e-github-impersonate \
+    --clusterrole=gha-e2e-impersonate-ci-viewer --user="gha:${GHA_SUB}" >/dev/null
 fi
 ok "RBAC applied"
 
@@ -288,20 +328,26 @@ log "Port-forwarding the proxy"
 port_forward 8443 443 -n "${PROXY_NS}" "svc/${PROXY_RELEASE}"
 
 # ---- Assertion 1: local Dex issuer works through the multi-issuer proxy.
+# Every request carries the mapped extra, so a passing 'get pods' also proves
+# the chart granted userextras/example.com/email to the proxy's ServiceAccount.
 write_kubeconfig "${DEX_TOKEN}" "${GEN}/kubeconfig-local.yaml"
 check_identity "${GEN}/kubeconfig-local.yaml" "oidc-local:${DEX_USER}" "Local Dex issuer"
+check_impersonation "${GEN}/kubeconfig-local.yaml" "oidc-local:${DEX_USER}" "Local Dex issuer"
 
-# ---- Assertion 2 (CI only): the real GitHub Actions token authenticates.
+# ---- Assertion 2 (CI only): the real GitHub Actions token authenticates,
+# with its own extra (userextras/github.com/repository) and --as.
 if [ -n "${GHA_TOKEN_FILE}" ]; then
   log "Authenticating the real GitHub Actions token through the proxy"
   write_kubeconfig "${GHA_TOKEN}" "${GEN}/kubeconfig-gha.yaml"
   check_identity "${GEN}/kubeconfig-gha.yaml" "gha:${GHA_SUB}" "GitHub Actions issuer"
+  check_impersonation "${GEN}/kubeconfig-gha.yaml" "gha:${GHA_SUB}" "GitHub Actions issuer"
 fi
 
 stop_pf
 echo
 echo "${GREEN}SUCCESS:${NC} multi-issuer proxy verified."
 if [ -n "${GHA_TOKEN_FILE}" ]; then
-  echo "  - real GitHub Actions OIDC token impersonated as gha:${GHA_SUB}"
+  echo "  - real GitHub Actions OIDC token impersonated as gha:${GHA_SUB}, with extra github.com/repository"
 fi
-echo "  - local Dex token impersonated as oidc-local:${DEX_USER}"
+echo "  - local Dex token impersonated as oidc-local:${DEX_USER}, with extra example.com/email"
+echo "  - kubectl --as=ci-viewer allowed for both, --as=nobody refused by the proxy"

--- a/pkg/proxy/handlers.go
+++ b/pkg/proxy/handlers.go
@@ -414,14 +414,14 @@ func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
 		if targetForContext != nil {
 			// add the original user's information as extra headers
 			// so they're recorded in the API server's audit log
-			extra["originaluser.jetstack.io-user"] = []string{userForContext.GetName()}
+			extra[accesslogging.ExtraKeyOriginalUser] = []string{userForContext.GetName()}
 
 			if origGroups := userForContext.GetGroups(); len(origGroups) > 0 {
-				extra["originaluser.jetstack.io-groups"] = slices.Clone(origGroups)
+				extra[accesslogging.ExtraKeyOriginalGroups] = slices.Clone(origGroups)
 			}
 
 			if userForContext.GetUID() != "" {
-				extra["originaluser.jetstack.io-uid"] = []string{userForContext.GetUID()}
+				extra[accesslogging.ExtraKeyOriginalUID] = []string{userForContext.GetUID()}
 			}
 
 			if len(userForContext.GetExtra()) > 0 {
@@ -430,7 +430,7 @@ func (p *Proxy) withImpersonateRequest(handler http.Handler) http.Handler {
 					p.handleError(rw, req, errJSONMarshal)
 					return
 				}
-				extra["originaluser.jetstack.io-extra"] = []string{string(jsonExtras)}
+				extra[accesslogging.ExtraKeyOriginalExtra] = []string{string(jsonExtras)}
 			}
 		}
 

--- a/pkg/proxy/logging/accesslog.go
+++ b/pkg/proxy/logging/accesslog.go
@@ -32,19 +32,47 @@ import (
 	proxycontext "github.com/rafpe/kube-oidc-proxy/pkg/proxy/context"
 )
 
+// Extra keys the proxy itself puts on an outbound impersonated request. They
+// are a runtime API contract: the API server authorizes each one as
+// `impersonate` on `userextras/<key>` (lowercased), so the chart's ClusterRole
+// must grant every key listed here, and a test holds the two together.
 const (
+	// UserHeaderClientIPKey carries the resolved client IP when
+	// --extra-user-header-client-ip is set.
 	UserHeaderClientIPKey = "Remote-Client-IP"
+
+	// The originaluser.jetstack.io-* keys carry the authenticated identity on a
+	// request that impersonates someone else (kubectl --as), so the API
+	// server's audit log records who really acted. Unchanged from upstream.
+	ExtraKeyOriginalUser   = "originaluser.jetstack.io-user"
+	ExtraKeyOriginalGroups = "originaluser.jetstack.io-groups"
+	ExtraKeyOriginalUID    = "originaluser.jetstack.io-uid"
+	ExtraKeyOriginalExtra  = "originaluser.jetstack.io-extra"
 )
+
+// FixedImpersonationExtraKeys lists every extra key the proxy can set on its
+// own, independent of claim mappings and operator-configured headers. The
+// chart grants exactly these, plus whatever the configuration declares.
+func FixedImpersonationExtraKeys() []string {
+	return []string{
+		UserHeaderClientIPKey,
+		ExtraKeyOriginalUser,
+		ExtraKeyOriginalGroups,
+		ExtraKeyOriginalUID,
+		ExtraKeyOriginalExtra,
+	}
+}
 
 // loggableExtraKeys is the allowlist of impersonation-extra keys that the proxy
 // sets itself and are safe to log. Everything else is authenticator-supplied
 // claim data and is counted, not logged, so arbitrary claims and credentials
-// never reach the log stream.
+// never reach the log stream. ExtraKeyOriginalExtra is deliberately absent: it
+// carries the original identity's whole extra map, which is claim data.
 var loggableExtraKeys = map[string]struct{}{
-	UserHeaderClientIPKey:             {},
-	"originaluser.jetstack.io-user":   {},
-	"originaluser.jetstack.io-groups": {},
-	"originaluser.jetstack.io-uid":    {},
+	UserHeaderClientIPKey:  {},
+	ExtraKeyOriginalUser:   {},
+	ExtraKeyOriginalGroups: {},
+	ExtraKeyOriginalUID:    {},
 }
 
 // AccessLogger writes the access record. It is an injected collaborator rather

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -34,7 +34,10 @@ import (
 )
 
 const (
-	UserHeaderClientIPKey = "Remote-Client-IP"
+	// UserHeaderClientIPKey is the logging package's constant re-exported for
+	// the callers that historically reached it here; the canonical list of
+	// keys the proxy sets is accesslogging.FixedImpersonationExtraKeys.
+	UserHeaderClientIPKey = accesslogging.UserHeaderClientIPKey
 	timestampLayout       = "2006-01-02T15:04:05-0700"
 )
 

--- a/test/e2e/framework/helper/chartrbac.go
+++ b/test/e2e/framework/helper/chartrbac.go
@@ -1,0 +1,96 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package helper
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// ChartPath is the Helm chart, relative to the repository root.
+const ChartPath = "chart/kube-oidc-proxy"
+
+// ChartRBACValuesFile is the values file the e2e suite renders the chart's
+// ClusterRole with. It declares the extra key the impersonation cases send
+// (rbac.userExtras) and nothing else, so what the suite grants the proxy is
+// exactly what the chart grants an operator who sets that value.
+const ChartRBACValuesFile = "test/e2e/framework/helper/testdata/chart-rbac-values.yaml"
+
+// ChartClusterRoleRules renders the chart's ClusterRole template and returns
+// its rules. The e2e suite deploys the proxy with these rules rather than a
+// hand-written copy, so a permission the proxy needs but the chart does not
+// grant fails the suite instead of surviving until an operator hits it.
+//
+// Rendering shells out to the helm binary; the suite already requires it in
+// CI and the Makefile checks for it locally.
+func ChartClusterRoleRules(repoRoot string, valuesFiles ...string) ([]rbacv1.PolicyRule, error) {
+	role, err := RenderChartClusterRole(repoRoot, valuesFiles...)
+	if err != nil {
+		return nil, err
+	}
+	return role.Rules, nil
+}
+
+// RenderChartClusterRole renders templates/clusterrole.yaml of the chart with
+// the given values files (paths relative to repoRoot or absolute) and decodes
+// it.
+func RenderChartClusterRole(repoRoot string, valuesFiles ...string) (*rbacv1.ClusterRole, error) {
+	helm, err := exec.LookPath("helm")
+	if err != nil {
+		return nil, fmt.Errorf("the e2e suite renders the chart's RBAC and needs helm on PATH: %w", err)
+	}
+
+	args := []string{"template", "e2e", filepath.Join(repoRoot, ChartPath), "--show-only", "templates/clusterrole.yaml"}
+	for _, f := range valuesFiles {
+		if !filepath.IsAbs(f) {
+			f = filepath.Join(repoRoot, f)
+		}
+		args = append(args, "-f", f)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command(helm, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("helm %s: %w\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+
+	var role rbacv1.ClusterRole
+	if err := yaml.Unmarshal(stdout.Bytes(), &role); err != nil {
+		return nil, fmt.Errorf("decoding rendered ClusterRole: %w\n%s", err, stdout.String())
+	}
+	if role.Kind != "ClusterRole" || len(role.Rules) == 0 {
+		return nil, fmt.Errorf("rendered %s is not a ClusterRole with rules:\n%s", ChartPath, stdout.String())
+	}
+	return &role, nil
+}
+
+// RulesAllow reports whether the rules grant verb on group/resource. It
+// mirrors the exact-match part of RBAC evaluation, which is all the chart's
+// ClusterRole uses: no wildcard resources, no resourceNames.
+func RulesAllow(rules []rbacv1.PolicyRule, group, resource, verb string) bool {
+	for _, r := range rules {
+		if !contains(r.APIGroups, group) || !contains(r.Resources, resource) {
+			continue
+		}
+		if contains(r.Verbs, verb) || contains(r.Verbs, "*") {
+			return true
+		}
+	}
+	return false
+}
+
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/framework/helper/chartrbac_test.go
+++ b/test/e2e/framework/helper/chartrbac_test.go
@@ -1,0 +1,120 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package helper
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+
+	accesslogging "github.com/rafpe/kube-oidc-proxy/pkg/proxy/logging"
+)
+
+// repoRoot locates the repository from this file, so the test needs no
+// environment variable: helper/ -> framework/ -> e2e/ -> test/ -> root.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, ChartPath, "Chart.yaml")); err != nil {
+		t.Fatalf("chart not found under %s: %v", root, err)
+	}
+	return root
+}
+
+// TestChartGrantsWhatTheProxyNeeds is the guard between the code and the
+// chart: every permission the proxy exercises against the API server must be
+// granted by the chart's ClusterRole as rendered with default values. The
+// list of extra keys comes from the proxy package, so a key added to the
+// outbound impersonation request without a matching grant fails here rather
+// than as a 403 on an operator's cluster.
+func TestChartGrantsWhatTheProxyNeeds(t *testing.T) {
+	rules, err := ChartClusterRoleRules(repoRoot(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type need struct{ group, resource, verb string }
+	needs := []need{
+		// Outbound impersonation of the mapped identity.
+		{"", "users", "impersonate"},
+		{"", "groups", "impersonate"},
+		{"", "serviceaccounts", "impersonate"},
+		{"authentication.k8s.io", "uids", "impersonate"},
+		// Authorizing inbound impersonation (kubectl --as).
+		{"authorization.k8s.io", "subjectaccessreviews", "create"},
+		// Validating passthrough tokens.
+		{"authentication.k8s.io", "tokenreviews", "create"},
+	}
+	// Every extra key the proxy itself puts on an outbound request, plus the
+	// credential ID the Kubernetes authenticator adds to every OIDC identity.
+	// The API server lowercases extra keys taken from headers before
+	// authorizing them, so the grant must be lowercase.
+	for _, key := range append(accesslogging.FixedImpersonationExtraKeys(), user.CredentialIDKey) {
+		needs = append(needs, need{"authentication.k8s.io", "userextras/" + strings.ToLower(key), "impersonate"})
+	}
+
+	for _, n := range needs {
+		if !RulesAllow(rules, n.group, n.resource, n.verb) {
+			t.Errorf("chart ClusterRole does not grant %s on %q/%s; the proxy needs it", n.verb, n.group, n.resource)
+		}
+	}
+}
+
+// TestChartGrantsDeclaredExtraKeys covers the operator-driven grants: keys
+// declared in claimMappings.extra, in extraImpersonationHeaders.headers and
+// in rbac.userExtras must all render, lowercased, as userextras grants.
+func TestChartGrantsDeclaredExtraKeys(t *testing.T) {
+	root := repoRoot(t)
+	values := filepath.Join(t.TempDir(), "values.yaml")
+	content := `
+extraImpersonationHeaders:
+  headers: example.com/env=prod,Example.com/Tier=gold
+rbac:
+  userExtras:
+    - Example.com/Team
+authenticationConfig:
+  content: |
+    apiVersion: apiserver.config.k8s.io/v1
+    kind: AuthenticationConfiguration
+    jwt:
+    - issuer:
+        url: https://issuer.example.com
+        audiences: ["kube-oidc-proxy"]
+      claimMappings:
+        username:
+          claim: sub
+          prefix: "ex:"
+        extra:
+        - key: example.com/actor
+          valueExpression: claims.actor
+`
+	if err := os.WriteFile(values, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rules, err := ChartClusterRoleRules(root, values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"example.com/actor", "example.com/env", "example.com/tier", "example.com/team"} {
+		if !RulesAllow(rules, "authentication.k8s.io", "userextras/"+key, "impersonate") {
+			t.Errorf("declared extra key %q is not granted as userextras/%s", key, key)
+		}
+	}
+
+	// The suite's own values file must grant the key the impersonation cases use.
+	rules, err = ChartClusterRoleRules(root, ChartRBACValuesFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !RulesAllow(rules, "authentication.k8s.io", "userextras/oktoimpersonateextra", "impersonate") {
+		t.Errorf("%s does not grant userextras/oktoimpersonateextra, which the impersonation e2e cases send", ChartRBACValuesFile)
+	}
+}

--- a/test/e2e/framework/helper/deploy.go
+++ b/test/e2e/framework/helper/deploy.go
@@ -158,6 +158,15 @@ func (h *Helper) DeployProxyWithExtras(ns *corev1.Namespace, issuerURL *url.URL,
 	pTrue := true
 	pFalse := false
 
+	// The proxy's own permissions come from the Helm chart, rendered with the
+	// suite's values file, not from a copy kept here. A permission the proxy
+	// needs but the chart does not grant therefore fails the suite, which is
+	// the artefact operators install.
+	chartRules, err := ChartClusterRoleRules(h.cfg.RepoRoot, ChartRBACValuesFile)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	crole, err := h.KubeClient.RbacV1().ClusterRoles().Create(context.TODO(), &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: kind.ProxyImageName + "-",
@@ -172,23 +181,7 @@ func (h *Helper) DeployProxyWithExtras(ns *corev1.Namespace, issuerURL *url.URL,
 				},
 			},
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"users", "groups", "serviceaccounts"},
-				Verbs:     []string{"impersonate"},
-			},
-			{
-				APIGroups: []string{"authentication.k8s.io"},
-				Resources: []string{"userextras/scopes", "tokenreviews", "uids", "userextras/originaluser.jetstack.io-user", "userextras/originaluser.jetstack.io-groups", "userextras/originaluser.jetstack.io-uid", "userextras/originaluser.jetstack.io-extra", "userextras/oktoimpersonateextra"},
-				Verbs:     []string{"impersonate", "create"},
-			},
-			{
-				APIGroups: []string{"authorization.k8s.io"},
-				Resources: []string{"subjectaccessreviews"},
-				Verbs:     []string{"create"},
-			},
-		},
+		Rules: chartRules,
 	}, metav1.CreateOptions{})
 	if err != nil {
 		return nil, nil, err

--- a/test/e2e/framework/helper/testdata/chart-rbac-values.yaml
+++ b/test/e2e/framework/helper/testdata/chart-rbac-values.yaml
@@ -1,0 +1,8 @@
+# Values the e2e suite renders the chart's ClusterRole with. Only what the
+# suite's own cases need on top of the chart defaults: the impersonation cases
+# send an Impersonate-Extra-oktoimpersonateextra header, which the API server
+# authorizes as userextras/oktoimpersonateextra, and rbac.userExtras is the
+# operator-facing way to grant a key that clients send themselves.
+rbac:
+  userExtras:
+    - oktoimpersonateextra


### PR DESCRIPTION
## Why the chart RBAC bugs got past CI

#138 and #139 fixed two permissions the chart's ClusterRole did not grant (`userextras/<key>` for mapped extras, and `create` on `subjectaccessreviews`). Every test was green while both were missing, for three reasons that each covered a different hole:

1. The e2e suite never installs the chart. `test/e2e/framework/helper/deploy.go` built the proxy's ClusterRole by hand in Go, a second copy of the chart template that nothing compared. The fixture had the permissions; the chart did not; only the fixture was tested.
2. The chart's own CI is `helm lint` and `helm template`. It proves the chart renders, never that an API server accepts what it rendered.
3. The two CI paths that do `helm install` the chart on a cluster (the demo, the GitHub Actions kind job) test with a plain token only: `get pods` allowed, `get secrets` denied. That path needs neither a SubjectAccessReview nor a `userextras` grant.

## Change

**The e2e suite deploys the proxy with the chart's RBAC.** `ChartClusterRoleRules` renders `templates/clusterrole.yaml` with `helm template` and the suite creates the proxy's ClusterRole from those rules. The only values it adds are in `testdata/chart-rbac-values.yaml`: `rbac.userExtras: [oktoimpersonateextra]`, the key the impersonation cases send, so the suite grants exactly what an operator setting that value gets. The hand-written rules are gone. `helm` is now a prerequisite of `make e2e` (checked with a clear message) and is set up in the shard jobs.

**A guard test between the code and the chart.** `TestChartGrantsWhatTheProxyNeeds` renders the chart with default values and asserts it grants every permission the proxy exercises: `impersonate` on users, groups, serviceaccounts and uids; `create` on `subjectaccessreviews` and `tokenreviews`; and `impersonate` on `userextras/<key>` for every key the proxy itself emits plus the credential ID the Kubernetes authenticator adds. The key list is `accesslogging.FixedImpersonationExtraKeys()`, new exported constants that `handlers.go` now writes with, so the test reads the same list the code uses. `TestChartGrantsDeclaredExtraKeys` covers keys declared through `claimMappings.extra`, `extraImpersonationHeaders.headers` and `rbac.userExtras`, lowercased. The test job installs helm and now runs `./test/e2e/framework/...`.

**The GitHub Actions kind job exercises both paths.** Both issuers in `hack/ci/gha-multi-issuer-e2e.sh` map an `extra`, so the existing `get pods` check only passes if the chart granted the key it read from that configuration. A ClusterRole scoped to one target username is bound to each identity under test, and `check_impersonation` expects `--as=ci-viewer` to succeed and `--as=nobody` to be refused by the proxy's own check, rather than fail with a 500 because the review could not be created.

## Verification

- `go build ./...`, `go vet`, `gofmt`; `go test -tags logcheck ./test/e2e/framework/... ./pkg/proxy/...` passes.
- Negative proof: removing the `authorization.k8s.io` rule from `templates/clusterrole.yaml` makes `TestChartGrantsWhatTheProxyNeeds` fail; before this PR, the same removal passed every check in CI.
- `bash -n` and `shellcheck -S warning` on the CI script.
- `make e2e GINKGO_LABEL_FILTER=shard-a` (the impersonation, headers and probe cases) on a local kind cluster with Kubernetes 1.37.0: 8 of 8 specs passed with the proxy deployed under the chart-rendered ClusterRole.

No behaviour change in the proxy: the constants replace string literals with the same values, and the logging allowlist is unchanged.
