### PR TITLE
ci: run the release contract check on every PR and restore the README prepare step

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,6 +47,12 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      # The release workflow runs this check against the merged release commit,
+      # after the release PR is already closed. Run it on every PR too so a
+      # docs or workflow edit cannot break the next release from main.
+      - name: Verify release contract
+        run: sh scripts/release-contract-check.sh
+
       # The generated event table in docs/logging.md must match the registry.
       # `make verify` cannot catch a stale table because it regenerates first,
       # so check it here against the committed file.

--- a/README.md
+++ b/README.md
@@ -139,4 +139,4 @@ Format, readiness and the per-issuer prefix rule: [multi-issuer authentication](
 
 Contributions are welcome — issues and pull requests both. Building requires Go 1.26. [Development](./docs/development.md) covers running the proxy from source, the hermetic `make e2e` end-to-end suite and a local multi-issuer test against a real GitHub Actions token; the [demo](./demo/README.md) stands the whole flow up with one command.
 
-Releases are review-gated and label-driven: every ordinary PR carries exactly one `release/*` label and every non-skip PR adds a changelog fragment, and ordinary merges never publish. The exact flow and its recovery procedure are in the [maintainer runbook](./docs/releases.md).
+Releases are review-gated and label-driven: every ordinary PR carries exactly one `release/*` label and every non-skip PR adds a changelog fragment, and ordinary merges never publish. A maintainer runs **Prepare Release** to open the automation-owned `release/next` PR, and merging that PR is what tags and publishes. The exact flow and its recovery procedure are in the [maintainer runbook](./docs/releases.md).

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -66,6 +66,29 @@ The workflow verifies that tag belongs to `main`, reruns checks and E2E, and
 resumes publication. It refuses to move a tag or overwrite an already published
 release.
 
+If **Release** fails before the tag exists (`release:check` or `release:e2e`
+failed on the merged release PR), the changelog entry and the draft release
+already exist but nothing was tagged or published. Do not re-run the failed
+`pull_request` run: it checks out the original merge commit, which still lacks
+the fix. Instead:
+
+1. Fix forward on `main` with a `release/skip` PR. Its own CI runs the unit
+   tests, the release contract check, and the E2E suite against the fix.
+2. Tag the fixed `main` commit by hand and push the tag. The tag push triggers
+   **release-image**, which builds, signs, and publishes the image and chart:
+
+   ```sh
+   git fetch origin
+   git tag -a vX.Y.Z -m "Release vX.Y.Z" origin/main
+   git push origin refs/tags/vX.Y.Z
+   ```
+
+3. When **release-image** is green, promote the draft that **Prepare Release**
+   created: `gh release edit vX.Y.Z --draft=false`.
+
+Do not also dispatch **Release** with that tag: its `release:artifact` job
+would publish the image and chart a second time.
+
 ## Repository setup
 
 Prepare Release depends on repository state that is not in this repository.


### PR DESCRIPTION
## Why

The `Release` run for v1.7.1 (run 33995170839) failed in `release:check`:

```
release-contract-check: README must describe the explicit prepare step
```

`scripts/release-contract-check.sh` requires `README.md` to mention **Prepare Release**. The documentation restructure in #140 rewrote the release paragraph and dropped the phrase. The contract check only runs inside `release.yaml`, against the merged release commit, so the ordinary PR CI on #140 and on the release PR itself never executed it. The tag, artifact, and publish jobs were skipped, so v1.7.1 has a changelog entry and a draft release but no tag, image, or chart.

## What

- `README.md`: name **Prepare Release** again in the release paragraph.
- `.github/workflows/test.yaml`: run `scripts/release-contract-check.sh` on every PR and push to `main`, so a docs or workflow edit fails its own PR instead of the next release.
- `docs/releases.md`: document recovery for a release that failed before its tag existed. The existing recovery section only covered failures after tag creation, and `workflow_dispatch` on `Release` requires an existing tag.

## Verification

`sh scripts/release-contract-check.sh` passes on this branch. The new CI step is the same script, so it also runs on this PR.

## Follow-up

After this merges: tag the fixed `main` commit as `v1.7.1`, let `release-image` publish the image and chart from the tag push, then promote the draft release. Steps are in the new recovery paragraph.