### PR TITLE
fix(chart): set the release namespace on every namespaced object

### DIFF
--- a/.changes/unreleased/20260906-chart-template-namespace.yaml
+++ b/.changes/unreleased/20260906-chart-template-namespace.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Every namespaced object the Helm chart renders now carries `metadata.namespace` set to the release namespace. `helm install` was unaffected, but `helm template ... | kubectl apply -f` placed the Deployment, Service, ServiceAccount, Secrets and Ingress in the caller's current namespace while the ClusterRoleBinding still named the rendered one, so a proxy applied that way ran without its RBAC grants. Manifests rendered for GitOps now land in the namespace they were rendered for.

--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -9,12 +9,14 @@ on:
       - '.github/workflows/helm.yaml'
       - 'hack/verify-chart-logging.sh'
       - 'hack/verify-chart-rbac.sh'
+      - 'hack/verify-chart-namespace.sh'
   pull_request:
     paths:
       - 'chart/kube-oidc-proxy/**'
       - '.github/workflows/helm.yaml'
       - 'hack/verify-chart-logging.sh'
       - 'hack/verify-chart-rbac.sh'
+      - 'hack/verify-chart-namespace.sh'
 
 permissions:
   contents: read
@@ -55,6 +57,9 @@ jobs:
 
       - name: ClusterRole grants every declared userextras key
         run: bash hack/verify-chart-rbac.sh
+
+      - name: namespaced objects carry the release namespace
+        run: bash hack/verify-chart-namespace.sh
 
       - name: default image tag follows appVersion
         # The release pipeline sets appVersion from the git tag; the chart must

--- a/chart/kube-oidc-proxy/templates/deployment.yaml
+++ b/chart/kube-oidc-proxy/templates/deployment.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kube-oidc-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
 spec:

--- a/chart/kube-oidc-proxy/templates/ingress.yaml
+++ b/chart/kube-oidc-proxy/templates/ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/chart/kube-oidc-proxy/templates/secret_config.yaml
+++ b/chart/kube-oidc-proxy/templates/secret_config.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kube-oidc-proxy.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
 type: Opaque

--- a/chart/kube-oidc-proxy/templates/secret_tls.yaml
+++ b/chart/kube-oidc-proxy/templates/secret_tls.yaml
@@ -9,6 +9,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ template "kube-oidc-proxy.fullname" . }}-issuer
+  namespace: {{ .Release.Namespace }}
 spec:
   selfSigned: {}
 ---
@@ -17,6 +18,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ template "kube-oidc-proxy.fullname" . }}-tls
+  namespace: {{ .Release.Namespace }}
 spec:
   commonName: {{ template "kube-oidc-proxy.fullname" . }}-tls
   dnsNames:
@@ -44,6 +46,7 @@ kind: Secret
 type: kubernetes.io/tls
 metadata:
   name: {{ template "kube-oidc-proxy.fullname" . }}-tls
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
 data:

--- a/chart/kube-oidc-proxy/templates/service.yaml
+++ b/chart/kube-oidc-proxy/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kube-oidc-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
   annotations:

--- a/chart/kube-oidc-proxy/templates/serviceaccount.yaml
+++ b/chart/kube-oidc-proxy/templates/serviceaccount.yaml
@@ -4,4 +4,5 @@ metadata:
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
   name: {{ include "kube-oidc-proxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 

--- a/chart/kube-oidc-proxy/templates/tests/test-connection.yaml
+++ b/chart/kube-oidc-proxy/templates/tests/test-connection.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "kube-oidc-proxy.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "kube-oidc-proxy.labels" . | indent 4 }}
   annotations:

--- a/hack/verify-chart-namespace.sh
+++ b/hack/verify-chart-namespace.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright Jetstack Ltd. See LICENSE for details.
+set -euo pipefail
+# `helm install` places namespaced objects in the release namespace itself, but
+# `helm template | kubectl apply` does not: an object without metadata.namespace
+# lands in the caller's current namespace while the ClusterRoleBinding still
+# names the rendered one, so the proxy runs without its RBAC grants. Every
+# namespaced object must therefore carry the release namespace explicitly, and
+# cluster-scoped objects must not carry one at all.
+CHART=chart/kube-oidc-proxy
+NS=verify-ns
+check() {
+  local label=$1; shift
+  local rows
+  rows=$(helm template kop "$CHART" --namespace "$NS" "$@" \
+    | yq -r 'select(.kind != null) | [.kind, .metadata.name, .metadata.namespace // "-"] | @tsv')
+  [ -n "$rows" ] || { echo "$label: nothing rendered" >&2; exit 1; }
+  while IFS=$'\t' read -r kind name ns; do
+    case "$kind" in
+      ClusterRole|ClusterRoleBinding)
+        [ "$ns" = "-" ] || { echo "$label: cluster-scoped $kind/$name carries namespace $ns" >&2; exit 1; } ;;
+      *)
+        [ "$ns" = "$NS" ] || { echo "$label: $kind/$name rendered with namespace '$ns', expected $NS" >&2; exit 1; } ;;
+    esac
+  done <<<"$rows"
+  echo "$label: $(wc -l <<<"$rows" | tr -d ' ') objects in $NS"
+}
+
+check "single-issuer" -f "$CHART/ci/single-issuer-values.yaml"
+check "multi-issuer" -f "$CHART/ci/multi-issuer-values.yaml"
+check "ingress" -f "$CHART/ci/single-issuer-values.yaml" --set ingress.enabled=true \
+  --set 'ingress.hosts[0].host=proxy.example.com' --set 'ingress.hosts[0].paths[0].path=/' \
+  --set 'ingress.hosts[0].paths[0].pathType=Prefix'
+check "cert-manager" -f "$CHART/ci/single-issuer-values.yaml" \
+  --set tls.certManager=true --set tls.selfSigned=true
+check "pdb" -f "$CHART/ci/single-issuer-values.yaml" --set podDisruptionBudget.enabled=true
+
+echo "chart namespaces: ok"


### PR DESCRIPTION
## Problem

The chart's namespaced templates carry no `metadata.namespace`. `helm install` fills it in from the release, so installs are fine. The documented GitOps path is not:

```sh
helm template kube-oidc-proxy ./chart/kube-oidc-proxy --namespace kube-oidc-proxy -f values.yaml > kube-oidc-proxy.yaml
kubectl apply -f kube-oidc-proxy.yaml
```

`--namespace` only sets `.Release.Namespace` for the render. The Deployment, Service, ServiceAccount, Secrets and Ingress are then applied into whatever namespace the caller's context points at, while the ClusterRoleBinding, which is cluster-scoped, still binds `system:serviceaccount:kube-oidc-proxy:kube-oidc-proxy`. The proxy comes up in the wrong namespace with none of its grants and fails every request.

## Change

- Every namespaced template sets `namespace: {{ .Release.Namespace }}`. The PodDisruptionBudget already did; this brings the Deployment, Service, ServiceAccount, config and TLS Secrets, cert-manager Issuer and Certificate, Ingress and the Helm test Pod in line.
- `hack/verify-chart-namespace.sh` renders both CI fixtures plus the ingress, cert-manager and PDB variants with `--namespace verify-ns` and asserts that every namespaced object carries that namespace and that the ClusterRole and ClusterRoleBinding carry none.
- The helm-chart workflow runs the check on every chart PR.
- Changelog fragment.

`helm install` and `helm upgrade` behaviour is unchanged: the value rendered is the release namespace they already used.

## Verification

```
$ bash hack/verify-chart-namespace.sh
single-issuer: 8 objects in verify-ns
multi-issuer: 8 objects in verify-ns
ingress: 9 objects in verify-ns
cert-manager: 9 objects in verify-ns
pdb: 9 objects in verify-ns
chart namespaces: ok
$ bash hack/verify-chart-rbac.sh && bash hack/verify-chart-logging.sh
chart rbac userextras: ok
chart logging values: ok
$ helm lint chart/kube-oidc-proxy -f chart/kube-oidc-proxy/ci/{single,multi}-issuer-values.yaml   # 0 failed
```