### PR TITLE
ci: check relative links and heading anchors in markdown

### DIFF
--- a/.github/workflows/links.yaml
+++ b/.github/workflows/links.yaml
@@ -1,0 +1,40 @@
+name: links
+
+# Relative links and heading anchors across the markdown files. Sections move
+# between pages; this fails the PR that moves one without updating the links
+# to it. Offline: external URLs are not fetched, so the check is deterministic.
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**/*.md'
+      - '.github/workflows/links.yaml'
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/links.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  # Cancel superseded pull request runs; never cancel a run on main or a
+  # scheduled run, whose results are recorded against the default branch.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  markdown-links:
+    name: "docs:links"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check relative links and anchors
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: --offline --include-fragments --no-progress --exclude-path graphify-out '**/*.md'
+          fail: true
+          failIfEmpty: true


### PR DESCRIPTION
## Problem

Nothing in CI verifies the relative links between markdown files or the `#heading` anchors they target. When a section moves to another page, every link to it silently starts landing on nothing. The docs restructure in #140 left three such links behind, found only by review.

## Change

A `links` workflow runs `lycheeverse/lychee-action` in offline mode with `--include-fragments` over every `*.md` file, excluding the generated `graphify-out/`. It triggers on pull requests and pushes to `main` that touch markdown, and fails the job on any broken relative link or missing anchor. External URLs are not fetched in offline mode, so the check is deterministic and adds no network dependency.

## Verification

Run locally with the same flags against the tree:

```
🔍 299 Total (in 0s) ✅ 224 OK 🚫 0 Errors 👻 75 Excluded
```

The excluded entries are external URLs, skipped by design. With a scratch file containing one bad anchor and one missing file:

```
[ERROR] docs/logging.md#no-such-heading | Cannot find fragment
[ERROR] docs/missing.md | Cannot find file
🔍 301 Total ✅ 224 OK 🚫 2 Errors 👻 75 Excluded   (exit 2)
```