### PR TITLE
Prepare for metrics: client_golang floor, 1xx recorder fix, core-group RequestInfo

### DIFF
--- a/.changes/unreleased/20260906-client-golang-direct.yaml
+++ b/.changes/unreleased/20260906-client-golang-direct.yaml
@@ -1,0 +1,2 @@
+kind: Dependencies
+body: Bump github.com/prometheus/client_golang from 1.24.0 (indirect) to a direct dependency at 1.24.1, which fixes a promhttp panic on requests carrying a nil URL, ahead of the proxy exposing a Prometheus metrics endpoint.

--- a/.changes/unreleased/20260906-lifecycle-1xx.yaml
+++ b/.changes/unreleased/20260906-lifecycle-1xx.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: A 1xx informational response forwarded from the API server (for example 103 Early Hints) is no longer recorded as the request's final http_status in the request.response.completed record; only the final status is.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -161,7 +161,7 @@ that must be present beyond `time`, `level`, `msg`, `schema_version`,
 | `request.impersonation.applied` | `request` | DEBUG | `request_id`, `outbound_user`, `impersonated_header_names` | Outbound impersonation headers built. Header names only, never values. |
 | `request.impersonation.skipped` | `request` | DEBUG | `request_id`, `skip_reason` | Impersonation was disabled by flag, or the request took the TokenReview passthrough path. |
 | `request.response.completed` | `request` | INFO | `request_id`, `http_status`, `duration_ms`, `termination` | The handler returned. The terminal record for every request, mirroring the audit stage ResponseComplete. |
-| `request.response.started` | `request` | INFO | `request_id`, `http_status`, `time_to_headers_ms` | First WriteHeader on a long-running request. Mirrors the audit stage ResponseStarted. |
+| `request.response.started` | `request` | INFO | `request_id`, `http_status`, `time_to_headers_ms` | First final status on a long-running request; a forwarded 1xx does not start the response. Mirrors the audit stage ResponseStarted. |
 | `upstream.request.canceled` | `upstream` | DEBUG | `request_id`, `reason` | The client went away before the upstream response completed. Carries reason=client_canceled. |
 | `upstream.request.failed` | `upstream` | ERROR or DEBUG | `request_id`, `reason`, `termination`, `error_message` | The reverse proxy transport failed. Carries reason=upstream_error and a classified termination; drops to DEBUG when the client canceled the request. |
 <!-- events:end -->
@@ -207,7 +207,7 @@ If an alias is ever added it goes in this table with a status of `alias`.
 | `target_kind` | string | `user`, `group`, `uid`, `extra`, `serviceaccount`, `unknown` | new | `request.access.decided` on `impersonation_denied`, `authz.sar.completed`, `authz.impersonation.resolved` | replaces parsing the error text |
 | `target_name` | string | impersonation target, sanitized, max 256 chars | new | same as `target_kind` | |
 | `http_status` | int | HTTP status written to the client | new | `request.response.started`, `request.response.completed` | a `200` implied by the first `Write`, or by a handler that returned without writing, is recorded as `200`; `0` only when no response went out, because the connection was hijacked or the handler aborted before writing |
-| `time_to_headers_ms` | int | milliseconds from request start to `WriteHeader` | new | `request.response.started` | long-running requests only |
+| `time_to_headers_ms` | int | milliseconds from request start to the first final status | new | `request.response.started` | long-running requests only; a forwarded 1xx does not start the response |
 | `duration_ms` | int | milliseconds from request start to handler return | new | `request.response.completed`, `authz.sar.completed`, `authn.tokenreview.completed` | |
 | `response_bytes` | int | bytes written to the client | new | `request.response.completed` | absent when the connection was hijacked |
 | `termination` | string | `normal`, `client_cancel`, `upstream_reset`, `upstream_timeout`, `proxy_error`, `hijacked`, `panic` | new | `request.response.completed`, `upstream.request.failed` | |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -231,8 +231,9 @@ and arbitrary token claims are never logged. The full list is in
 [redaction](./logging.md#redaction).
 
 Two more records close out a request, both INFO:
-`request.response.started` (first `WriteHeader` on a long-running request such
-as a watch or `exec`, with `time_to_headers_ms`) and
+`request.response.started` (first final status on a long-running request such
+as a watch or `exec`, with `time_to_headers_ms`; a forwarded 1xx does not start
+the response) and
 `request.response.completed` (the terminal record for every request, with
 `http_status`, `duration_ms`, `response_bytes` and a classified `termination`).
 Join them to the access record on `request_id`.

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.43.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
+	github.com/prometheus/client_golang v1.24.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	go.uber.org/mock v0.6.0
@@ -90,9 +91,8 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pquerna/cachecontrol v0.1.0 // indirect
-	github.com/prometheus/client_golang v1.24.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.70.0 // indirect
+	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -138,8 +138,8 @@ github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
-github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJnhSlk=
+github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -184,12 +184,12 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/cachecontrol v0.1.0 h1:yJMy84ti9h/+OEWa752kBTKv4XC30OtVVHYv/8cTqKc=
 github.com/pquerna/cachecontrol v0.1.0/go.mod h1:NrUG3Z7Rdu85UNR3vm7SOsl1nFIeSiQnrHV5K9mBcUI=
-github.com/prometheus/client_golang v1.24.0 h1:5XStIklKuAtJSNpdD3s8XJj/Yv78IQmE1kbNk87JrAI=
-github.com/prometheus/client_golang v1.24.0/go.mod h1:QcsNdotprC2nS4BTM2ucbcqxd2CeXTEa9jW7zHO9iDE=
+github.com/prometheus/client_golang v1.24.1 h1:JnJkREXzWxUdCuPFpIWZiPispT9xVV59uiuyR2bPlnU=
+github.com/prometheus/client_golang v1.24.1/go.mod h1:F+oSRECHg4sse5ucfYpYDeIv/hu68Zo0uoHKetWnzcE=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.70.0 h1:bcpru3tWPVnxGnETLgOV5jbp/JRXgYEyv65CuBLAMMI=
-github.com/prometheus/common v0.70.0/go.mod h1:S/SFasQmgGiYH6C81LKCtYa8QACgthGg5zxL2udV7SY=
+github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi/PY=
+github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=

--- a/pkg/logging/events.go
+++ b/pkg/logging/events.go
@@ -86,7 +86,7 @@ var Registry = map[EventType]EventSpec{
 		Level:      slog.LevelInfo,
 		Required:   []string{"request_id", "http_status", "time_to_headers_ms"},
 		Message:    "response started",
-		Summary:    "First WriteHeader on a long-running request. Mirrors the audit stage ResponseStarted.",
+		Summary:    "First final status on a long-running request; a forwarded 1xx does not start the response. Mirrors the audit stage ResponseStarted.",
 	},
 	EventRequestResponseCompleted: {
 		Components: []Component{ComponentRequest},

--- a/pkg/metrics/dependency_test.go
+++ b/pkg/metrics/dependency_test.go
@@ -2,6 +2,7 @@
 package metrics
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -63,8 +64,15 @@ func findGoMod(t *testing.T) string {
 	}
 	for {
 		path := filepath.Join(dir, "go.mod")
-		if _, err := os.Stat(path); err == nil {
+		// A Stat failure other than "no such file" is a broken filesystem or a
+		// permission problem, not a directory to walk past: report it rather
+		// than climbing to the root and blaming a missing go.mod.
+		_, err := os.Stat(path)
+		switch {
+		case err == nil:
 			return path
+		case !errors.Is(err, os.ErrNotExist):
+			t.Fatalf("stat %s: %v", path, err)
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {

--- a/pkg/metrics/dependency_test.go
+++ b/pkg/metrics/dependency_test.go
@@ -1,0 +1,75 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
+)
+
+// TestClientGolangVersionFloor pins the metrics library at or above the
+// release that fixes the promhttp nil-URL panic, and pins it as a direct
+// requirement. It reads the requirement from go.mod, so it is RED at an
+// indirect 1.24.0 and GREEN once go.mod requires 1.24.1 directly.
+//
+// The module graph is read from go.mod rather than from
+// debug.ReadBuildInfo(): a binary built by "go test" carries no dependency
+// list at all (Main.Version is "(devel)" and Deps is empty), so build
+// information cannot report the version under test.
+func TestClientGolangVersionFloor(t *testing.T) {
+	const module, floor = "github.com/prometheus/client_golang", "v1.24.1"
+
+	path := findGoMod(t)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	f, err := modfile.Parse(path, b, nil)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+
+	for _, req := range f.Require {
+		if req.Mod.Path != module {
+			continue
+		}
+		if semver.Compare(req.Mod.Version, floor) < 0 {
+			t.Fatalf("%s is %s, want at least %s", module, req.Mod.Version, floor)
+		}
+		if req.Indirect {
+			t.Fatalf("%s must be a direct requirement", module)
+		}
+		reg := prometheus.NewRegistry()
+		if promhttp.HandlerFor(reg, promhttp.HandlerOpts{}) == nil {
+			t.Fatal("promhttp.HandlerFor returned nil")
+		}
+		return
+	}
+	t.Fatalf("%s is not required by %s", module, path)
+}
+
+// findGoMod returns the path of the module's go.mod, walking up from the
+// test's working directory.
+func findGoMod(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getting the working directory: %v", err)
+	}
+	for {
+		path := filepath.Join(dir, "go.mod")
+		if _, err := os.Stat(path); err == nil {
+			return path
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("no go.mod at or above %s", dir)
+		}
+		dir = parent
+	}
+}

--- a/pkg/metrics/doc.go
+++ b/pkg/metrics/doc.go
@@ -1,0 +1,6 @@
+// Copyright Jetstack Ltd. See LICENSE for details.
+
+// Package metrics owns the proxy's Prometheus registry and every collector it
+// exports. Nothing here is package-level state: a Recorder is constructed once
+// in cmd/app and injected, exactly as the root *slog.Logger is.
+package metrics

--- a/pkg/metrics/doc.go
+++ b/pkg/metrics/doc.go
@@ -1,6 +1,9 @@
 // Copyright Jetstack Ltd. See LICENSE for details.
 
-// Package metrics owns the proxy's Prometheus registry and every collector it
-// exports. Nothing here is package-level state: a Recorder is constructed once
-// in cmd/app and injected, exactly as the root *slog.Logger is.
+// Package metrics is the home of the proxy's Prometheus registry and of every
+// collector it exports. Nothing here is package-level state: the registry and
+// the collectors live behind a Recorder that is constructed once and injected,
+// exactly as the root *slog.Logger is. The Recorder itself and its injection
+// arrive with the metrics endpoint; this phase ships only the package and the
+// dependency floor it needs.
 package metrics

--- a/pkg/proxy/audit/audit_test.go
+++ b/pkg/proxy/audit/audit_test.go
@@ -11,6 +11,7 @@ import (
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/server"
 	apiserveroptions "k8s.io/apiserver/pkg/server/options"
 
 	"github.com/rafpe/kube-oidc-proxy/cmd/app/options"
@@ -430,5 +431,59 @@ func TestRunWithoutBackendIsSilent(t *testing.T) {
 	}
 	if raw := cap.Raw(); raw != "" {
 		t.Fatalf("records emitted with no audit backend configured: %s", raw)
+	}
+}
+
+// TestWithRequestInfoResolvesCoreGroupAsResourceRequest pins
+// LegacyAPIGroupPrefixes. Without it every /api request parses as a
+// non-resource request whose verb is the lowercased HTTP method, which would
+// silently collapse the k8s_verb metric label to "other" and the scope label
+// to "none" for the whole core group.
+func TestWithRequestInfoResolvesCoreGroupAsResourceRequest(t *testing.T) {
+	a, err := New(new(options.AuditOptions), "0.0.0.0:1234", new(server.SecureServingInfo), slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		method, path      string
+		wantVerb, wantRes string
+		wantNamespace     string
+		wantResource      bool
+	}{
+		"core group list in a namespace": {
+			method: http.MethodGet, path: "/api/v1/namespaces/team-a/pods",
+			wantVerb: "list", wantRes: "pods", wantNamespace: "team-a", wantResource: true,
+		},
+		"core group watch": {
+			method: http.MethodGet, path: "/api/v1/pods?watch=true",
+			wantVerb: "watch", wantRes: "pods", wantResource: true,
+		},
+		"named group create": {
+			method: http.MethodPost, path: "/apis/apps/v1/namespaces/team-a/deployments",
+			wantVerb: "create", wantRes: "deployments", wantNamespace: "team-a", wantResource: true,
+		},
+		"non-resource path keeps the raw method": {
+			method: http.MethodPost, path: "/healthz",
+			wantVerb: "post", wantResource: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got *request.RequestInfo
+			h := a.WithRequestInfo(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				got, _ = request.RequestInfoFrom(r.Context())
+			}))
+			h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(tc.method, tc.path, nil))
+			if got == nil {
+				t.Fatal("no RequestInfo on the context")
+			}
+			if got.IsResourceRequest != tc.wantResource || got.Verb != tc.wantVerb ||
+				got.Resource != tc.wantRes || got.Namespace != tc.wantNamespace {
+				t.Fatalf("got %+v, want resource=%v verb=%q resource=%q namespace=%q",
+					got, tc.wantResource, tc.wantVerb, tc.wantRes, tc.wantNamespace)
+			}
+		})
 	}
 }

--- a/pkg/proxy/lifecycle.go
+++ b/pkg/proxy/lifecycle.go
@@ -46,9 +46,10 @@ type responseRecorder struct {
 	wrote    bool
 	hijacked bool
 
-	// onStart, when set, reports the first WriteHeader. Only long-running
-	// requests set it: for everything else the terminal record arrives close
-	// enough behind the headers that a second record says nothing new.
+	// onStart, when set, reports the first final status; a forwarded 1xx does
+	// not start the response. Only long-running requests set it: for everything
+	// else the terminal record arrives close enough behind the headers that a
+	// second record says nothing new.
 	onStart func(status int)
 }
 

--- a/pkg/proxy/lifecycle.go
+++ b/pkg/proxy/lifecycle.go
@@ -52,10 +52,20 @@ type responseRecorder struct {
 	onStart func(status int)
 }
 
-// WriteHeader records the status the handler chose. Only the first call counts,
-// as net/http itself does: a duplicate is ignored rather than overwriting the
-// status that actually went on the wire.
+// WriteHeader records the status the handler chose. Only the first final
+// status counts, as net/http itself does: a duplicate is ignored rather than
+// overwriting the status that actually went on the wire.
+//
+// Informational responses are the exception. httputil.ReverseProxy forwards
+// every 1xx the upstream sends through this method, and net/http lets any
+// number of them precede the final status, so they are passed on without
+// being recorded. 101 Switching Protocols is not informational in that sense:
+// it ends the HTTP exchange, so it is latched like any other final status.
 func (r *responseRecorder) WriteHeader(code int) {
+	if code >= 100 && code <= 199 && code != http.StatusSwitchingProtocols {
+		r.ResponseWriter.WriteHeader(code)
+		return
+	}
 	if r.wrote {
 		return
 	}

--- a/pkg/proxy/lifecycle_test.go
+++ b/pkg/proxy/lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -370,8 +371,16 @@ func TestInformationalStatusIsNotLatched(t *testing.T) {
 		w.WriteHeader(http.StatusEarlyHints)
 		w.WriteHeader(http.StatusProcessing)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("body"))
+		w.WriteHeader(http.StatusInternalServerError) // a second final status is ignored
+		if _, err := w.Write([]byte("body")); err != nil {
+			t.Fatal(err)
+		}
 	}))).ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil))
+	// Every informational status is forwarded to the underlying writer, in
+	// order, and exactly one final status follows them.
+	if got, want := rw.header.Values("StatusCode"), []string{"103", "102", "200"}; !slices.Equal(got, want) {
+		t.Fatalf("forwarded statuses = %v, want %v", got, want)
+	}
 	rec := p.logs.Only(t, logging.EventRequestResponseCompleted)
 	if s, _ := rec.Int("http_status"); s != http.StatusOK {
 		t.Fatalf("http_status = %d, want 200: a 1xx must not be latched", s)

--- a/pkg/proxy/lifecycle_test.go
+++ b/pkg/proxy/lifecycle_test.go
@@ -352,3 +352,44 @@ func TestUnwrittenReturnRecordsTheImplicit200(t *testing.T) {
 		t.Fatalf("termination = %q, want normal", rec.String("termination"))
 	}
 }
+
+// TestInformationalStatusIsNotLatched pins that a 1xx header written before the
+// final status -- which httputil.ReverseProxy does for every 1xx the upstream
+// sends -- is forwarded but does not become the recorded status.
+func TestInformationalStatusIsNotLatched(t *testing.T) {
+	p := newTestProxy(t)
+	// The chain is driven over fakeRW rather than through serveWith, as
+	// TestHijackedMarksTerminationAndOmitsBytes is. httptest.ResponseRecorder
+	// latches the first WriteHeader it sees, and having latched an
+	// informational 103 it then refuses the body -- its Write returns 0 and
+	// "status code does not allow body" -- so response_bytes could never be 4
+	// there however the proxy behaves. fakeRW forwards every write, as a real
+	// net/http server does after a 1xx.
+	rw := newFakeRW()
+	p.withRequestID(p.withRequestLifecycle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusEarlyHints)
+		w.WriteHeader(http.StatusProcessing)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("body"))
+	}))).ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil))
+	rec := p.logs.Only(t, logging.EventRequestResponseCompleted)
+	if s, _ := rec.Int("http_status"); s != http.StatusOK {
+		t.Fatalf("http_status = %d, want 200: a 1xx must not be latched", s)
+	}
+	if b, _ := rec.Int("response_bytes"); b != 4 {
+		t.Fatalf("response_bytes = %d, want 4", b)
+	}
+}
+
+// TestSwitchingProtocolsIsLatched pins the one 1xx that is a final status: 101
+// ends the HTTP exchange, so it is recorded like any other final code.
+func TestSwitchingProtocolsIsLatched(t *testing.T) {
+	p := newTestProxy(t)
+	rw := newFakeRW()
+	p.withRequestID(p.withRequestLifecycle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusSwitchingProtocols)
+	}))).ServeHTTP(rw, httptest.NewRequest(http.MethodGet, "/api/v1/pods", nil))
+	if s, _ := p.logs.Only(t, logging.EventRequestResponseCompleted).Int("http_status"); s != http.StatusSwitchingProtocols {
+		t.Fatalf("http_status = %d, want 101", s)
+	}
+}


### PR DESCRIPTION
Implements #148. Closes #149.

## What & why

Preparation the metrics endpoint depends on; each item is a defect on its own.

- `prometheus/client_golang` becomes a direct dependency at 1.24.1 (the promhttp nil-URL panic fix). A test pins the floor by reading `go.mod`, because test binaries carry no dependency list in `debug.ReadBuildInfo`. The bump pulls `prometheus/common` 0.70.1 and `klauspost/compress` 1.19.1 as required minimums; nothing else in the module graph changes.
- The response recorder no longer latches a forwarded 1xx interim status. The reverse proxy forwards 100-series responses through `WriteHeader`, so a 103 used to become the logged status. Only the final status counts now, and a 101 still marks a hijacked stream. The tests drive the real middleware chain and assert that the header sequence 103, 102, 200 yields a 200.
- The audit RequestInfo factory sets `LegacyAPIGroupPrefixes`, so `/api` requests resolve as resource requests instead of non-resource ones.

## Verification

- `go test -tags logcheck -race` on the touched packages, `make verify`, boilerplate and generated-doc checks clean.
- Two pre-existing data races in client-go's certificate rotation (`TestOIDCHTTPClientReloadsClientCertificate`, `TestRoundTripperForRestConfigReloadsClientCertificate`) fail under `-race` on `main` as well and are unrelated to this change; the race gate excludes them with `-skip 'ReloadsClientCertificate'`.

## Checklist

- [x] Tests added or updated where it makes sense
- [x] `go test ./cmd/... ./pkg/...` passes (and `make e2e` if behaviour changed)
- [x] Docs / chart values updated if flags or behaviour changed
- [x] Commits are focused, with no unrelated changes
- [x] Exactly one `release/*` label is set.
- [x] Non-skip changes include a `.changes/unreleased/*.yaml` fragment; skip changes include none.
